### PR TITLE
Implement operations control center phases 4-6

### DIFF
--- a/docs/migration/phase4-6-backlog.md
+++ b/docs/migration/phase4-6-backlog.md
@@ -1,0 +1,54 @@
+# Phase 4–6 Backlog Tracker
+
+The following tables capture the Phase 4, Phase 5, and Phase 6 backlog items for the OutPaged production migration. Each entry mirrors the product requirements supplied by the stakeholder request so work can be planned and cross-referenced quickly.
+
+## Phase 4
+
+| ID | Title | Description | Acceptance Criteria | Team | Priority |
+| --- | --- | --- | --- | --- | --- |
+| OP-INC-001 | Incident Entity & Severity Ladder | As Operations, I want incidents with severities (Sev1–Sev4) so we can classify and route response. | Create Incident with title/desc/severity/affected services; Default SLA by severity applied; Incident states: Open → Mitigated → Monitoring → Resolved. | Operations | P1 |
+| OP-INC-002 | On-Call Rotation & Paging | As Operations, I want on-call schedules and paging so Sev1 alerts reach the right engineer. | Admin can define rotations and time windows; Sev1 creates page to active on-call; Audit log shows who was paged and when. | Operations | P1 |
+| OP-INC-003 | Incident Workspace (War Room) | As Operations, I want an incident workspace so cross-team collaboration is organized. | On incident Open: create workspace with timeline, tasks, links; Add responders; All actions timestamped in incident timeline. | Operations | P1 |
+| OP-INC-004 | Postmortem Template & Actions | As Operations, I want a postmortem template to capture learnings and action items. | On Resolved: prompt to create Postmortem doc; Required fields: impact, root cause, corrective actions; Action items auto-created and linked. | Operations | P1 |
+| OP-CHG-001 | Change Request Workflow | As Operations, I want a change workflow (Draft → Review → Approved → Implementing → Validated → Done) with gates. | Risk, Impact, Backout Plan required before Approved; Named approver recorded; Implementing blocked without approved state. | Operations | P1 |
+| OP-CHG-002 | Change Calendar & Freeze Windows | As Operations, I want a change calendar and freeze windows to avoid risky deployments. | Calendar shows scheduled changes; Freeze windows block Approved→Implementing unless override by Admin; Conflicts flagged. | Operations | P2 |
+| OP-SRV-001 | Service Registry & Ownership | As a Platform Lead, I want a service catalog with owners so incidents map to responsible teams. | Create Service with name, team owner, runbook link, tier; Items can link to Services; Ownership appears on incidents and changes. | Platform | P1 |
+| OP-SRV-002 | Runbooks & Checklists | As Engineers, we want runbooks attached to services/incidents for faster resolution. | Attach runbooks (links/files) to Services; Incident shows relevant runbooks; Checklists can be marked complete and logged. | Platform | P2 |
+| OP-DEP-001 | Dependency Graph View | As a Planner, I want a dependency graph so I can see cross-item dependencies visually. | Graph nodes = items/epics, edges = depends-on; Zoom, pan, filter by team/status; Clickthrough opens item. | Frontend | P1 |
+| OP-DEP-002 | Impact Analysis (“What Breaks If This Slips”) | As a PM, I want to know downstream impact when a dependency slips. | Adjusting a date shows impacted items and delay estimate; Critical paths highlighted; Export impact list (CSV). | Frontend | P2 |
+| OP-SLA-001 | Business Hour Calendars & Escalations | As Operations, I want SLA timers that respect business hours and escalate on breach. | Define business calendars; SLA pauses on specified states; Near-breach and breach escalate via notifications to on-call and leads. | Operations | P1 |
+| OP-SEARCH-002 | Saved Searches & Sharing | As a power user, I want to save and share advanced queries. | Save query with name/visibility; Share link reproduces filters; Permission-aware visibility. | Frontend | P2 |
+| OP-OPS-004 | Ops Dashboard | As Leadership, I want an Ops dashboard for MTTA/MTTR, SLA trends, change success rate. | Widgets show MTTA, MTTR, SLA compliance %, change failure rate; Time range filters; Export PNG/CSV. | Frontend | P2 |
+
+## Phase 5
+
+| ID | Title | Description | Acceptance Criteria | Team | Priority |
+| --- | --- | --- | --- | --- | --- |
+| OP-DOC-001 | Docs Editor with Templates | As a PM, I want a docs editor with PRD/RFC templates so specs live with work. | Create doc with rich text, headings, tables; Start from PRD/RFC templates; Autosave; Permission-aware sharing. | Frontend | P1 |
+| OP-DOC-002 | Status Chips & Field Bindings in Docs | As a PM, I want live item chips and bound fields inside docs. | Insert item chip showing ID/status/assignee; Bind fields (e.g., due date) to items; Chips update live when items change. | Frontend | P1 |
+| OP-DOC-003 | Doc Change Tracking & Approvals | As a Lead, I want tracked changes and approvals on docs. | Track insert/delete with author and timestamp; Request approval from reviewers; Doc cannot be marked Final without required approvals. | Frontend | P1 |
+| OP-PORT-001 | Portfolio Dashboard & Initiative Health | As Leadership, I want a portfolio view to track initiative health and progress. | Initiatives with health (G/A/R), progress %, budget vs plan (optional); Drill-down to epics; Save/share views. | Frontend | P1 |
+| OP-PORT-002 | Dependency Risk Heatmap | As Leadership, I want a heatmap of cross-team dependency risk. | Grid by team x team shows count/severity of blocking dependencies; Click reveals list; Export CSV. | Frontend | P2 |
+| OP-OKR-001 | OKRs Linked to Work | As Leadership, I want OKRs connected to initiatives and items. | Create Objectives and KRs; Link KRs to epics/items; Rollup progress to Objective; Quarterly view and check-ins. | Frontend | P2 |
+| OP-IMP-001 | CSV Importer Wizard | As an Admin, I want to import items from CSV with mapping and validation. | Upload CSV; Map columns to fields; Validate and preview; Import in batches with error report. | Admin | P1 |
+| OP-IMP-002 | Jira Import (Projects/Issues/Sprints) | As an Admin, I want to import from Jira to accelerate migration. | OAuth/API or CSV; Map issue types/fields/statuses; Preserve comments/attachments when possible; Dry-run preview. | Admin | P1 |
+| OP-IMP-003 | Monday Import (Boards/Groups/Items) | As an Admin, I want to import from Monday boards into projects. | API token; Map columns to fields; Convert groups to statuses or tags; Preview before import. | Admin | P2 |
+| OP-EXP-001 | Exports & API Tokens | As a Data Analyst, I want CSV/JSON exports and personal API tokens. | Export current view to CSV/JSON; Create/revoke API tokens; All exports audited. | Platform | P1 |
+| OP-DIG-001 | Executive Digest v2 (Email/Slack) | As Leadership, I want weekly executive digests with key deltas and risks. | Schedule digest by portfolio/team; Include top risks, slips, releases; Delivered to email and Slack channel; Permission-aware. | Platform | P2 |
+| OP-REP-001 | Portfolio Reports Pack | As Leadership, I want printable/exportable portfolio reports. | Generate PDF/PNG for roadmap snapshot, initiative status, dependency risk; Time-stamped and shareable. | Frontend | P2 |
+
+## Phase 6
+
+| ID | Title | Description | Acceptance Criteria | Team | Priority |
+| --- | --- | --- | --- | --- | --- |
+| OP-PERF-001 | 10k+ Item Performance Hardening | As a user, I want smooth lists and filters even with 10k+ items. | Virtualized lists; Indexed queries; Sub-second filter on common fields; Performance budget CI checks. | Platform | P1 |
+| OP-PERF-002 | Query Caching & N+1 Guardrails | As a Platform engineer, I want caching and safeguards to avoid N+1 and slow queries. | Add server-side caching on heavy endpoints; Query analyzer warnings in CI; Telemetry for slow queries. | Platform | P2 |
+| OP-BCK-001 | Daily Backups & Project-Level PITR | As an Admin, I want backups and point-in-time restore for a single project. | Automated daily backups; Request restore of a project to timestamp T; Admin UI to initiate restore; Audit of restores. | Admin | P1 |
+| OP-REL-004 | Multi-Region Readiness | As an Admin, I want failover readiness to improve resilience. | Health checks; Replication strategy documented/validated; Runbook for failover drill; Status banner during failover. | Admin | P2 |
+| OP-MOB-001 | Mobile Apps v1 (iOS/Android) Sign-In & Inbox | As a user, I want to sign in on mobile and see my notifications/inbox. | Google SSO; Notification list with deep links; Mark read; Push enabled via provider. | Mobile | P1 |
+| OP-MOB-002 | Quick Approvals & Comments (Mobile) | As a user, I want to approve and comment from my phone. | Approve/Reject on approvals; Comment composer with mentions; Offline queue for pending actions. | Mobile | P1 |
+| OP-OFF-001 | Offline Create & Comment (Web/Mobile) | As a user, I want to create items and comment offline and have them sync later. | Local queue persists across reload; Automatic retry on reconnect; Conflict resolution prompts. | Platform | P2 |
+| OP-ADM-001 | Sandbox & Config Promotion | As an Admin, I want a sandbox and promotion pipeline for workflows/templates. | Create sandbox env; Edit workflows/templates; Promote to prod with diff/approval; Version history retained. | Admin | P1 |
+| OP-TEMP-001 | Template Governance & Versioning | As a PMO, I want template versioning and publishing approvals. | Templates have versions, changelog, owners; Publishing requires approval; Projects can pin to specific version. | Admin | P2 |
+| OP-SCIM-001 | SCIM Provisioning & Deprovisioning | As an Admin, I want automated user lifecycle with our IdP. | SCIM integration to create/update/deprovision users and teams; Deprovision revokes sessions within 1 minute. | Admin | P2 |
+| OP-ANA-001 | Operational Metrics & SLO Dashboard | As Engineering, I want SLO dashboards for API/UI health. | Define SLOs (availability/latency/error rate); Display burn-rate alerts; Export incidents linked to SLO breaches. | Platform | P2 |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./hooks/useAuth";
 import { SecurityProvider } from "./components/security/SecurityProvider";
 import { AccessibilityProvider } from "./components/accessibility/AccessibilityProvider";
+import { OperationsProvider } from "./components/operations/OperationsProvider";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 import { AppLayout } from "./components/layout/AppLayout";
 import { AuthRedirect } from "./components/AuthRedirect";
@@ -42,6 +43,7 @@ import Automation from "./pages/Automation";
 import Analytics from "./pages/Analytics";
 import Auth from "./pages/Auth";
 import NotFound from "./pages/NotFound";
+import OperationsCenter from "./pages/OperationsCenter";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -64,14 +66,15 @@ const App = () => (
     <AuthProvider>
       <SecurityProvider>
         <AccessibilityProvider>
-          <ErrorBoundary>
-            <TooltipProvider>
-              <Toaster />
-              <Sonner />
-              <BrowserRouter>
-                <CommandPalette />
-                <KeyboardShortcuts />
-                <Routes>
+          <OperationsProvider>
+            <ErrorBoundary>
+              <TooltipProvider>
+                <Toaster />
+                <Sonner />
+                <BrowserRouter>
+                  <CommandPalette />
+                  <KeyboardShortcuts />
+                  <Routes>
                   {/* Public routes */}
                   <Route path="/auth" element={<Auth />} />
                   
@@ -115,6 +118,7 @@ const App = () => (
                       <EnterpriseControlPanel />
                     </AdminGuard>
                   } />
+                  <Route path="operations" element={<OperationsCenter />} />
                 </Route>
                 
                 {/* Default route - redirect based on auth status */}
@@ -122,14 +126,15 @@ const App = () => (
                 
                 {/* Catch-all route */}
                 <Route path="*" element={<NotFound />} />
-                  </Routes>
-                </BrowserRouter>
-              </TooltipProvider>
-            </ErrorBoundary>
-          </AccessibilityProvider>
-        </SecurityProvider>
-      </AuthProvider>
-    </QueryClientProvider>
-  );
+              </Routes>
+            </BrowserRouter>
+          </TooltipProvider>
+        </ErrorBoundary>
+      </OperationsProvider>
+    </AccessibilityProvider>
+  </SecurityProvider>
+</AuthProvider>
+</QueryClientProvider>
+);
 
 export default App;

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -30,7 +30,8 @@ import {
   Bell, 
   Building2,
   Headphones,
-  Shield
+  Shield,
+  Activity
 } from "lucide-react";
 
 interface NavItem {
@@ -76,6 +77,12 @@ const navigationItems = [
     url: "/dashboard/tickets",
     icon: Headphones,
     description: "Customer support and ticketing"
+  },
+  {
+    title: "Operations",
+    url: "/dashboard/operations",
+    icon: Activity,
+    description: "Incidents, changes, and service ownership"
   },
   {
     title: "Reports",

--- a/src/components/operations/AdminGovernancePanel.tsx
+++ b/src/components/operations/AdminGovernancePanel.tsx
@@ -1,0 +1,196 @@
+import { useState } from "react";
+import { UserCog } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useOperations } from "./OperationsProvider";
+
+export function AdminGovernancePanel() {
+  const { sandboxPromotions, templateVersions, scimEvents, recordSandboxPromotion, recordTemplateVersion, recordScimEvent } = useOperations();
+  const [sandboxDraft, setSandboxDraft] = useState({ name: "Workflow sandbox", status: "pending" as "draft" | "pending" | "approved" | "rejected" });
+  const [templateDraft, setTemplateDraft] = useState({ templateId: "template-prd", version: 2, changelog: "Updated sections", published: true });
+  const [scimDraft, setScimDraft] = useState({ user: "user@example.com", type: "provision" as "provision" | "update" | "deprovision" });
+
+  const handleSandbox = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    recordSandboxPromotion({ name: sandboxDraft.name, status: sandboxDraft.status });
+    setSandboxDraft({ name: "Workflow sandbox", status: "pending" });
+  };
+
+  const handleTemplate = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    recordTemplateVersion({ templateId: templateDraft.templateId, version: templateDraft.version, changelog: templateDraft.changelog, published: templateDraft.published, createdBy: "admin" });
+    setTemplateDraft({ templateId: "template-prd", version: templateDraft.version + 1, changelog: "", published: false });
+  };
+
+  const handleScim = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    recordScimEvent({ user: scimDraft.user, type: scimDraft.type });
+    setScimDraft({ user: "user@example.com", type: "provision" });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Admin governance</CardTitle>
+        <CardDescription>
+          Promote sandbox changes, manage template versions, and audit SCIM provisioning events.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleSandbox} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-4 space-y-2">
+            <Label>Sandbox name</Label>
+            <Input
+              value={sandboxDraft.name}
+              onChange={(event) => setSandboxDraft((prev) => ({ ...prev, name: event.target.value }))}
+            />
+          </div>
+          <div className="lg:col-span-4 space-y-2">
+            <Label>Status</Label>
+            <Select value={sandboxDraft.status} onValueChange={(value) => setSandboxDraft((prev) => ({ ...prev, status: value as typeof prev.status }))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="draft">Draft</SelectItem>
+                <SelectItem value="pending">Pending</SelectItem>
+                <SelectItem value="approved">Approved</SelectItem>
+                <SelectItem value="rejected">Rejected</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="lg:col-span-4 flex items-end justify-end">
+            <Button type="submit">
+              Promote sandbox
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-2 text-sm">
+          {sandboxPromotions.length === 0 ? (
+            <p className="text-muted-foreground">No sandbox promotions logged.</p>
+          ) : (
+            sandboxPromotions.map((promotion) => (
+              <Card key={promotion.id} className="border-dashed">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{promotion.name}</CardTitle>
+                  <CardDescription>Status {promotion.status}</CardDescription>
+                </CardHeader>
+              </Card>
+            ))
+          )}
+        </div>
+
+        <form onSubmit={handleTemplate} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-4 space-y-2">
+            <Label>Template ID</Label>
+            <Input
+              value={templateDraft.templateId}
+              onChange={(event) => setTemplateDraft((prev) => ({ ...prev, templateId: event.target.value }))}
+            />
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label>Version</Label>
+            <Input
+              type="number"
+              value={templateDraft.version}
+              onChange={(event) => setTemplateDraft((prev) => ({ ...prev, version: Number(event.target.value) }))}
+            />
+          </div>
+          <div className="lg:col-span-4 space-y-2">
+            <Label>Changelog</Label>
+            <Input
+              value={templateDraft.changelog}
+              onChange={(event) => setTemplateDraft((prev) => ({ ...prev, changelog: event.target.value }))}
+            />
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label>Published</Label>
+            <Select value={templateDraft.published ? "yes" : "no"} onValueChange={(value) => setTemplateDraft((prev) => ({ ...prev, published: value === "yes" }))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="yes">Yes</SelectItem>
+                <SelectItem value="no">No</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="lg:col-span-12 flex justify-end">
+            <Button type="submit">
+              Save version
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-2 text-sm">
+          {templateVersions.length === 0 ? (
+            <p className="text-muted-foreground">No template versions recorded.</p>
+          ) : (
+            templateVersions.map((version) => (
+              <Card key={version.id} className="border-dashed">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{version.templateId} v{version.version}</CardTitle>
+                  <CardDescription>{version.changelog}</CardDescription>
+                </CardHeader>
+              </Card>
+            ))
+          )}
+        </div>
+
+        <form onSubmit={handleScim} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-4 space-y-2">
+            <Label>User</Label>
+            <Input
+              value={scimDraft.user}
+              onChange={(event) => setScimDraft((prev) => ({ ...prev, user: event.target.value }))}
+              placeholder="user@example.com"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Event</Label>
+            <Select value={scimDraft.type} onValueChange={(value) => setScimDraft((prev) => ({ ...prev, type: value as typeof prev.type }))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="provision">Provision</SelectItem>
+                <SelectItem value="update">Update</SelectItem>
+                <SelectItem value="deprovision">Deprovision</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="lg:col-span-5 flex items-end justify-end">
+            <Button type="submit">
+              <UserCog className="h-4 w-4 mr-2" /> Log SCIM event
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-2 text-sm">
+          {scimEvents.length === 0 ? (
+            <p className="text-muted-foreground">No SCIM events recorded.</p>
+          ) : (
+            scimEvents.map((event) => (
+              <Card key={event.id} className="border-dashed">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{event.type}</CardTitle>
+                  <CardDescription>{event.user} • {new Date(event.occurredAt).toLocaleString()}</CardDescription>
+                </CardHeader>
+              </Card>
+            ))
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/operations/ChangeManagementPanel.tsx
+++ b/src/components/operations/ChangeManagementPanel.tsx
@@ -1,0 +1,438 @@
+import { useMemo, useState } from "react";
+import { format, parseISO } from "date-fns";
+import { AlertTriangle, CalendarCheck2, ClipboardList, Shield } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { useToast } from "@/hooks/use-toast";
+import {
+  ChangeRequest,
+  ChangeState,
+  FreezeWindow,
+  useOperations,
+} from "./OperationsProvider";
+
+const CHANGE_FLOW: ChangeState[] = ["draft", "review", "approved", "implementing", "validated", "done"];
+
+const stateLabel: Record<ChangeState, string> = {
+  draft: "Draft",
+  review: "In Review",
+  approved: "Approved",
+  implementing: "Implementing",
+  validated: "Validated",
+  done: "Done",
+};
+
+export function ChangeManagementPanel() {
+  const {
+    changeRequests,
+    services,
+    createChangeRequest,
+    transitionChangeState,
+    freezeWindows,
+    scheduleFreezeWindow,
+  } = useOperations();
+  const { toast } = useToast();
+
+  const [changeDraft, setChangeDraft] = useState({
+    title: "",
+    description: "",
+    risk: "",
+    impact: "",
+    backoutPlan: "",
+    serviceIds: [] as string[],
+    plannedStart: "",
+    plannedEnd: "",
+  });
+
+  const [approverDraft, setApproverDraft] = useState<Record<string, string>>({});
+  const [freezeDraft, setFreezeDraft] = useState({
+    name: "",
+    start: "",
+    end: "",
+    teams: [] as string[],
+  });
+
+  const ownerTeams = useMemo(() => Array.from(new Set(services.map((service) => service.ownerTeam))), [services]);
+
+  const handleCreateChange = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!changeDraft.title || !changeDraft.risk || !changeDraft.impact || !changeDraft.backoutPlan) {
+      toast({
+        title: "Missing required fields",
+        description: "Risk, impact, and backout plan are mandatory before review.",
+        variant: "destructive",
+      });
+      return;
+    }
+    createChangeRequest({
+      title: changeDraft.title,
+      description: changeDraft.description,
+      risk: changeDraft.risk,
+      impact: changeDraft.impact,
+      backoutPlan: changeDraft.backoutPlan,
+      requestedBy: "Change Manager",
+      serviceIds: changeDraft.serviceIds,
+      plannedStart: changeDraft.plannedStart || undefined,
+      plannedEnd: changeDraft.plannedEnd || undefined,
+    });
+    setChangeDraft({ title: "", description: "", risk: "", impact: "", backoutPlan: "", serviceIds: [], plannedStart: "", plannedEnd: "" });
+  };
+
+  const handleTransition = (change: ChangeRequest, nextState: ChangeState, overrideFreeze = false) => {
+    try {
+      transitionChangeState(change.id, nextState, "Change Manager", {
+        approverName: nextState === "approved" ? approverDraft[change.id] : undefined,
+        overrideFreeze,
+      });
+      toast({ title: `Change moved to ${stateLabel[nextState]}` });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to update change";
+      toast({ title: "Transition blocked", description: message, variant: "destructive" });
+    }
+  };
+
+  const handleScheduleFreeze = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!freezeDraft.name || !freezeDraft.start || !freezeDraft.end || freezeDraft.teams.length === 0) {
+      toast({
+        title: "Freeze window incomplete",
+        description: "Provide a name, date range, and the teams affected.",
+        variant: "destructive",
+      });
+      return;
+    }
+    scheduleFreezeWindow({
+      name: freezeDraft.name,
+      start: freezeDraft.start,
+      end: freezeDraft.end,
+      teams: freezeDraft.teams,
+      allowOverride: false,
+    });
+    setFreezeDraft({ name: "", start: "", end: "", teams: [] });
+  };
+
+  const calendarEntries = useMemo(() => {
+    return [...changeRequests]
+      .filter((change) => change.plannedStart)
+      .sort((a, b) => parseISO(a.plannedStart ?? new Date().toISOString()).getTime() - parseISO(b.plannedStart ?? new Date().toISOString()).getTime());
+  }, [changeRequests]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Change enablement</CardTitle>
+        <CardDescription>
+          Govern deployments with stage gates, approvals, and freeze windows enforced across the change calendar.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleCreateChange} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-4 space-y-2">
+            <Label htmlFor="change-title">Change title</Label>
+            <Input
+              id="change-title"
+              value={changeDraft.title}
+              onChange={(event) => setChangeDraft((prev) => ({ ...prev, title: event.target.value }))}
+              placeholder="Deploy payments service 4.2"
+            />
+          </div>
+          <div className="lg:col-span-4 space-y-2">
+            <Label htmlFor="change-description">Description</Label>
+            <Textarea
+              id="change-description"
+              value={changeDraft.description}
+              onChange={(event) => setChangeDraft((prev) => ({ ...prev, description: event.target.value }))}
+              placeholder="Summary of the change, validation steps, and rollout plan"
+              rows={3}
+            />
+          </div>
+          <div className="lg:col-span-4 grid gap-3">
+            <div className="space-y-1">
+              <Label>Risk assessment</Label>
+              <Textarea
+                value={changeDraft.risk}
+                onChange={(event) => setChangeDraft((prev) => ({ ...prev, risk: event.target.value }))}
+                placeholder="Call out blast radius, customer impact, rollback complexity"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label>Impact summary</Label>
+              <Textarea
+                value={changeDraft.impact}
+                onChange={(event) => setChangeDraft((prev) => ({ ...prev, impact: event.target.value }))}
+                placeholder="Affected services, users, revenue exposure"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label>Backout plan</Label>
+              <Textarea
+                value={changeDraft.backoutPlan}
+                onChange={(event) => setChangeDraft((prev) => ({ ...prev, backoutPlan: event.target.value }))}
+                placeholder="Document fallback, rollback commands, communications"
+              />
+            </div>
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Planned start</Label>
+            <Input
+              type="datetime-local"
+              value={changeDraft.plannedStart}
+              onChange={(event) => setChangeDraft((prev) => ({ ...prev, plannedStart: event.target.value }))}
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Planned end</Label>
+            <Input
+              type="datetime-local"
+              value={changeDraft.plannedEnd}
+              onChange={(event) => setChangeDraft((prev) => ({ ...prev, plannedEnd: event.target.value }))}
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Impacted services</Label>
+            <div className="border rounded-md p-3 space-y-2 max-h-40 overflow-auto">
+              {services.map((service) => {
+                const checked = changeDraft.serviceIds.includes(service.id);
+                return (
+                  <label key={service.id} className="flex items-center gap-2 text-sm">
+                    <Checkbox
+                      checked={checked}
+                      onCheckedChange={(checked) => {
+                        const isChecked = checked === true;
+                        setChangeDraft((prev) => ({
+                          ...prev,
+                          serviceIds: isChecked
+                            ? [...prev.serviceIds, service.id]
+                            : prev.serviceIds.filter((id) => id !== service.id),
+                        }));
+                      }}
+                    />
+                    <span>{service.name}</span>
+                    <Badge variant="outline" className="ml-auto text-xs">
+                      {service.ownerTeam}
+                    </Badge>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+          <div className="lg:col-span-12 flex justify-end">
+            <Button type="submit">
+              Submit change for review
+            </Button>
+          </div>
+        </form>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          {changeRequests.map((change) => {
+            const currentIndex = CHANGE_FLOW.indexOf(change.state);
+            const nextState = CHANGE_FLOW[currentIndex + 1];
+            return (
+              <Card key={change.id}>
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <ClipboardList className="h-4 w-4 text-primary" /> {change.title}
+                  </CardTitle>
+                  <CardDescription>
+                    Requested by {change.requestedBy} • {change.serviceIds.length} service(s)
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm">
+                  <div className="flex flex-wrap gap-2">
+                    {CHANGE_FLOW.map((state, index) => (
+                      <Badge
+                        key={state}
+                        variant={index <= currentIndex ? "default" : "outline"}
+                      >
+                        {stateLabel[state]}
+                      </Badge>
+                    ))}
+                  </div>
+                  <div className="space-y-1">
+                    <div className="text-xs text-muted-foreground">Risk</div>
+                    <p>{change.risk}</p>
+                  </div>
+                  <div className="space-y-1">
+                    <div className="text-xs text-muted-foreground">Impact</div>
+                    <p>{change.impact}</p>
+                  </div>
+                  <div className="space-y-1">
+                    <div className="text-xs text-muted-foreground">Backout</div>
+                    <p>{change.backoutPlan}</p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {change.serviceIds.map((serviceId) => {
+                      const service = services.find((item) => item.id === serviceId);
+                      return service ? (
+                        <Badge key={serviceId} variant="outline">
+                          {service.name}
+                        </Badge>
+                      ) : null;
+                    })}
+                  </div>
+                  {nextState && (
+                    <div className="space-y-2">
+                      {nextState === "approved" && (
+                        <div className="space-y-1">
+                          <Label htmlFor={`approver-${change.id}`}>Approver</Label>
+                          <Input
+                            id={`approver-${change.id}`}
+                            value={approverDraft[change.id] ?? ""}
+                            onChange={(event) =>
+                              setApproverDraft((prev) => ({ ...prev, [change.id]: event.target.value }))
+                            }
+                            placeholder="Approver name"
+                          />
+                        </div>
+                      )}
+                      <div className="flex gap-2">
+                        <Button
+                          type="button"
+                          variant={nextState === "done" ? "default" : "outline"}
+                          onClick={() => handleTransition(change, nextState)}
+                          disabled={nextState === "approved" && !approverDraft[change.id]}
+                        >
+                          Advance to {stateLabel[nextState]}
+                        </Button>
+                        {nextState === "implementing" && (
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            onClick={() => handleTransition(change, nextState, true)}
+                          >
+                            Override freeze
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                  {change.plannedStart && (
+                    <div className="text-xs text-muted-foreground flex items-center gap-2">
+                      <CalendarCheck2 className="h-3 w-3" /> Scheduled {format(parseISO(change.plannedStart), "MMM d HH:mm")}
+                    </div>
+                  )}
+                  {change.freezeOverride && (
+                    <div className="text-xs text-muted-foreground flex items-center gap-1 text-amber-600">
+                      <AlertTriangle className="h-3 w-3" /> Override documented
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+
+        <div className="border rounded-lg p-4 space-y-4">
+          <h4 className="font-semibold flex items-center gap-2 text-sm">
+            <CalendarCheck2 className="h-4 w-4" /> Change calendar
+          </h4>
+          <div className="space-y-2 text-sm">
+            {calendarEntries.length === 0 && <p className="text-muted-foreground">No scheduled changes yet.</p>}
+            {calendarEntries.map((change) => (
+              <div key={change.id} className="flex flex-wrap items-center justify-between gap-2 border rounded-md p-3">
+                <div>
+                  <div className="font-medium">{change.title}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {format(parseISO(change.plannedStart ?? new Date().toISOString()), "MMM d HH:mm")} →
+                    {change.plannedEnd ? ` ${format(parseISO(change.plannedEnd), "MMM d HH:mm")}` : " TBD"}
+                  </div>
+                </div>
+                <Badge variant="outline">{stateLabel[change.state]}</Badge>
+              </div>
+            ))}
+          </div>
+
+          <div className="border-t pt-4 space-y-3">
+            <h5 className="font-semibold flex items-center gap-2 text-sm">
+              <Shield className="h-4 w-4" /> Freeze windows
+            </h5>
+            <form onSubmit={handleScheduleFreeze} className="grid gap-3 lg:grid-cols-12">
+              <div className="lg:col-span-3 space-y-1">
+                <Label htmlFor="freeze-name">Name</Label>
+                <Input
+                  id="freeze-name"
+                  value={freezeDraft.name}
+                  onChange={(event) => setFreezeDraft((prev) => ({ ...prev, name: event.target.value }))}
+                  placeholder="Holiday freeze"
+                />
+              </div>
+              <div className="lg:col-span-3 space-y-1">
+                <Label htmlFor="freeze-start">Start</Label>
+                <Input
+                  id="freeze-start"
+                  type="datetime-local"
+                  value={freezeDraft.start}
+                  onChange={(event) => setFreezeDraft((prev) => ({ ...prev, start: event.target.value }))}
+                />
+              </div>
+              <div className="lg:col-span-3 space-y-1">
+                <Label htmlFor="freeze-end">End</Label>
+                <Input
+                  id="freeze-end"
+                  type="datetime-local"
+                  value={freezeDraft.end}
+                  onChange={(event) => setFreezeDraft((prev) => ({ ...prev, end: event.target.value }))}
+                />
+              </div>
+              <div className="lg:col-span-3 space-y-1">
+                <Label>Affected teams</Label>
+                <div className="border rounded-md p-2 space-y-1 max-h-32 overflow-auto">
+                  {ownerTeams.map((team) => {
+                    const checked = freezeDraft.teams.includes(team);
+                    return (
+                      <label key={team} className="flex items-center gap-2 text-xs">
+                        <Checkbox
+                          checked={checked}
+                          onCheckedChange={(checked) =>
+                            setFreezeDraft((prev) => ({
+                              ...prev,
+                              teams: checked === true
+                                ? [...prev.teams, team]
+                                : prev.teams.filter((item) => item !== team),
+                            }))
+                          }
+                        />
+                        <span>{team}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+              <div className="lg:col-span-12 flex justify-end">
+                <Button type="submit">Schedule freeze</Button>
+              </div>
+            </form>
+
+            <div className="space-y-2 text-sm">
+              {freezeWindows.length === 0 && (
+                <p className="text-muted-foreground">No freeze windows configured. Approvals will block changes when a window overlaps.</p>
+              )}
+              {freezeWindows.map((window: FreezeWindow) => (
+                <div key={window.id} className="flex flex-wrap items-center justify-between gap-2 rounded-md border p-3">
+                  <div>
+                    <div className="font-medium">{window.name}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {format(parseISO(window.start), "MMM d HH:mm")} → {format(parseISO(window.end), "MMM d HH:mm")} • {window.teams.join(", ")}
+                    </div>
+                  </div>
+                  <Badge variant="destructive">Blocking</Badge>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/operations/DependencyImpactPanel.tsx
+++ b/src/components/operations/DependencyImpactPanel.tsx
@@ -1,0 +1,302 @@
+import { useMemo, useState } from "react";
+import ReactFlow, { Background, Controls, MiniMap, Node, Edge } from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { addDays, format } from "date-fns";
+import { DownloadCloud, Network, Target } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { useOperations } from "./OperationsProvider";
+
+interface DependencyDraft {
+  name: string;
+  team: string;
+  status: string;
+  dueDate: string;
+  dependsOn: string[];
+  criticalPath: boolean;
+}
+
+export function DependencyImpactPanel() {
+  const { dependencyItems, registerDependencyItem } = useOperations();
+  const [filters, setFilters] = useState({ team: "all", status: "all" });
+  const [draft, setDraft] = useState<DependencyDraft>({
+    name: "",
+    team: "",
+    status: "planned",
+    dueDate: new Date().toISOString().slice(0, 10),
+    dependsOn: [],
+    criticalPath: false,
+  });
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [delayDays, setDelayDays] = useState(0);
+
+  const nodes: Node[] = dependencyItems.map((item, index) => ({
+    id: item.id,
+    data: { label: `${item.name}\n${item.team}` },
+    position: { x: (index % 4) * 200, y: Math.floor(index / 4) * 120 },
+    style: {
+      border: item.criticalPath ? "2px solid var(--primary)" : "1px solid var(--border)",
+      padding: 12,
+      borderRadius: 8,
+      background: "var(--card)",
+    },
+  }));
+
+  const edges: Edge[] = dependencyItems.flatMap((item) =>
+    item.dependsOn.map((dependencyId) => ({ id: `${dependencyId}-${item.id}`, source: dependencyId, target: item.id }))
+  );
+
+  const filteredItems = dependencyItems.filter((item) => {
+    const teamMatch = filters.team === "all" || item.team === filters.team;
+    const statusMatch = filters.status === "all" || item.status === filters.status;
+    return teamMatch && statusMatch;
+  });
+
+  const selectedItem = dependencyItems.find((item) => item.id === selectedId) ?? filteredItems[0] ?? null;
+
+  const impactedItems = useMemo(() => {
+    if (!selectedItem) return [] as typeof dependencyItems;
+    const visited = new Set<string>();
+    const result: typeof dependencyItems = [];
+
+    const traverse = (id: string) => {
+      dependencyItems.forEach((item) => {
+        if (item.dependsOn.includes(id) && !visited.has(item.id)) {
+          visited.add(item.id);
+          result.push(item);
+          traverse(item.id);
+        }
+      });
+    };
+
+    traverse(selectedItem.id);
+    return result;
+  }, [dependencyItems, selectedItem]);
+
+  const handleCreateDependency = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!draft.name || !draft.team || !draft.dueDate) return;
+    registerDependencyItem({
+      name: draft.name,
+      team: draft.team,
+      status: draft.status,
+      dueDate: draft.dueDate,
+      dependsOn: draft.dependsOn,
+      criticalPath: draft.criticalPath,
+    });
+    setDraft({ name: "", team: "", status: "planned", dueDate: new Date().toISOString().slice(0, 10), dependsOn: [], criticalPath: false });
+  };
+
+  const exportImpactCsv = () => {
+    if (!selectedItem) return;
+    const rows = [selectedItem, ...impactedItems].map((item) => ({
+      item: item.name,
+      team: item.team,
+      status: item.status,
+      dueDate: item.dueDate,
+    }));
+    const header = "Item,Team,Status,Due Date";
+    const data = rows.map((row) => `${row.item},${row.team},${row.status},${row.dueDate}`);
+    const blob = new Blob([header + "\n" + data.join("\n")], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "impact-analysis.csv";
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const adjustedDueDate = selectedItem
+    ? format(addDays(new Date(selectedItem.dueDate), delayDays), "MMM d, yyyy")
+    : "-";
+
+  return (
+    <Card className="col-span-2">
+      <CardHeader>
+        <CardTitle>Dependency graph & impact analysis</CardTitle>
+        <CardDescription>
+          Visualize cross-team dependencies, filter by ownership, and forecast downstream delays with shareable exports.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleCreateDependency} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-3 space-y-2">
+            <Label htmlFor="dependency-name">Item</Label>
+            <Input
+              id="dependency-name"
+              value={draft.name}
+              onChange={(event) => setDraft((prev) => ({ ...prev, name: event.target.value }))}
+              placeholder="Release payments"
+            />
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label htmlFor="dependency-team">Team</Label>
+            <Input
+              id="dependency-team"
+              value={draft.team}
+              onChange={(event) => setDraft((prev) => ({ ...prev, team: event.target.value }))}
+              placeholder="Payments"
+            />
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label>Status</Label>
+            <select
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+              value={draft.status}
+              onChange={(event) => setDraft((prev) => ({ ...prev, status: event.target.value }))}
+            >
+              <option value="planned">Planned</option>
+              <option value="in_progress">In Progress</option>
+              <option value="blocked">Blocked</option>
+              <option value="done">Done</option>
+            </select>
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label>Due date</Label>
+            <Input
+              type="date"
+              value={draft.dueDate}
+              onChange={(event) => setDraft((prev) => ({ ...prev, dueDate: event.target.value }))}
+            />
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label>Depends on</Label>
+            <Textarea
+              value={draft.dependsOn.join(",")}
+              onChange={(event) =>
+                setDraft((prev) => ({
+                  ...prev,
+                  dependsOn: event.target.value.split(",").map((id) => id.trim()).filter(Boolean),
+                }))
+              }
+              placeholder="Paste IDs separated by commas"
+              rows={2}
+            />
+          </div>
+          <div className="lg:col-span-1 space-y-2">
+            <Label>Critical path</Label>
+            <Select
+              value={draft.criticalPath ? "yes" : "no"}
+              onValueChange={(value) => setDraft((prev) => ({ ...prev, criticalPath: value === "yes" }))}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="yes">Yes</SelectItem>
+                <SelectItem value="no">No</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="lg:col-span-12 flex justify-end">
+            <Button type="submit">
+              Add dependency
+            </Button>
+          </div>
+        </form>
+
+        <div className="grid gap-4 lg:grid-cols-3">
+          <div className="lg:col-span-2 border rounded-lg p-3">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Network className="h-4 w-4" /> Dependency graph
+              </div>
+              <div className="flex gap-2 text-xs">
+                <select
+                  className="rounded-md border border-input bg-transparent px-2 py-1"
+                  value={filters.team}
+                  onChange={(event) => setFilters((prev) => ({ ...prev, team: event.target.value }))}
+                >
+                  <option value="all">All teams</option>
+                  {Array.from(new Set(dependencyItems.map((item) => item.team))).map((team) => (
+                    <option key={team} value={team}>
+                      {team}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  className="rounded-md border border-input bg-transparent px-2 py-1"
+                  value={filters.status}
+                  onChange={(event) => setFilters((prev) => ({ ...prev, status: event.target.value }))}
+                >
+                  <option value="all">All statuses</option>
+                  {Array.from(new Set(dependencyItems.map((item) => item.status))).map((status) => (
+                    <option key={status} value={status}>
+                      {status}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="h-[320px] rounded-md border">
+              <ReactFlow
+                nodes={nodes}
+                edges={edges}
+                fitView
+                onNodeClick={(_, node) => setSelectedId(node.id)}
+              >
+                <MiniMap />
+                <Controls />
+                <Background />
+              </ReactFlow>
+            </div>
+          </div>
+
+          <div className="border rounded-lg p-3 space-y-3">
+            <div className="flex items-center gap-2 text-sm">
+              <Target className="h-4 w-4" /> Impact forecast
+            </div>
+            {selectedItem ? (
+              <div className="space-y-2 text-sm">
+                <div>
+                  <div className="text-xs text-muted-foreground">Selected item</div>
+                  <div className="font-medium">{selectedItem.name}</div>
+                  <div className="text-xs text-muted-foreground">Due {selectedItem.dueDate}</div>
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="impact-delay">Delay (days)</Label>
+                  <Input
+                    id="impact-delay"
+                    type="number"
+                    value={delayDays}
+                    onChange={(event) => setDelayDays(Number(event.target.value))}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    New completion date {adjustedDueDate}. Downstream items will inherit the same delay.
+                  </p>
+                </div>
+                <div className="space-y-1">
+                  <div className="text-xs text-muted-foreground">Impacted items</div>
+                  <div className="flex flex-wrap gap-2">
+                    {impactedItems.map((item) => (
+                      <Badge key={item.id} variant={item.criticalPath ? "destructive" : "outline"}>
+                        {item.name}
+                      </Badge>
+                    ))}
+                    {impactedItems.length === 0 && <Badge variant="outline">No downstream impacts</Badge>}
+                  </div>
+                </div>
+                <Button type="button" variant="outline" size="sm" onClick={exportImpactCsv}>
+                  <DownloadCloud className="h-4 w-4 mr-2" /> Export impact list
+                </Button>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">Select a node in the graph to forecast delays.</p>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/operations/DocsWorkspacePanel.tsx
+++ b/src/components/operations/DocsWorkspacePanel.tsx
@@ -1,0 +1,286 @@
+import { useMemo, useState } from "react";
+import { FileText, PenSquare, UserPlus } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useOperations } from "./OperationsProvider";
+
+export function DocsWorkspacePanel() {
+  const { docTemplates, documents, saveDocument, requestDocApproval, respondToDocApproval } = useOperations();
+  const [docDraft, setDocDraft] = useState({ title: "", templateId: docTemplates[0]?.id ?? "" });
+  const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
+  const [chipDraft, setChipDraft] = useState({ itemId: "", status: "", assignee: "" });
+  const [boundDraft, setBoundDraft] = useState({ field: "", value: "" });
+  const [approvalDraft, setApprovalDraft] = useState({ reviewer: "" });
+
+  const selectedDoc = useMemo(() => documents.find((doc) => doc.id === selectedDocId) ?? documents[0] ?? null, [documents, selectedDocId]);
+
+  const templateContent = docTemplates.find((template) => template.id === docDraft.templateId)?.content ?? "";
+
+  const handleCreateDoc = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!docDraft.title) return;
+    const doc = saveDocument({
+      title: docDraft.title,
+      templateId: docDraft.templateId,
+      content: templateContent,
+      changes: [],
+      chips: [],
+      boundFields: [],
+      requiredApprovers: [],
+    });
+    setSelectedDocId(doc.id);
+    setDocDraft({ title: "", templateId: docTemplates[0]?.id ?? "" });
+  };
+
+  const handleContentChange = (content: string) => {
+    if (!selectedDoc) return;
+    saveDocument({
+      id: selectedDoc.id,
+      title: selectedDoc.title,
+      templateId: selectedDoc.templateId,
+      content,
+      changes: [
+        ...selectedDoc.changes,
+        {
+          id: `${Date.now()}`,
+          type: "insert",
+          content,
+          author: "operations",
+          timestamp: new Date().toISOString(),
+        },
+      ],
+    });
+  };
+
+  const handleAddChip = () => {
+    if (!selectedDoc || !chipDraft.itemId || !chipDraft.status) return;
+    saveDocument({
+      id: selectedDoc.id,
+      title: selectedDoc.title,
+      chips: [...selectedDoc.chips, { ...chipDraft }],
+    });
+    setChipDraft({ itemId: "", status: "", assignee: "" });
+  };
+
+  const handleAddBoundField = () => {
+    if (!selectedDoc || !boundDraft.field) return;
+    saveDocument({
+      id: selectedDoc.id,
+      title: selectedDoc.title,
+      boundFields: [...selectedDoc.boundFields, { field: boundDraft.field, itemId: boundDraft.field, value: boundDraft.value }],
+    });
+    setBoundDraft({ field: "", value: "" });
+  };
+
+  const handleRequestApproval = () => {
+    if (!selectedDoc || !approvalDraft.reviewer) return;
+    saveDocument({
+      id: selectedDoc.id,
+      title: selectedDoc.title,
+      requiredApprovers: Array.from(new Set([...(selectedDoc.requiredApprovers ?? []), approvalDraft.reviewer])),
+    });
+    requestDocApproval(selectedDoc.id, approvalDraft.reviewer);
+    setApprovalDraft({ reviewer: "" });
+  };
+
+  return (
+    <Card className="col-span-2">
+      <CardHeader>
+        <CardTitle>Docs workspace</CardTitle>
+        <CardDescription>
+          Draft PRDs and RFCs with live chips, field bindings, tracked changes, and structured approvals.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleCreateDoc} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-4 space-y-2">
+            <Label htmlFor="doc-title">Title</Label>
+            <Input
+              id="doc-title"
+              value={docDraft.title}
+              onChange={(event) => setDocDraft((prev) => ({ ...prev, title: event.target.value }))}
+              placeholder="Payments API RFC"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label htmlFor="doc-template">Template</Label>
+            <select
+              id="doc-template"
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+              value={docDraft.templateId}
+              onChange={(event) => setDocDraft((prev) => ({ ...prev, templateId: event.target.value }))}
+            >
+              {docTemplates.map((template) => (
+                <option key={template.id} value={template.id}>
+                  {template.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="lg:col-span-5 flex items-end justify-end">
+            <Button type="submit">
+              Create doc
+            </Button>
+          </div>
+        </form>
+
+        {documents.length === 0 ? (
+          <div className="text-sm text-muted-foreground border rounded-lg p-6">
+            No documents yet. Create a PRD or RFC to start collaborating.
+          </div>
+        ) : (
+          <Tabs value={selectedDoc?.id ?? documents[0].id} onValueChange={setSelectedDocId}>
+            <TabsList className="flex-wrap">
+              {documents.map((doc) => (
+                <TabsTrigger key={doc.id} value={doc.id} className="text-left">
+                  <div className="flex items-center gap-2">
+                    <FileText className="h-4 w-4" />
+                    <span>{doc.title}</span>
+                    <Badge variant={doc.status === "final" ? "secondary" : "outline"}>{doc.status}</Badge>
+                  </div>
+                </TabsTrigger>
+              ))}
+            </TabsList>
+
+            {documents.map((doc) => (
+              <TabsContent key={doc.id} value={doc.id} className="space-y-4">
+                <div className="grid gap-4 lg:grid-cols-2">
+                  <div className="border rounded-lg p-4 space-y-3">
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <PenSquare className="h-4 w-4" /> Body
+                    </div>
+                    <Textarea
+                      value={doc.content}
+                      onChange={(event) => handleContentChange(event.target.value)}
+                      rows={12}
+                    />
+                    <div className="text-xs text-muted-foreground">
+                      Autosaved {new Date(doc.autosavedAt).toLocaleTimeString()} • {doc.changes.length} tracked change(s)
+                    </div>
+                  </div>
+
+                  <div className="border rounded-lg p-4 space-y-4 text-sm">
+                    <div>
+                      <Label>Status chips</Label>
+                      <div className="flex gap-2 mt-2">
+                        <Input
+                          value={chipDraft.itemId}
+                          onChange={(event) => setChipDraft((prev) => ({ ...prev, itemId: event.target.value }))}
+                          placeholder="Item ID"
+                        />
+                        <Input
+                          value={chipDraft.status}
+                          onChange={(event) => setChipDraft((prev) => ({ ...prev, status: event.target.value }))}
+                          placeholder="Status"
+                        />
+                        <Input
+                          value={chipDraft.assignee}
+                          onChange={(event) => setChipDraft((prev) => ({ ...prev, assignee: event.target.value }))}
+                          placeholder="Assignee"
+                        />
+                        <Button type="button" onClick={handleAddChip}>
+                          Add
+                        </Button>
+                      </div>
+                      <div className="flex flex-wrap gap-2 mt-2">
+                        {doc.chips.map((chip) => (
+                          <Badge key={chip.itemId} variant="outline">
+                            {chip.itemId} • {chip.status} • {chip.assignee}
+                          </Badge>
+                        ))}
+                        {doc.chips.length === 0 && <Badge variant="outline">No chips</Badge>}
+                      </div>
+                    </div>
+
+                    <div>
+                      <Label>Bound fields</Label>
+                      <div className="flex gap-2 mt-2">
+                        <Input
+                          value={boundDraft.field}
+                          onChange={(event) => setBoundDraft((prev) => ({ ...prev, field: event.target.value }))}
+                          placeholder="Field"
+                        />
+                        <Input
+                          value={boundDraft.value}
+                          onChange={(event) => setBoundDraft((prev) => ({ ...prev, value: event.target.value }))}
+                          placeholder="Value"
+                        />
+                        <Button type="button" onClick={handleAddBoundField}>
+                          Bind
+                        </Button>
+                      </div>
+                      <div className="flex flex-wrap gap-2 mt-2">
+                        {doc.boundFields.map((field) => (
+                          <Badge key={field.field} variant="secondary">
+                            {field.field}: {field.value}
+                          </Badge>
+                        ))}
+                        {doc.boundFields.length === 0 && <Badge variant="outline">No bound fields</Badge>}
+                      </div>
+                    </div>
+
+                    <div>
+                      <Label>Approvals</Label>
+                      <div className="flex gap-2 mt-2">
+                        <Input
+                          value={approvalDraft.reviewer}
+                          onChange={(event) => setApprovalDraft({ reviewer: event.target.value })}
+                          placeholder="Reviewer email"
+                        />
+                        <Button type="button" onClick={handleRequestApproval}>
+                          <UserPlus className="h-4 w-4 mr-1" /> Request
+                        </Button>
+                      </div>
+                      <div className="space-y-1 mt-2 text-xs">
+                        {doc.approvals.length === 0 && <p className="text-muted-foreground">No approvals requested.</p>}
+                        {doc.approvals.map((approval) => (
+                          <div key={approval.id} className="flex items-center justify-between">
+                            <span>{approval.reviewer}</span>
+                            <div className="flex gap-2">
+                              <Badge variant="outline">{approval.status}</Badge>
+                              {approval.status === "pending" && (
+                                <>
+                                  <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => respondToDocApproval(approval.id, "approved")}
+                                  >
+                                    Approve
+                                  </Button>
+                                  <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => respondToDocApproval(approval.id, "rejected")}
+                                  >
+                                    Reject
+                                  </Button>
+                                </>
+                              )}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </TabsContent>
+            ))}
+          </Tabs>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/operations/ExecutiveReportingPanel.tsx
+++ b/src/components/operations/ExecutiveReportingPanel.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { FileDown, Send } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useOperations } from "./OperationsProvider";
+
+export function ExecutiveReportingPanel() {
+  const { digestSchedules, reports, scheduleDigest, recordReport } = useOperations();
+  const [digestDraft, setDigestDraft] = useState({
+    scope: "Portfolio A",
+    cadence: "weekly" as "weekly" | "monthly",
+    channel: "email" as "email" | "slack" | "both",
+    recipients: "exec@example.com",
+  });
+  const [reportType, setReportType] = useState("roadmap");
+
+  const handleScheduleDigest = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    scheduleDigest({
+      scope: digestDraft.scope,
+      cadence: digestDraft.cadence,
+      channel: digestDraft.channel,
+      recipients: digestDraft.recipients.split(",").map((value) => value.trim()),
+    });
+    setDigestDraft({ scope: "Portfolio A", cadence: digestDraft.cadence, channel: digestDraft.channel, recipients: "" });
+  };
+
+  const handleGenerateReport = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    recordReport({ type: reportType as "roadmap" | "status" | "dependency", url: `/reports/${reportType}.pdf` });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Executive reporting</CardTitle>
+        <CardDescription>
+          Automate digests and export PDF/PNG packs for leadership-ready updates.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleScheduleDigest} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-4 space-y-2">
+            <Label>Scope</Label>
+            <Input
+              value={digestDraft.scope}
+              onChange={(event) => setDigestDraft((prev) => ({ ...prev, scope: event.target.value }))}
+              placeholder="Portfolio name"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Cadence</Label>
+            <Select value={digestDraft.cadence} onValueChange={(value) => setDigestDraft((prev) => ({ ...prev, cadence: value as typeof prev.cadence }))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="weekly">Weekly</SelectItem>
+                <SelectItem value="monthly">Monthly</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Channel</Label>
+            <Select value={digestDraft.channel} onValueChange={(value) => setDigestDraft((prev) => ({ ...prev, channel: value as typeof prev.channel }))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="email">Email</SelectItem>
+                <SelectItem value="slack">Slack</SelectItem>
+                <SelectItem value="both">Email + Slack</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="lg:col-span-12 space-y-2">
+            <Label>Recipients</Label>
+            <Input
+              value={digestDraft.recipients}
+              onChange={(event) => setDigestDraft((prev) => ({ ...prev, recipients: event.target.value }))}
+              placeholder="comma-separated emails"
+            />
+          </div>
+          <div className="lg:col-span-12 flex justify-end">
+            <Button type="submit">
+              <Send className="h-4 w-4 mr-2" /> Schedule digest
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-2 text-sm">
+          {digestSchedules.length === 0 ? (
+            <p className="text-muted-foreground">No digests scheduled.</p>
+          ) : (
+            digestSchedules.map((schedule) => (
+              <Card key={schedule.id} className="border-dashed">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{schedule.scope}</CardTitle>
+                  <CardDescription>
+                    {schedule.cadence} via {schedule.channel} • Recipients {schedule.recipients.join(", ")}
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            ))
+          )}
+        </div>
+
+        <form onSubmit={handleGenerateReport} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-4 space-y-2">
+            <Label>Report type</Label>
+            <Select value={reportType} onValueChange={setReportType}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="roadmap">Roadmap snapshot</SelectItem>
+                <SelectItem value="status">Initiative status</SelectItem>
+                <SelectItem value="dependency">Dependency risk</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="lg:col-span-8 flex items-end justify-end">
+            <Button type="submit">
+              <FileDown className="h-4 w-4 mr-2" /> Generate export
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-2 text-sm">
+          {reports.length === 0 ? (
+            <p className="text-muted-foreground">No executive reports generated yet.</p>
+          ) : (
+            reports.map((report) => (
+              <Card key={report.id} className="border-dashed">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{report.type.toUpperCase()} report</CardTitle>
+                  <CardDescription>Generated {new Date(report.generatedAt).toLocaleString()}</CardDescription>
+                </CardHeader>
+                <CardContent className="text-xs text-muted-foreground">
+                  <a href={report.url} target="_blank" rel="noreferrer" className="text-primary hover:underline">
+                    {report.url}
+                  </a>
+                </CardContent>
+              </Card>
+            ))
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/operations/ImportExportPanel.tsx
+++ b/src/components/operations/ImportExportPanel.tsx
@@ -1,0 +1,194 @@
+import { useState } from "react";
+import { KeyRound, UploadCloud, Workflow } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { useOperations } from "./OperationsProvider";
+
+export function ImportExportPanel() {
+  const { importJobs, exportJobs, apiTokens, recordImportJob, updateImportJobStatus, recordExport, manageToken } = useOperations();
+  const [importDraft, setImportDraft] = useState({ type: "csv", mapping: "title=Title,status=Status" });
+  const [exportDraft, setExportDraft] = useState({ format: "csv", scope: "incidents" });
+  const [tokenDraft, setTokenDraft] = useState({ name: "" });
+
+  const handleCreateImport = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const job = recordImportJob({ type: importDraft.type as "csv" | "jira" | "monday", mapping: Object.fromEntries(importDraft.mapping.split(",").map((pair) => pair.split("="))) });
+    updateImportJobStatus(job.id, "validating");
+    setTimeout(() => updateImportJobStatus(job.id, "completed"), 1000);
+    setImportDraft({ type: "csv", mapping: "title=Title,status=Status" });
+  };
+
+  const handleCreateExport = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const token = apiTokens.find((t) => !t.revoked) ?? manageToken({ name: "Ops API" });
+    recordExport({ format: exportDraft.format as "csv" | "json", scope: exportDraft.scope, tokenId: token.id });
+    setExportDraft({ format: "csv", scope: "incidents" });
+  };
+
+  const handleCreateToken = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!tokenDraft.name) return;
+    manageToken({ name: tokenDraft.name });
+    setTokenDraft({ name: "" });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Importers & exports</CardTitle>
+        <CardDescription>
+          Migrate work from CSV, Jira, and Monday, then audit every export and API token usage.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleCreateImport} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Import source</Label>
+            <Select value={importDraft.type} onValueChange={(value) => setImportDraft((prev) => ({ ...prev, type: value }))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="csv">CSV</SelectItem>
+                <SelectItem value="jira">Jira</SelectItem>
+                <SelectItem value="monday">Monday</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="lg:col-span-7 space-y-2">
+            <Label>Field mapping</Label>
+            <Input
+              value={importDraft.mapping}
+              onChange={(event) => setImportDraft((prev) => ({ ...prev, mapping: event.target.value }))}
+              placeholder="title=Title,status=Status"
+            />
+          </div>
+          <div className="lg:col-span-2 flex items-end justify-end">
+            <Button type="submit">
+              <UploadCloud className="h-4 w-4 mr-2" /> Queue import
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-3 text-sm">
+          {importJobs.length === 0 ? (
+            <p className="text-muted-foreground">No imports submitted yet.</p>
+          ) : (
+            importJobs.map((job) => (
+              <Card key={job.id} className="border-dashed">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <Workflow className="h-4 w-4" /> {job.type.toUpperCase()} import
+                  </CardTitle>
+                  <CardDescription>Mapping {Object.keys(job.mapping).join(", ")}</CardDescription>
+                </CardHeader>
+                <CardContent className="flex items-center gap-2">
+                  <Badge variant="outline">{job.status}</Badge>
+                  {job.errors && job.errors.length > 0 && <Badge variant="destructive">{job.errors.length} errors</Badge>}
+                </CardContent>
+              </Card>
+            ))
+          )}
+        </div>
+
+        <form onSubmit={handleCreateExport} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Format</Label>
+            <Select value={exportDraft.format} onValueChange={(value) => setExportDraft((prev) => ({ ...prev, format: value }))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="csv">CSV</SelectItem>
+                <SelectItem value="json">JSON</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="lg:col-span-5 space-y-2">
+            <Label>Scope</Label>
+            <Input
+              value={exportDraft.scope}
+              onChange={(event) => setExportDraft((prev) => ({ ...prev, scope: event.target.value }))}
+              placeholder="incidents"
+            />
+          </div>
+          <div className="lg:col-span-4 flex items-end justify-end">
+            <Button type="submit">
+              Export now
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-3 text-sm">
+          {exportJobs.length === 0 ? (
+            <p className="text-muted-foreground">No exports generated yet.</p>
+          ) : (
+            exportJobs.map((job) => (
+              <Card key={job.id} className="border-dashed">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{job.format.toUpperCase()} export • {job.scope}</CardTitle>
+                  <CardDescription>Token {job.tokenId}</CardDescription>
+                </CardHeader>
+                <CardContent className="text-xs text-muted-foreground">
+                  Generated {new Date(job.createdAt).toLocaleString()}
+                </CardContent>
+              </Card>
+            ))
+          )}
+        </div>
+
+        <form onSubmit={handleCreateToken} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-4 space-y-2">
+            <Label htmlFor="token-name">API token name</Label>
+            <Input
+              id="token-name"
+              value={tokenDraft.name}
+              onChange={(event) => setTokenDraft({ name: event.target.value })}
+              placeholder="Operations analyst"
+            />
+          </div>
+          <div className="lg:col-span-8 flex items-end justify-end">
+            <Button type="submit">
+              <KeyRound className="h-4 w-4 mr-2" /> Generate token
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-3 text-sm">
+          {apiTokens.length === 0 ? (
+            <p className="text-muted-foreground">No active tokens.</p>
+          ) : (
+            apiTokens.map((token) => (
+              <Card key={token.id}>
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <KeyRound className="h-4 w-4" /> {token.name}
+                  </CardTitle>
+                  <CardDescription>Created {new Date(token.createdAt).toLocaleString()}</CardDescription>
+                </CardHeader>
+                <CardContent className="flex items-center gap-3">
+                  <Badge variant={token.revoked ? "destructive" : "secondary"}>{token.revoked ? "Revoked" : "Active"}</Badge>
+                  {!token.revoked && (
+                    <Button type="button" size="sm" variant="outline" onClick={() => manageToken({ id: token.id, name: token.name, revoke: true })}>
+                      Revoke
+                    </Button>
+                  )}
+                </CardContent>
+              </Card>
+            ))
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/operations/IncidentManagementPanel.tsx
+++ b/src/components/operations/IncidentManagementPanel.tsx
@@ -1,0 +1,648 @@
+import { useMemo, useState } from "react";
+import { format, formatDistanceToNow } from "date-fns";
+import { AlertTriangle, CheckCircle2, Clock, Link as LinkIcon, Plus, Users } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  SLA_BY_SEVERITY,
+  Incident,
+  IncidentState,
+  IncidentSeverity,
+  useOperations,
+} from "./OperationsProvider";
+
+const INCIDENT_FLOW: IncidentState[] = ["open", "mitigated", "monitoring", "resolved"];
+
+const severityVariant: Record<IncidentSeverity, "default" | "destructive" | "secondary" | "outline"> = {
+  Sev1: "destructive",
+  Sev2: "default",
+  Sev3: "secondary",
+  Sev4: "outline",
+};
+
+const stateLabels: Record<IncidentState, string> = {
+  open: "Open",
+  mitigated: "Mitigated",
+  monitoring: "Monitoring",
+  resolved: "Resolved",
+};
+
+export function IncidentManagementPanel() {
+  const {
+    incidents,
+    services,
+    businessCalendars,
+    createIncident,
+    transitionIncident,
+    addIncidentResponder,
+    addWorkspaceTask,
+    updateWorkspaceTaskStatus,
+    addWorkspaceLink,
+    recordPostmortem,
+    addIncidentTimelineEntry,
+    toggleServiceChecklist,
+  } = useOperations();
+
+  const [newIncident, setNewIncident] = useState({
+    title: "",
+    description: "",
+    severity: "Sev2" as IncidentSeverity,
+    affectedServices: [] as string[],
+    businessCalendarId: "",
+  });
+  const [selectedIncidentId, setSelectedIncidentId] = useState<string | null>(null);
+  const [postmortemIncidentId, setPostmortemIncidentId] = useState<string | null>(null);
+  const [postmortemDraft, setPostmortemDraft] = useState({
+    impact: "",
+    rootCause: "",
+    correctiveActions: "",
+    actionItems: "",
+    createdBy: "",
+  });
+  const [responderDraft, setResponderDraft] = useState("");
+  const [taskDraft, setTaskDraft] = useState({ title: "", owner: "" });
+  const [linkDraft, setLinkDraft] = useState({ label: "", url: "" });
+
+  const selectedIncident = useMemo(
+    () => incidents.find((incident) => incident.id === selectedIncidentId) ?? incidents[0] ?? null,
+    [incidents, selectedIncidentId]
+  );
+
+  const handleIncidentSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!newIncident.title || !newIncident.description) return;
+    const incident = createIncident({
+      title: newIncident.title,
+      description: newIncident.description,
+      severity: newIncident.severity,
+      affectedServices: newIncident.affectedServices,
+      businessCalendarId: newIncident.businessCalendarId || undefined,
+    });
+    setSelectedIncidentId(incident.id);
+    setNewIncident({ title: "", description: "", severity: "Sev2", affectedServices: [], businessCalendarId: "" });
+  };
+
+  const handleResponderAdd = () => {
+    if (!selectedIncident || !responderDraft) return;
+    addIncidentResponder(selectedIncident.id, responderDraft);
+    addIncidentTimelineEntry(selectedIncident.id, {
+      actor: responderDraft,
+      action: "Joined incident as responder",
+    });
+    setResponderDraft("");
+  };
+
+  const handleTaskAdd = () => {
+    if (!selectedIncident || !taskDraft.title || !taskDraft.owner) return;
+    addWorkspaceTask(selectedIncident.id, taskDraft);
+    addIncidentTimelineEntry(selectedIncident.id, {
+      actor: taskDraft.owner,
+      action: `Created task: ${taskDraft.title}`,
+    });
+    setTaskDraft({ title: "", owner: "" });
+  };
+
+  const handleLinkAdd = () => {
+    if (!selectedIncident || !linkDraft.label || !linkDraft.url) return;
+    addWorkspaceLink(selectedIncident.id, linkDraft);
+    addIncidentTimelineEntry(selectedIncident.id, {
+      actor: "system",
+      action: `Added workspace link: ${linkDraft.label}`,
+    });
+    setLinkDraft({ label: "", url: "" });
+  };
+
+  const handlePostmortemSubmit = () => {
+    if (!postmortemIncidentId) return;
+    const actionItems = postmortemDraft.actionItems
+      .split("\n")
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .map((description) => ({ description, owner: postmortemDraft.createdBy }));
+    recordPostmortem(postmortemIncidentId, {
+      incidentId: postmortemIncidentId,
+      impact: postmortemDraft.impact,
+      rootCause: postmortemDraft.rootCause,
+      correctiveActions: postmortemDraft.correctiveActions,
+      createdBy: postmortemDraft.createdBy,
+      actionItems,
+    });
+    setPostmortemDraft({ impact: "", rootCause: "", correctiveActions: "", actionItems: "", createdBy: "" });
+    setPostmortemIncidentId(null);
+  };
+
+  return (
+    <Card className="col-span-2">
+      <CardHeader>
+        <CardTitle>Incident Command Center</CardTitle>
+        <CardDescription>
+          Track incidents end-to-end with severity-driven SLAs, on-call mobilization, and dedicated workspaces.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleIncidentSubmit} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-3 space-y-2">
+            <Label htmlFor="incident-title">Incident title</Label>
+            <Input
+              id="incident-title"
+              value={newIncident.title}
+              onChange={(event) => setNewIncident((prev) => ({ ...prev, title: event.target.value }))}
+              placeholder="Core API outage"
+            />
+          </div>
+          <div className="lg:col-span-4 space-y-2">
+            <Label htmlFor="incident-description">Description</Label>
+            <Textarea
+              id="incident-description"
+              value={newIncident.description}
+              onChange={(event) => setNewIncident((prev) => ({ ...prev, description: event.target.value }))}
+              placeholder="Describe customer impact, scope, and initial signals"
+              rows={3}
+            />
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label htmlFor="incident-severity">Severity</Label>
+            <select
+              id="incident-severity"
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+              value={newIncident.severity}
+              onChange={(event) =>
+                setNewIncident((prev) => ({ ...prev, severity: event.target.value as IncidentSeverity }))
+              }
+            >
+              {Object.keys(SLA_BY_SEVERITY).map((severity) => (
+                <option key={severity} value={severity}>
+                  {severity} • Default SLA {SLA_BY_SEVERITY[severity as IncidentSeverity]}h
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label htmlFor="incident-calendar">Business calendar</Label>
+            <select
+              id="incident-calendar"
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+              value={newIncident.businessCalendarId}
+              onChange={(event) => setNewIncident((prev) => ({ ...prev, businessCalendarId: event.target.value }))}
+            >
+              <option value="">Default 24x7</option>
+              {businessCalendars.map((calendar) => (
+                <option key={calendar.id} value={calendar.id}>
+                  {calendar.name} ({calendar.timezone})
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Affected services</Label>
+            <div className="border rounded-md p-3 space-y-2 max-h-40 overflow-auto">
+              {services.length === 0 && (
+                <p className="text-xs text-muted-foreground">Define services in the Service Registry to link ownership.</p>
+              )}
+              {services.map((service) => {
+                const checked = newIncident.affectedServices.includes(service.id);
+                return (
+                  <label key={service.id} className="flex items-center gap-2 text-sm">
+                    <Checkbox
+                      checked={checked}
+                      onCheckedChange={(checked) => {
+                        const isChecked = checked === true;
+                        setNewIncident((prev) => ({
+                          ...prev,
+                          affectedServices: isChecked
+                            ? [...prev.affectedServices, service.id]
+                            : prev.affectedServices.filter((id) => id !== service.id),
+                        }));
+                      }}
+                    />
+                    <span>{service.name}</span>
+                    <Badge variant="outline" className="ml-auto text-xs">
+                      {service.ownerTeam}
+                    </Badge>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+          <div className="lg:col-span-12 flex items-end justify-between">
+            <div className="text-sm text-muted-foreground">
+              SLA is automatically set based on severity. Sev1 incidents notify active on-call engineers immediately.
+            </div>
+            <Button type="submit" className="ml-auto">
+              <Plus className="mr-2 h-4 w-4" />
+              Create incident
+            </Button>
+          </div>
+        </form>
+
+        <Tabs defaultValue={selectedIncident?.id ?? incidents[0]?.id} value={selectedIncident?.id} onValueChange={setSelectedIncidentId}>
+          <TabsList className="flex-wrap">
+            {incidents.map((incident) => (
+              <TabsTrigger key={incident.id} value={incident.id} className="text-left">
+                <div className="flex items-center gap-2">
+                  <Badge variant={severityVariant[incident.severity]}>{incident.severity}</Badge>
+                  <span className="font-medium">{incident.title}</span>
+                </div>
+              </TabsTrigger>
+            ))}
+          </TabsList>
+
+          {incidents.map((incident) => (
+            <TabsContent key={incident.id} value={incident.id} className="space-y-4">
+              <div className="grid gap-4 lg:grid-cols-12">
+                <div className="lg:col-span-8 space-y-4">
+                  <div className="border rounded-lg p-4 space-y-4">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <h3 className="text-xl font-semibold">{incident.title}</h3>
+                        <p className="text-sm text-muted-foreground">{incident.description}</p>
+                      </div>
+                      <div className="text-sm text-muted-foreground text-right">
+                        <div>Opened {formatDistanceToNow(new Date(incident.createdAt), { addSuffix: true })}</div>
+                        <div>
+                          SLA breach {formatDistanceToNow(new Date(incident.slaDueAt), { addSuffix: true })}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {incident.affectedServices.map((serviceId) => {
+                        const service = services.find((item) => item.id === serviceId);
+                        if (!service) return null;
+                        return (
+                          <Badge key={serviceId} variant="outline">
+                            {service.name} • {service.ownerTeam}
+                          </Badge>
+                        );
+                      })}
+                    </div>
+                    <div className="flex flex-wrap gap-3 items-center">
+                      {INCIDENT_FLOW.map((state, index) => {
+                        const stateIndex = INCIDENT_FLOW.indexOf(incident.state);
+                        const isCurrent = incident.state === state;
+                        const isCompleted = stateIndex > INCIDENT_FLOW.indexOf(state);
+                        const canAdvance = incident.state !== "resolved" && index === stateIndex + 1;
+                        return (
+                          <div key={state} className="flex items-center gap-2">
+                            <Button
+                              variant={isCurrent ? "default" : isCompleted ? "secondary" : "outline"}
+                              size="sm"
+                              disabled={!isCurrent && !canAdvance}
+                              onClick={() => transitionIncident(incident.id, state, "Operations")}
+                            >
+                              {stateLabels[state]}
+                            </Button>
+                            {index < INCIDENT_FLOW.length - 1 && <Separator orientation="vertical" className="h-6" />}
+                          </div>
+                        );
+                      })}
+                      {incident.state === "resolved" && !incident.postmortem && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            setPostmortemIncidentId(incident.id);
+                            setPostmortemDraft({ impact: "", rootCause: "", correctiveActions: "", actionItems: "", createdBy: "" });
+                          }}
+                        >
+                          <CheckCircle2 className="mr-2 h-4 w-4" /> Complete postmortem
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="border rounded-lg p-4 space-y-4">
+                    <div className="flex items-center justify-between">
+                      <h4 className="font-semibold flex items-center gap-2">
+                        <Users className="h-4 w-4" /> Responders
+                      </h4>
+                      <div className="flex gap-2">
+                        <Input
+                          value={responderDraft}
+                          onChange={(event) => setResponderDraft(event.target.value)}
+                          placeholder="Add engineer"
+                          className="h-9"
+                        />
+                        <Button type="button" onClick={handleResponderAdd}>
+                          Add
+                        </Button>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {incident.workspace.responders.map((responder) => (
+                        <Badge key={responder} variant="secondary">
+                          {responder}
+                        </Badge>
+                      ))}
+                      {incident.workspace.responders.length === 0 && (
+                        <p className="text-sm text-muted-foreground">No responders added yet.</p>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="grid gap-4 lg:grid-cols-2">
+                    <div className="border rounded-lg p-4 space-y-4">
+                      <div className="flex items-center justify-between">
+                        <h4 className="font-semibold flex items-center gap-2">
+                          <CheckCircle2 className="h-4 w-4" /> Task checklist
+                        </h4>
+                        <div className="flex gap-2">
+                          <Input
+                            value={taskDraft.title}
+                            onChange={(event) => setTaskDraft((prev) => ({ ...prev, title: event.target.value }))}
+                            placeholder="Define mitigation"
+                            className="h-9"
+                          />
+                          <Input
+                            value={taskDraft.owner}
+                            onChange={(event) => setTaskDraft((prev) => ({ ...prev, owner: event.target.value }))}
+                            placeholder="Owner"
+                            className="h-9"
+                          />
+                          <Button type="button" onClick={handleTaskAdd}>
+                            Add
+                          </Button>
+                        </div>
+                      </div>
+                      <div className="space-y-2">
+                        {incident.workspace.tasks.length === 0 && (
+                          <p className="text-sm text-muted-foreground">No workspace tasks yet. Capture mitigation steps here.</p>
+                        )}
+                        {incident.workspace.tasks.map((task) => (
+                          <label key={task.id} className="flex items-center gap-3 text-sm">
+                            <Checkbox
+                              checked={task.status === "done"}
+                              onCheckedChange={(checked) => {
+                                const isChecked = checked === true;
+                                updateWorkspaceTaskStatus(incident.id, task.id, isChecked ? "done" : "in_progress");
+                                addIncidentTimelineEntry(incident.id, {
+                                  actor: task.owner,
+                                  action: `${isChecked ? "Completed" : "Reopened"} task: ${task.title}`,
+                                });
+                              }}
+                            />
+                            <span className={task.status === "done" ? "line-through" : ""}>{task.title}</span>
+                            <Badge variant="outline" className="ml-auto text-xs">
+                              {task.owner}
+                            </Badge>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="border rounded-lg p-4 space-y-4">
+                      <div className="flex items-center justify-between">
+                        <h4 className="font-semibold flex items-center gap-2">
+                          <LinkIcon className="h-4 w-4" /> War room resources
+                        </h4>
+                        <div className="flex gap-2">
+                          <Input
+                            value={linkDraft.label}
+                            onChange={(event) => setLinkDraft((prev) => ({ ...prev, label: event.target.value }))}
+                            placeholder="Runbook or dashboard"
+                            className="h-9"
+                          />
+                          <Input
+                            value={linkDraft.url}
+                            onChange={(event) => setLinkDraft((prev) => ({ ...prev, url: event.target.value }))}
+                            placeholder="https://"
+                            className="h-9"
+                          />
+                          <Button type="button" onClick={handleLinkAdd}>
+                            Attach
+                          </Button>
+                        </div>
+                      </div>
+                      <div className="space-y-2">
+                        {incident.workspace.links.length === 0 && (
+                          <p className="text-sm text-muted-foreground">Attach dashboards, chat channels, or feature flags here.</p>
+                        )}
+                        {incident.workspace.links.map((link) => (
+                          <a
+                            key={link.id}
+                            href={link.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="flex items-center justify-between rounded-md border p-2 text-sm hover:border-primary"
+                          >
+                            <span>{link.label}</span>
+                            <LinkIcon className="h-4 w-4 text-muted-foreground" />
+                          </a>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="border rounded-lg p-4 space-y-3">
+                    <h4 className="font-semibold flex items-center gap-2">
+                      <Clock className="h-4 w-4" /> Timeline
+                    </h4>
+                    <div className="space-y-2 max-h-64 overflow-auto">
+                      {incident.workspace.timeline.map((entry) => (
+                        <div key={entry.id} className="flex items-start gap-3 text-sm">
+                          <div className="text-xs text-muted-foreground min-w-[120px]">
+                            {format(new Date(entry.timestamp), "MMM d HH:mm")}
+                          </div>
+                          <div className="font-medium">{entry.actor}</div>
+                          <div className="text-muted-foreground">{entry.action}</div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                <aside className="lg:col-span-4 space-y-4">
+                  <Card>
+                    <CardHeader className="pb-2">
+                      <CardTitle className="text-base">Service runbooks</CardTitle>
+                      <CardDescription>
+                        Automatically surface linked runbooks and tier-based checklists.
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                      {incident.affectedServices.length === 0 && (
+                        <p className="text-sm text-muted-foreground">No services linked. Add a service to unlock ownership context.</p>
+                      )}
+                      {incident.affectedServices.map((serviceId) => {
+                        const service = services.find((item) => item.id === serviceId);
+                        if (!service) return null;
+                        return (
+                          <div key={serviceId} className="border rounded-md p-3 space-y-2">
+                            <div className="flex items-center justify-between">
+                              <div>
+                                <p className="font-semibold text-sm">{service.name}</p>
+                                <p className="text-xs text-muted-foreground">Owned by {service.ownerTeam}</p>
+                              </div>
+                              <Badge variant="outline">{service.tier}</Badge>
+                            </div>
+                            <div className="space-y-1">
+                              {service.runbooks.length === 0 ? (
+                                <p className="text-xs text-muted-foreground">No runbooks uploaded yet.</p>
+                              ) : (
+                                service.runbooks.map((runbook) => (
+                                  <a
+                                    key={runbook.id}
+                                    href={runbook.link}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="flex items-center gap-2 text-xs text-primary hover:underline"
+                                  >
+                                    <LinkIcon className="h-3 w-3" /> {runbook.name}
+                                  </a>
+                                ))
+                              )}
+                            </div>
+                            <div className="space-y-1">
+                              {service.checklists.length === 0 && (
+                                <p className="text-xs text-muted-foreground">No readiness checklist configured.</p>
+                              )}
+                              {service.checklists.map((item) => (
+                                <label key={item.id} className="flex items-center gap-2 text-xs">
+                                  <Checkbox
+                                    checked={item.completed}
+                                    onCheckedChange={() => {
+                                      const nextState = !item.completed;
+                                      toggleServiceChecklist(service.id, item.id, "Operations");
+                                      addIncidentTimelineEntry(incident.id, {
+                                        actor: "Operations",
+                                        action: `${nextState ? "Completed" : "Reopened"} service checklist item: ${item.label}`,
+                                      });
+                                    }}
+                                  />
+                                  <span className={item.completed ? "line-through" : ""}>{item.label}</span>
+                                </label>
+                              ))}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </CardContent>
+                  </Card>
+
+                  {incident.nearBreachEscalated && !incident.breachEscalated && (
+                    <Card className="border-amber-200 bg-amber-50">
+                      <CardHeader className="pb-2">
+                        <CardTitle className="text-base flex items-center gap-2 text-amber-900">
+                          <AlertTriangle className="h-4 w-4" /> SLA nearing breach
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent className="text-sm text-amber-900">
+                        Notify escalation contacts to reinforce mitigation. Update responders with recovery ETA.
+                      </CardContent>
+                    </Card>
+                  )}
+
+                  {incident.breachEscalated && (
+                    <Card className="border-destructive bg-destructive/10">
+                      <CardHeader className="pb-2">
+                        <CardTitle className="text-base flex items-center gap-2 text-destructive">
+                          <AlertTriangle className="h-4 w-4" /> SLA breached
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent className="text-sm text-destructive">
+                        SLA has breached. Ensure leadership is paged and initiate corrective actions per runbook.
+                      </CardContent>
+                    </Card>
+                  )}
+                </aside>
+              </div>
+            </TabsContent>
+          ))}
+        </Tabs>
+
+        {incidents.length === 0 && (
+          <div className="text-center py-10 text-muted-foreground border rounded-lg">
+            No incidents yet. Create your first incident to activate the workspace.
+          </div>
+        )}
+
+        <Dialog open={postmortemIncidentId !== null} onOpenChange={(open) => !open && setPostmortemIncidentId(null)}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Capture postmortem</DialogTitle>
+              <DialogDescription>
+                Document impact, root cause, and corrective actions before closing this incident.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-3">
+              <div>
+                <Label htmlFor="postmortem-impact">Impact</Label>
+                <Textarea
+                  id="postmortem-impact"
+                  value={postmortemDraft.impact}
+                  onChange={(event) => setPostmortemDraft((prev) => ({ ...prev, impact: event.target.value }))}
+                  placeholder="Describe customer impact, duration, and scope"
+                />
+              </div>
+              <div>
+                <Label htmlFor="postmortem-root">Root cause</Label>
+                <Textarea
+                  id="postmortem-root"
+                  value={postmortemDraft.rootCause}
+                  onChange={(event) => setPostmortemDraft((prev) => ({ ...prev, rootCause: event.target.value }))}
+                  placeholder="What caused the incident? Include contributing factors"
+                />
+              </div>
+              <div>
+                <Label htmlFor="postmortem-corrective">Corrective actions</Label>
+                <Textarea
+                  id="postmortem-corrective"
+                  value={postmortemDraft.correctiveActions}
+                  onChange={(event) => setPostmortemDraft((prev) => ({ ...prev, correctiveActions: event.target.value }))}
+                  placeholder="Long-term fixes to prevent recurrence"
+                />
+              </div>
+              <div>
+                <Label htmlFor="postmortem-actions">Action items</Label>
+                <Textarea
+                  id="postmortem-actions"
+                  value={postmortemDraft.actionItems}
+                  onChange={(event) => setPostmortemDraft((prev) => ({ ...prev, actionItems: event.target.value }))}
+                  placeholder="List follow-up tasks, one per line"
+                />
+              </div>
+              <div>
+                <Label htmlFor="postmortem-owner">Captured by</Label>
+                <Input
+                  id="postmortem-owner"
+                  value={postmortemDraft.createdBy}
+                  onChange={(event) => setPostmortemDraft((prev) => ({ ...prev, createdBy: event.target.value }))}
+                  placeholder="Incident commander"
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                onClick={handlePostmortemSubmit}
+                disabled={!postmortemDraft.impact || !postmortemDraft.rootCause || !postmortemDraft.correctiveActions || !postmortemDraft.createdBy}
+              >
+                Save postmortem & create action items
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/operations/MobileOfflinePanel.tsx
+++ b/src/components/operations/MobileOfflinePanel.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import { CheckCircle2, Smartphone, WifiOff } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useOperations } from "./OperationsProvider";
+
+export function MobileOfflinePanel() {
+  const { mobileApprovals, offlineQueue, recordMobileApproval, recordOfflineItem } = useOperations();
+  const [approvalDraft, setApprovalDraft] = useState({ itemId: "APP-1", comment: "", status: "approved" });
+  const [offlineDraft, setOfflineDraft] = useState({ type: "task", payload: "{}" });
+
+  const handleCreateApproval = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    recordMobileApproval({ itemId: approvalDraft.itemId, status: approvalDraft.status as "approved" | "rejected" | "pending", comment: approvalDraft.comment });
+    setApprovalDraft({ itemId: "APP-1", comment: "", status: "approved" });
+  };
+
+  const handleOfflineCreate = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      const payload = JSON.parse(offlineDraft.payload || "{}");
+      recordOfflineItem({ type: offlineDraft.type as "task" | "comment", payload });
+      setOfflineDraft({ type: "task", payload: "{}" });
+    } catch (error) {
+      console.error("Invalid JSON", error);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Mobile approvals & offline queue</CardTitle>
+        <CardDescription>
+          Allow leaders to approve on the go and ensure offline actions sync once connectivity returns.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleCreateApproval} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-4 space-y-2">
+            <Label htmlFor="mobile-item">Item ID</Label>
+            <Input
+              id="mobile-item"
+              value={approvalDraft.itemId}
+              onChange={(event) => setApprovalDraft((prev) => ({ ...prev, itemId: event.target.value }))}
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Status</Label>
+            <Select value={approvalDraft.status} onValueChange={(value) => setApprovalDraft((prev) => ({ ...prev, status: value }))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="approved">Approve</SelectItem>
+                <SelectItem value="rejected">Reject</SelectItem>
+                <SelectItem value="pending">Pending</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="lg:col-span-5 space-y-2">
+            <Label>Comment</Label>
+            <Input
+              value={approvalDraft.comment}
+              onChange={(event) => setApprovalDraft((prev) => ({ ...prev, comment: event.target.value }))}
+              placeholder="Looks good"
+            />
+          </div>
+          <div className="lg:col-span-12 flex justify-end">
+            <Button type="submit">
+              <Smartphone className="h-4 w-4 mr-2" /> Log mobile decision
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-2 text-sm">
+          {mobileApprovals.length === 0 ? (
+            <p className="text-muted-foreground">No mobile approvals yet.</p>
+          ) : (
+            mobileApprovals.map((approval) => (
+              <Card key={approval.id} className="border-dashed">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <CheckCircle2 className="h-4 w-4" /> {approval.itemId}
+                  </CardTitle>
+                  <CardDescription>{approval.status} • {approval.comment}</CardDescription>
+                </CardHeader>
+              </Card>
+            ))
+          )}
+        </div>
+
+        <form onSubmit={handleOfflineCreate} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Offline type</Label>
+            <Select value={offlineDraft.type} onValueChange={(value) => setOfflineDraft((prev) => ({ ...prev, type: value }))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="task">Task</SelectItem>
+                <SelectItem value="comment">Comment</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="lg:col-span-9 space-y-2">
+            <Label>Payload (JSON)</Label>
+            <Input
+              value={offlineDraft.payload}
+              onChange={(event) => setOfflineDraft((prev) => ({ ...prev, payload: event.target.value }))}
+              placeholder='{ "title": "Draft task" }'
+            />
+          </div>
+          <div className="lg:col-span-12 flex justify-end">
+            <Button type="submit">
+              <WifiOff className="h-4 w-4 mr-2" /> Queue offline action
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-2 text-sm">
+          {offlineQueue.length === 0 ? (
+            <p className="text-muted-foreground">Offline queue is clear.</p>
+          ) : (
+            offlineQueue.map((entry) => (
+              <Card key={entry.id} className="border-dashed">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{entry.type}</CardTitle>
+                  <CardDescription>Created {new Date(entry.createdAt).toLocaleString()}</CardDescription>
+                </CardHeader>
+                <CardContent className="text-xs text-muted-foreground">
+                  <pre className="whitespace-pre-wrap">{JSON.stringify(entry.payload, null, 2)}</pre>
+                </CardContent>
+              </Card>
+            ))
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/operations/OnCallRotationPanel.tsx
+++ b/src/components/operations/OnCallRotationPanel.tsx
@@ -1,0 +1,247 @@
+import { useMemo, useState } from "react";
+import { format } from "date-fns";
+import { AlertOctagon, BellRing, Clock, UserCheck } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { useOperations } from "./OperationsProvider";
+
+const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+interface ShiftDraft {
+  dayOfWeek: number;
+  startHour: number;
+  endHour: number;
+  engineer: string;
+}
+
+export function OnCallRotationPanel() {
+  const { onCallRotations, pagingAudit, createOnCallRotation, acknowledgePage } = useOperations();
+  const [rotationDraft, setRotationDraft] = useState({ name: "", team: "", timezone: "UTC" });
+  const [shiftDraft, setShiftDraft] = useState<ShiftDraft>({ dayOfWeek: 1, startHour: 9, endHour: 17, engineer: "" });
+  const [shifts, setShifts] = useState<ShiftDraft[]>([]);
+
+  const handleAddShift = () => {
+    if (!shiftDraft.engineer) return;
+    setShifts((prev) => [...prev, shiftDraft]);
+    setShiftDraft({ dayOfWeek: 1, startHour: 9, endHour: 17, engineer: "" });
+  };
+
+  const handleCreateRotation = () => {
+    if (!rotationDraft.name || !rotationDraft.team || shifts.length === 0) return;
+    createOnCallRotation({
+      ...rotationDraft,
+      shifts: shifts.map((shift) => ({
+        id: `${shift.dayOfWeek}-${shift.startHour}-${shift.engineer}`,
+        ...shift,
+      })),
+      escalationContacts: [],
+    });
+    setRotationDraft({ name: "", team: "", timezone: "UTC" });
+    setShifts([]);
+  };
+
+  const activeShiftInfo = useMemo(() => {
+    const now = new Date();
+    const day = now.getDay();
+    const hour = now.getHours();
+    return onCallRotations.map((rotation) => {
+      const activeShift = rotation.shifts.find((shift) => {
+        if (shift.dayOfWeek !== day) return false;
+        if (shift.startHour <= shift.endHour) {
+          return hour >= shift.startHour && hour < shift.endHour;
+        }
+        return hour >= shift.startHour || hour < shift.endHour;
+      });
+      return { rotationId: rotation.id, engineer: activeShift?.engineer };
+    });
+  }, [onCallRotations]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>On-call rotations & paging</CardTitle>
+        <CardDescription>
+          Define follow-the-sun schedules so Sev1 incidents automatically mobilize the correct responder with audit trails.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-3 space-y-2">
+            <Label htmlFor="rotation-name">Rotation name</Label>
+            <Input
+              id="rotation-name"
+              value={rotationDraft.name}
+              onChange={(event) => setRotationDraft((prev) => ({ ...prev, name: event.target.value }))}
+              placeholder="Operations Primary"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label htmlFor="rotation-team">Team</Label>
+            <Input
+              id="rotation-team"
+              value={rotationDraft.team}
+              onChange={(event) => setRotationDraft((prev) => ({ ...prev, team: event.target.value }))}
+              placeholder="Platform"
+            />
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label htmlFor="rotation-timezone">Timezone</Label>
+            <Input
+              id="rotation-timezone"
+              value={rotationDraft.timezone}
+              onChange={(event) => setRotationDraft((prev) => ({ ...prev, timezone: event.target.value }))}
+              placeholder="UTC"
+            />
+          </div>
+          <div className="lg:col-span-12 border rounded-md p-3 space-y-3">
+            <h4 className="text-sm font-semibold">Define shift coverage</h4>
+            <div className="grid gap-3 lg:grid-cols-12 items-end">
+              <div className="lg:col-span-3 space-y-1">
+                <Label>Day</Label>
+                <select
+                  className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+                  value={shiftDraft.dayOfWeek}
+                  onChange={(event) =>
+                    setShiftDraft((prev) => ({ ...prev, dayOfWeek: Number(event.target.value) }))
+                  }
+                >
+                  {DAYS.map((day, index) => (
+                    <option key={day} value={index}>
+                      {day}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="lg:col-span-2 space-y-1">
+                <Label>Start hour</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={23}
+                  value={shiftDraft.startHour}
+                  onChange={(event) => setShiftDraft((prev) => ({ ...prev, startHour: Number(event.target.value) }))}
+                />
+              </div>
+              <div className="lg:col-span-2 space-y-1">
+                <Label>End hour</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={23}
+                  value={shiftDraft.endHour}
+                  onChange={(event) => setShiftDraft((prev) => ({ ...prev, endHour: Number(event.target.value) }))}
+                />
+              </div>
+              <div className="lg:col-span-3 space-y-1">
+                <Label>Engineer</Label>
+                <Input
+                  value={shiftDraft.engineer}
+                  onChange={(event) => setShiftDraft((prev) => ({ ...prev, engineer: event.target.value }))}
+                  placeholder="oncall@example.com"
+                />
+              </div>
+              <div className="lg:col-span-2">
+                <Button type="button" onClick={handleAddShift} className="w-full">
+                  Add shift
+                </Button>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs">
+              {shifts.length === 0 && <span className="text-muted-foreground">No shifts configured yet.</span>}
+              {shifts.map((shift, index) => (
+                <Badge key={`${shift.dayOfWeek}-${index}`} variant="outline">
+                  {DAYS[shift.dayOfWeek]} • {shift.startHour}:00 → {shift.endHour}:00 • {shift.engineer}
+                </Badge>
+              ))}
+            </div>
+          </div>
+          <div className="lg:col-span-12 flex justify-end">
+            <Button type="button" onClick={handleCreateRotation} disabled={shifts.length === 0}>
+              Save rotation
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          {onCallRotations.map((rotation) => {
+            const active = activeShiftInfo.find((info) => info.rotationId === rotation.id);
+            return (
+              <Card key={rotation.id} className="border-dashed">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <BellRing className="h-4 w-4 text-primary" /> {rotation.name}
+                  </CardTitle>
+                  <CardDescription>
+                    Team {rotation.team} • {rotation.timezone}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-2 text-sm">
+                  <div className="flex items-center gap-2 text-muted-foreground">
+                    <Clock className="h-3 w-3" /> Active engineer: {active?.engineer ?? "No coverage"}
+                  </div>
+                  <div className="space-y-1">
+                    {rotation.shifts.map((shift) => (
+                      <div key={shift.id} className="flex items-center justify-between">
+                        <span>
+                          {DAYS[shift.dayOfWeek]} • {shift.startHour}:00 → {shift.endHour}:00
+                        </span>
+                        <Badge variant="secondary">{shift.engineer}</Badge>
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+          {onCallRotations.length === 0 && (
+            <div className="col-span-2 text-sm text-muted-foreground border rounded-lg p-6">
+              Define a rotation to automatically notify the right engineer when Sev1 incidents trigger.
+            </div>
+          )}
+        </div>
+
+        <div className="border rounded-lg p-4 space-y-3">
+          <h4 className="font-semibold flex items-center gap-2 text-sm">
+            <AlertOctagon className="h-4 w-4" /> Paging audit log
+          </h4>
+          <div className="space-y-2 text-sm">
+            {pagingAudit.length === 0 && <p className="text-muted-foreground">No pages triggered yet.</p>}
+            {pagingAudit.map((entry) => (
+              <div
+                key={entry.id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-md border p-3"
+              >
+                <div>
+                  <div className="font-medium">{entry.engineer}</div>
+                  <div className="text-xs text-muted-foreground">
+                    Paged at {format(new Date(entry.triggeredAt), "MMM d HH:mm" )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  {entry.acknowledgedAt ? (
+                    <Badge variant="outline" className="flex items-center gap-1">
+                      <UserCheck className="h-3 w-3" /> Acknowledged {format(new Date(entry.acknowledgedAt), "MMM d HH:mm")}
+                    </Badge>
+                  ) : (
+                    <Button variant="outline" size="sm" onClick={() => acknowledgePage(entry.id)}>
+                      Mark acknowledged
+                    </Button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/operations/OperationsProvider.tsx
+++ b/src/components/operations/OperationsProvider.tsx
@@ -1,0 +1,1515 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { addHours, addMinutes, differenceInMinutes, isAfter, isBefore, parseISO } from "date-fns";
+
+export type IncidentSeverity = "Sev1" | "Sev2" | "Sev3" | "Sev4";
+export type IncidentState = "open" | "mitigated" | "monitoring" | "resolved";
+export type ChangeState = "draft" | "review" | "approved" | "implementing" | "validated" | "done";
+
+export interface TimelineEntry {
+  id: string;
+  timestamp: string;
+  actor: string;
+  action: string;
+}
+
+export interface WorkspaceTask {
+  id: string;
+  title: string;
+  owner: string;
+  status: "open" | "in_progress" | "done";
+}
+
+export interface WorkspaceLink {
+  id: string;
+  label: string;
+  url: string;
+}
+
+export interface PostmortemActionItem {
+  id: string;
+  description: string;
+  owner: string;
+  dueDate?: string;
+  status: "open" | "in_progress" | "done";
+}
+
+export interface PostmortemRecord {
+  id: string;
+  incidentId: string;
+  impact: string;
+  rootCause: string;
+  correctiveActions: string;
+  createdAt: string;
+  createdBy: string;
+  actionItems: PostmortemActionItem[];
+}
+
+export interface IncidentWorkspace {
+  timeline: TimelineEntry[];
+  responders: string[];
+  tasks: WorkspaceTask[];
+  links: WorkspaceLink[];
+}
+
+export interface Incident {
+  id: string;
+  title: string;
+  description: string;
+  severity: IncidentSeverity;
+  affectedServices: string[];
+  state: IncidentState;
+  createdAt: string;
+  updatedAt: string;
+  slaDueAt: string;
+  workspace: IncidentWorkspace;
+  postmortem?: PostmortemRecord | null;
+  businessCalendarId?: string;
+  slaPausedAt?: string | null;
+  nearBreachEscalated?: boolean;
+  breachEscalated?: boolean;
+}
+
+export interface RotationShift {
+  id: string;
+  dayOfWeek: number;
+  startHour: number;
+  endHour: number;
+  engineer: string;
+}
+
+export interface OnCallRotation {
+  id: string;
+  name: string;
+  team: string;
+  timezone: string;
+  shifts: RotationShift[];
+  escalationContacts: string[];
+}
+
+export interface PagingAuditEntry {
+  id: string;
+  incidentId: string;
+  rotationId: string;
+  engineer: string;
+  triggeredAt: string;
+  acknowledgedAt?: string;
+}
+
+export interface ChangeRequest {
+  id: string;
+  title: string;
+  description: string;
+  risk: string;
+  impact: string;
+  backoutPlan: string;
+  state: ChangeState;
+  requestedBy: string;
+  approverName?: string;
+  approvedAt?: string;
+  plannedStart?: string;
+  plannedEnd?: string;
+  serviceIds: string[];
+  freezeOverride?: boolean;
+  timeline: TimelineEntry[];
+}
+
+export interface FreezeWindow {
+  id: string;
+  name: string;
+  start: string;
+  end: string;
+  teams: string[];
+  allowOverride: boolean;
+}
+
+export interface RunbookReference {
+  id: string;
+  name: string;
+  link: string;
+  type: "link" | "file";
+}
+
+export interface ChecklistItem {
+  id: string;
+  label: string;
+  completed: boolean;
+  completedAt?: string;
+  completedBy?: string;
+}
+
+export interface Service {
+  id: string;
+  name: string;
+  ownerTeam: string;
+  runbookLink: string;
+  tier: "Tier 1" | "Tier 2" | "Tier 3";
+  runbooks: RunbookReference[];
+  checklists: ChecklistItem[];
+}
+
+export interface DependencyItem {
+  id: string;
+  name: string;
+  team: string;
+  status: string;
+  dueDate: string;
+  dependsOn: string[];
+  criticalPath: boolean;
+}
+
+export interface BusinessHour {
+  day: number;
+  start: string;
+  end: string;
+}
+
+export interface BusinessCalendar {
+  id: string;
+  name: string;
+  timezone: string;
+  hours: BusinessHour[];
+  pauseStates: IncidentState[];
+  escalationContacts: {
+    nearBreach: string[];
+    breach: string[];
+  };
+}
+
+export interface SavedSearch {
+  id: string;
+  name: string;
+  query: string;
+  filters: Record<string, unknown>;
+  visibility: "private" | "team" | "organization";
+  owner: string;
+  sharedUrl: string;
+}
+
+export interface OpsMetricSnapshot {
+  id: string;
+  capturedAt: string;
+  mttaMinutes: number;
+  mttrMinutes: number;
+  slaCompliance: number;
+  changeFailureRate: number;
+}
+
+export interface DocTemplate {
+  id: string;
+  name: string;
+  type: "PRD" | "RFC" | "Custom";
+  content: string;
+}
+
+export interface BoundField {
+  field: string;
+  itemId: string;
+  value: string;
+}
+
+export interface StatusChip {
+  itemId: string;
+  status: string;
+  assignee: string;
+}
+
+export interface DocChange {
+  id: string;
+  type: "insert" | "delete";
+  content: string;
+  author: string;
+  timestamp: string;
+}
+
+export interface DocApproval {
+  id: string;
+  docId: string;
+  reviewer: string;
+  status: "pending" | "approved" | "rejected";
+  requestedAt: string;
+  respondedAt?: string;
+}
+
+export interface OpsDocument {
+  id: string;
+  title: string;
+  templateId?: string;
+  content: string;
+  autosavedAt: string;
+  chips: StatusChip[];
+  boundFields: BoundField[];
+  changes: DocChange[];
+  approvals: DocApproval[];
+  requiredApprovers: string[];
+  status: "draft" | "final";
+}
+
+export interface Initiative {
+  id: string;
+  name: string;
+  health: "green" | "amber" | "red";
+  progress: number;
+  budgetPlanned?: number;
+  budgetActual?: number;
+  epicIds: string[];
+}
+
+export interface PortfolioView {
+  id: string;
+  name: string;
+  filters: Record<string, unknown>;
+  sharedWith: string[];
+}
+
+export interface DependencyRiskRecord {
+  id: string;
+  blockingTeam: string;
+  blockedTeam: string;
+  severity: "low" | "medium" | "high";
+  count: number;
+  impactedItems: string[];
+}
+
+export interface KeyResult {
+  id: string;
+  name: string;
+  target: number;
+  current: number;
+  linkedItemIds: string[];
+}
+
+export interface Objective {
+  id: string;
+  name: string;
+  description: string;
+  quarter: string;
+  owner: string;
+  keyResults: KeyResult[];
+}
+
+export interface ImportJob {
+  id: string;
+  type: "csv" | "jira" | "monday";
+  status: "pending" | "validating" | "importing" | "completed" | "failed";
+  createdAt: string;
+  mapping: Record<string, string>;
+  errors?: string[];
+}
+
+export interface ExportJob {
+  id: string;
+  format: "csv" | "json";
+  scope: string;
+  tokenId: string;
+  createdAt: string;
+}
+
+export interface ApiToken {
+  id: string;
+  name: string;
+  createdAt: string;
+  lastUsedAt?: string;
+  revoked?: boolean;
+}
+
+export interface DigestSchedule {
+  id: string;
+  scope: string;
+  cadence: "weekly" | "monthly";
+  channel: "email" | "slack" | "both";
+  recipients: string[];
+  lastSentAt?: string;
+}
+
+export interface PortfolioReport {
+  id: string;
+  type: "roadmap" | "status" | "dependency";
+  generatedAt: string;
+  url: string;
+}
+
+export interface PerformanceGuardrail {
+  id: string;
+  name: string;
+  threshold: number;
+  metric: string;
+  status: "passing" | "failing";
+}
+
+export interface BackupJob {
+  id: string;
+  projectId: string;
+  requestedAt: string;
+  completedAt?: string;
+  restorePoint?: string;
+}
+
+export interface FailoverDrill {
+  id: string;
+  name: string;
+  executedAt: string;
+  status: "pending" | "completed" | "in_progress";
+  notes?: string;
+}
+
+export interface MobileApproval {
+  id: string;
+  itemId: string;
+  status: "pending" | "approved" | "rejected";
+  requestedAt: string;
+  decidedAt?: string;
+  comment?: string;
+}
+
+export interface OfflineItem {
+  id: string;
+  type: "task" | "comment";
+  payload: Record<string, unknown>;
+  createdAt: string;
+  syncedAt?: string;
+}
+
+export interface SandboxPromotion {
+  id: string;
+  name: string;
+  submittedAt: string;
+  approvedAt?: string;
+  status: "draft" | "pending" | "approved" | "rejected";
+}
+
+export interface TemplateVersion {
+  id: string;
+  templateId: string;
+  version: number;
+  createdAt: string;
+  createdBy: string;
+  changelog: string;
+  published: boolean;
+}
+
+export interface ScimEvent {
+  id: string;
+  type: "provision" | "update" | "deprovision";
+  user: string;
+  occurredAt: string;
+}
+
+export interface SloDefinition {
+  id: string;
+  name: string;
+  indicator: "availability" | "latency" | "error_rate";
+  target: number;
+  burnRate?: number;
+  linkedIncidents: string[];
+}
+
+export interface OperationsState {
+  incidents: Incident[];
+  onCallRotations: OnCallRotation[];
+  pagingAudit: PagingAuditEntry[];
+  changeRequests: ChangeRequest[];
+  freezeWindows: FreezeWindow[];
+  services: Service[];
+  dependencyItems: DependencyItem[];
+  businessCalendars: BusinessCalendar[];
+  savedSearches: SavedSearch[];
+  opsMetrics: OpsMetricSnapshot[];
+  docTemplates: DocTemplate[];
+  documents: OpsDocument[];
+  initiatives: Initiative[];
+  portfolioViews: PortfolioView[];
+  dependencyRisks: DependencyRiskRecord[];
+  objectives: Objective[];
+  importJobs: ImportJob[];
+  exportJobs: ExportJob[];
+  apiTokens: ApiToken[];
+  digestSchedules: DigestSchedule[];
+  reports: PortfolioReport[];
+  performanceGuardrails: PerformanceGuardrail[];
+  backupJobs: BackupJob[];
+  failoverDrills: FailoverDrill[];
+  mobileApprovals: MobileApproval[];
+  offlineQueue: OfflineItem[];
+  sandboxPromotions: SandboxPromotion[];
+  templateVersions: TemplateVersion[];
+  scimEvents: ScimEvent[];
+  sloDefinitions: SloDefinition[];
+}
+
+const createId = () => (typeof globalThis.crypto !== 'undefined' && globalThis.crypto.randomUUID ? globalThis.crypto.randomUUID() : Math.random().toString(36).slice(2));
+
+export const SLA_BY_SEVERITY: Record<IncidentSeverity, number> = {
+  Sev1: 1,
+  Sev2: 4,
+  Sev3: 8,
+  Sev4: 24,
+};
+
+const STORAGE_KEY = "operations_state_v1";
+
+const defaultState: OperationsState = {
+  incidents: [],
+  onCallRotations: [],
+  pagingAudit: [],
+  changeRequests: [],
+  freezeWindows: [],
+  services: [],
+  dependencyItems: [],
+  businessCalendars: [],
+  savedSearches: [],
+  opsMetrics: [],
+  docTemplates: [
+    {
+      id: "template-prd",
+      name: "Product Requirements Document",
+      type: "PRD",
+      content: "# Overview\n## Goals\n## Success Metrics\n## Requirements\n",
+    },
+    {
+      id: "template-rfc",
+      name: "Request for Comments",
+      type: "RFC",
+      content: "# Summary\n## Context\n## Proposal\n## Alternatives\n",
+    },
+  ],
+  documents: [],
+  initiatives: [],
+  portfolioViews: [],
+  dependencyRisks: [],
+  objectives: [],
+  importJobs: [],
+  exportJobs: [],
+  apiTokens: [],
+  digestSchedules: [],
+  reports: [],
+  performanceGuardrails: [],
+  backupJobs: [],
+  failoverDrills: [],
+  mobileApprovals: [],
+  offlineQueue: [],
+  sandboxPromotions: [],
+  templateVersions: [],
+  scimEvents: [],
+  sloDefinitions: [],
+};
+
+interface OperationsContextValue extends OperationsState {
+  createIncident: (input: {
+    title: string;
+    description: string;
+    severity: IncidentSeverity;
+    affectedServices: string[];
+    businessCalendarId?: string;
+  }) => Incident;
+  transitionIncident: (incidentId: string, nextState: IncidentState, actor: string) => void;
+  addIncidentTimelineEntry: (incidentId: string, entry: Omit<TimelineEntry, "id" | "timestamp"> & { timestamp?: string }) => void;
+  addIncidentResponder: (incidentId: string, responder: string) => void;
+  addWorkspaceTask: (incidentId: string, task: Omit<WorkspaceTask, "id" | "status">) => void;
+  updateWorkspaceTaskStatus: (incidentId: string, taskId: string, status: WorkspaceTask["status"]) => void;
+  addWorkspaceLink: (incidentId: string, link: Omit<WorkspaceLink, "id">) => void;
+  recordPostmortem: (incidentId: string, record: Omit<PostmortemRecord, "id" | "createdAt">) => void;
+  createOnCallRotation: (rotation: Omit<OnCallRotation, "id">) => OnCallRotation;
+  recordPagingEvent: (incidentId: string, rotationId: string, engineer: string) => void;
+  acknowledgePage: (auditId: string) => void;
+  createChangeRequest: (input: Omit<ChangeRequest, "id" | "state" | "timeline"> & { state?: ChangeState }) => ChangeRequest;
+  transitionChangeState: (changeId: string, nextState: ChangeState, actor: string, options?: { approverName?: string; overrideFreeze?: boolean }) => void;
+  scheduleFreezeWindow: (window: Omit<FreezeWindow, "id">) => void;
+  createService: (service: Omit<Service, "id" | "runbooks" | "checklists"> & { runbooks?: RunbookReference[]; checklists?: ChecklistItem[] }) => Service;
+  updateService: (serviceId: string, updates: Partial<Service>) => void;
+  addServiceRunbook: (serviceId: string, runbook: Omit<RunbookReference, "id">) => void;
+  toggleServiceChecklist: (serviceId: string, checklistId: string, completedBy: string) => void;
+  registerDependencyItem: (item: Omit<DependencyItem, "id">) => DependencyItem;
+  saveBusinessCalendar: (calendar: Omit<BusinessCalendar, "id"> & { id?: string }) => BusinessCalendar;
+  escalateIfNeeded: () => void;
+  saveSearch: (search: Omit<SavedSearch, "id" | "sharedUrl">) => SavedSearch;
+  captureOpsMetrics: () => OpsMetricSnapshot;
+  saveDocument: (doc: Partial<OpsDocument> & { id?: string; title: string }) => OpsDocument;
+  requestDocApproval: (docId: string, reviewer: string) => void;
+  respondToDocApproval: (approvalId: string, status: "approved" | "rejected") => void;
+  updatePortfolio: (initiative: Omit<Initiative, "id"> & { id?: string }) => Initiative;
+  savePortfolioView: (view: Omit<PortfolioView, "id"> & { id?: string }) => PortfolioView;
+  saveDependencyRisk: (risk: Omit<DependencyRiskRecord, "id"> & { id?: string }) => DependencyRiskRecord;
+  saveObjective: (objective: Omit<Objective, "id"> & { id?: string }) => Objective;
+  recordImportJob: (job: Omit<ImportJob, "id" | "status"> & { status?: ImportJob["status"] }) => ImportJob;
+  updateImportJobStatus: (jobId: string, status: ImportJob["status"], errors?: string[]) => void;
+  recordExport: (exportJob: Omit<ExportJob, "id">) => ExportJob;
+  manageToken: (token: Omit<ApiToken, "id" | "createdAt"> & { id?: string; revoke?: boolean }) => ApiToken;
+  scheduleDigest: (schedule: Omit<DigestSchedule, "id"> & { id?: string }) => DigestSchedule;
+  recordReport: (report: Omit<PortfolioReport, "id">) => PortfolioReport;
+  definePerformanceGuardrail: (guardrail: Omit<PerformanceGuardrail, "id"> & { id?: string }) => PerformanceGuardrail;
+  recordBackupJob: (job: Omit<BackupJob, "id"> & { id?: string }) => BackupJob;
+  recordFailoverDrill: (drill: Omit<FailoverDrill, "id"> & { id?: string }) => FailoverDrill;
+  recordMobileApproval: (approval: Omit<MobileApproval, "id"> & { id?: string }) => MobileApproval;
+  recordOfflineItem: (item: Omit<OfflineItem, "id"> & { id?: string }) => OfflineItem;
+  recordSandboxPromotion: (promotion: Omit<SandboxPromotion, "id"> & { id?: string }) => SandboxPromotion;
+  recordTemplateVersion: (version: Omit<TemplateVersion, "id"> & { id?: string }) => TemplateVersion;
+  recordScimEvent: (event: Omit<ScimEvent, "id">) => ScimEvent;
+  recordSlo: (slo: Omit<SloDefinition, "id"> & { id?: string }) => SloDefinition;
+}
+
+const OperationsContext = createContext<OperationsContextValue | undefined>(undefined);
+
+export function OperationsProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<OperationsState>(() => {
+    const stored = typeof window !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored) as OperationsState;
+        return { ...defaultState, ...parsed };
+      } catch (error) {
+        console.error("Failed to parse operations state", error);
+      }
+    }
+    return defaultState;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }, [state]);
+
+  const findActiveShift = (rotation: OnCallRotation) => {
+    const now = new Date();
+    const day = now.getDay();
+    const hour = now.getHours();
+    return rotation.shifts.find((shift) => {
+      if (shift.dayOfWeek !== day) return false;
+      if (shift.startHour <= shift.endHour) {
+        return hour >= shift.startHour && hour < shift.endHour;
+      }
+      // overnight shift
+      return hour >= shift.startHour || hour < shift.endHour;
+    });
+  };
+
+  const escalateIfNeeded = () => {
+    const now = new Date();
+    setState((prev) => {
+      let changed = false;
+      const updatedIncidents = prev.incidents.map((incident) => {
+        const due = parseISO(incident.slaDueAt);
+        const minutesToDue = differenceInMinutes(due, now);
+        if (minutesToDue <= 30 && minutesToDue > 0 && !incident.nearBreachEscalated) {
+          changed = true;
+          return { ...incident, nearBreachEscalated: true };
+        }
+        if (isBefore(due, now) && !incident.breachEscalated) {
+          changed = true;
+          return { ...incident, breachEscalated: true };
+        }
+        return incident;
+      });
+      if (!changed) return prev;
+      return { ...prev, incidents: updatedIncidents };
+    });
+  };
+
+  useEffect(() => {
+    const interval = setInterval(() => escalateIfNeeded(), 60_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const value: OperationsContextValue = useMemo(() => ({
+    ...state,
+    createIncident: ({ title, description, severity, affectedServices, businessCalendarId }) => {
+      const now = new Date();
+      const slaDueAt = addHours(now, SLA_BY_SEVERITY[severity]).toISOString();
+      const incident: Incident = {
+        id: createId(),
+        title,
+        description,
+        severity,
+        affectedServices,
+        state: "open",
+        createdAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+        slaDueAt,
+        workspace: {
+          timeline: [
+            {
+              id: createId(),
+              timestamp: now.toISOString(),
+              actor: "system",
+              action: "Incident created",
+            },
+          ],
+          responders: [],
+          tasks: [],
+          links: [],
+        },
+        postmortem: null,
+        businessCalendarId,
+        slaPausedAt: null,
+      };
+
+      setState((prev) => ({
+        ...prev,
+        incidents: [...prev.incidents, incident],
+      }));
+
+      if (severity === "Sev1") {
+        const pagingEntries = state.onCallRotations.flatMap((rotation) => {
+          const activeShift = findActiveShift(rotation);
+          if (!activeShift) return [];
+          return [{
+            id: createId(),
+            incidentId: incident.id,
+            rotationId: rotation.id,
+            engineer: activeShift.engineer,
+            triggeredAt: new Date().toISOString(),
+          }];
+        });
+        if (pagingEntries.length) {
+          setState((prev) => ({
+            ...prev,
+            pagingAudit: [...prev.pagingAudit, ...pagingEntries],
+          }));
+        }
+      }
+
+      return incident;
+    },
+    transitionIncident: (incidentId, nextState, actor) => {
+      setState((prev) => {
+        const incidents = prev.incidents.map((incident) => {
+          if (incident.id !== incidentId) return incident;
+          const now = new Date();
+          const calendar = incident.businessCalendarId
+            ? prev.businessCalendars.find((cal) => cal.id === incident.businessCalendarId)
+            : undefined;
+          const isPauseState = calendar?.pauseStates.includes(nextState) ?? false;
+          let slaDueAt = incident.slaDueAt;
+          let slaPausedAt = incident.slaPausedAt ?? null;
+          const timelineEntries = [
+            ...incident.workspace.timeline,
+            {
+              id: createId(),
+              timestamp: now.toISOString(),
+              actor,
+              action: `Moved to ${nextState}`,
+            },
+          ];
+          if (isPauseState && !slaPausedAt) {
+            slaPausedAt = now.toISOString();
+            timelineEntries.push({
+              id: createId(),
+              timestamp: now.toISOString(),
+              actor: "system",
+              action: "SLA paused per business hours",
+            });
+          }
+          if (!isPauseState && slaPausedAt) {
+            const pausedMinutes = differenceInMinutes(now, parseISO(slaPausedAt));
+            slaDueAt = addMinutes(parseISO(slaDueAt), pausedMinutes).toISOString();
+            timelineEntries.push({
+              id: createId(),
+              timestamp: now.toISOString(),
+              actor: "system",
+              action: "SLA resumed",
+            });
+            slaPausedAt = null;
+          }
+          const updated: Incident = {
+            ...incident,
+            state: nextState,
+            updatedAt: now.toISOString(),
+            slaDueAt,
+            slaPausedAt,
+            workspace: {
+              ...incident.workspace,
+              timeline: timelineEntries,
+            },
+          };
+          if (nextState === "resolved" && !incident.postmortem) {
+            updated.workspace.timeline.push({
+              id: createId(),
+              timestamp: now.toISOString(),
+              actor: "system",
+              action: "Postmortem required",
+            });
+          }
+          return updated;
+        });
+        return { ...prev, incidents };
+      });
+    },
+    addIncidentTimelineEntry: (incidentId, entry) => {
+      setState((prev) => ({
+        ...prev,
+        incidents: prev.incidents.map((incident) =>
+          incident.id === incidentId
+            ? {
+                ...incident,
+                workspace: {
+                  ...incident.workspace,
+                  timeline: [
+                    ...incident.workspace.timeline,
+                    {
+                      id: createId(),
+                      timestamp: entry.timestamp ?? new Date().toISOString(),
+                      actor: entry.actor,
+                      action: entry.action,
+                    },
+                  ],
+                },
+              }
+            : incident
+        ),
+      }));
+    },
+    addIncidentResponder: (incidentId, responder) => {
+      setState((prev) => ({
+        ...prev,
+        incidents: prev.incidents.map((incident) =>
+          incident.id === incidentId
+            ? {
+                ...incident,
+                workspace: {
+                  ...incident.workspace,
+                  responders: Array.from(new Set([...incident.workspace.responders, responder])),
+                },
+              }
+            : incident
+        ),
+      }));
+    },
+    addWorkspaceTask: (incidentId, task) => {
+      setState((prev) => ({
+        ...prev,
+        incidents: prev.incidents.map((incident) =>
+          incident.id === incidentId
+            ? {
+                ...incident,
+                workspace: {
+                  ...incident.workspace,
+                  tasks: [
+                    ...incident.workspace.tasks,
+                    {
+                      id: createId(),
+                      title: task.title,
+                      owner: task.owner,
+                      status: "open",
+                    },
+                  ],
+                },
+              }
+            : incident
+        ),
+      }));
+    },
+    updateWorkspaceTaskStatus: (incidentId, taskId, status) => {
+      setState((prev) => ({
+        ...prev,
+        incidents: prev.incidents.map((incident) =>
+          incident.id === incidentId
+            ? {
+                ...incident,
+                workspace: {
+                  ...incident.workspace,
+                  tasks: incident.workspace.tasks.map((task) =>
+                    task.id === taskId ? { ...task, status } : task
+                  ),
+                },
+              }
+            : incident
+        ),
+      }));
+    },
+    addWorkspaceLink: (incidentId, link) => {
+      setState((prev) => ({
+        ...prev,
+        incidents: prev.incidents.map((incident) =>
+          incident.id === incidentId
+            ? {
+                ...incident,
+                workspace: {
+                  ...incident.workspace,
+                  links: [
+                    ...incident.workspace.links,
+                    {
+                      id: createId(),
+                      label: link.label,
+                      url: link.url,
+                    },
+                  ],
+                },
+              }
+            : incident
+        ),
+      }));
+    },
+    recordPostmortem: (incidentId, record) => {
+      const now = new Date();
+      setState((prev) => ({
+        ...prev,
+        incidents: prev.incidents.map((incident) =>
+          incident.id === incidentId
+            ? {
+                ...incident,
+                postmortem: {
+                  id: createId(),
+                  incidentId,
+                  impact: record.impact,
+                  rootCause: record.rootCause,
+                  correctiveActions: record.correctiveActions,
+                  createdAt: now.toISOString(),
+                  createdBy: record.createdBy,
+                  actionItems: record.actionItems.map((item) => ({
+                    ...item,
+                    id: createId(),
+                    status: "open",
+                  })),
+                },
+                workspace: {
+                  ...incident.workspace,
+                  timeline: [
+                    ...incident.workspace.timeline,
+                    {
+                      id: createId(),
+                      timestamp: now.toISOString(),
+                      actor: record.createdBy,
+                      action: "Postmortem captured",
+                    },
+                  ],
+                },
+              }
+            : incident
+        ),
+      }));
+    },
+    createOnCallRotation: (rotation) => {
+      const newRotation: OnCallRotation = { ...rotation, id: createId() };
+      setState((prev) => ({
+        ...prev,
+        onCallRotations: [...prev.onCallRotations, newRotation],
+      }));
+      return newRotation;
+    },
+    recordPagingEvent: (incidentId, rotationId, engineer) => {
+      const entry: PagingAuditEntry = {
+        id: createId(),
+        incidentId,
+        rotationId,
+        engineer,
+        triggeredAt: new Date().toISOString(),
+      };
+      setState((prev) => ({
+        ...prev,
+        pagingAudit: [...prev.pagingAudit, entry],
+      }));
+    },
+    acknowledgePage: (auditId) => {
+      setState((prev) => ({
+        ...prev,
+        pagingAudit: prev.pagingAudit.map((entry) =>
+          entry.id === auditId
+            ? { ...entry, acknowledgedAt: new Date().toISOString() }
+            : entry
+        ),
+      }));
+    },
+    createChangeRequest: (input) => {
+      const change: ChangeRequest = {
+        id: createId(),
+        title: input.title,
+        description: input.description,
+        risk: input.risk,
+        impact: input.impact,
+        backoutPlan: input.backoutPlan,
+        state: input.state ?? "draft",
+        requestedBy: input.requestedBy,
+        approverName: input.approverName,
+        approvedAt: input.approvedAt,
+        plannedStart: input.plannedStart,
+        plannedEnd: input.plannedEnd,
+        serviceIds: input.serviceIds,
+        freezeOverride: input.freezeOverride,
+        timeline: [
+          {
+            id: createId(),
+            timestamp: new Date().toISOString(),
+            actor: input.requestedBy,
+            action: "Change created",
+          },
+        ],
+      };
+      setState((prev) => ({
+        ...prev,
+        changeRequests: [...prev.changeRequests, change],
+      }));
+      return change;
+    },
+    transitionChangeState: (changeId, nextState, actor, options) => {
+      setState((prev) => {
+        const change = prev.changeRequests.find((c) => c.id === changeId);
+        if (!change) return prev;
+        if (nextState === "approved" && (!change.risk || !change.impact || !change.backoutPlan)) {
+          throw new Error("Risk, impact, and backout plan are required before approval");
+        }
+        if (nextState === "implementing" && change.state !== "approved" && !options?.overrideFreeze) {
+          throw new Error("Change must be approved before implementing");
+        }
+        if (nextState === "implementing" && !options?.overrideFreeze) {
+          const now = new Date();
+          const affectedTeams = change.serviceIds
+            .map((serviceId) => prev.services.find((service) => service.id === serviceId)?.ownerTeam)
+            .filter((team): team is string => Boolean(team));
+          const inFreeze = prev.freezeWindows.some((window) => {
+            const start = parseISO(window.start);
+            const end = parseISO(window.end);
+            return isBefore(start, now) && isAfter(end, now) && window.teams.some((team) => affectedTeams.includes(team));
+          });
+          if (inFreeze) {
+            throw new Error("Change is blocked by a freeze window");
+          }
+        }
+        const updatedChanges = prev.changeRequests.map((c) =>
+          c.id === changeId
+            ? {
+                ...c,
+                state: nextState,
+                approverName: options?.approverName ?? c.approverName,
+                approvedAt: nextState === "approved" ? new Date().toISOString() : c.approvedAt,
+                freezeOverride: options?.overrideFreeze ?? c.freezeOverride,
+                timeline: [
+                  ...c.timeline,
+                  {
+                    id: createId(),
+                    timestamp: new Date().toISOString(),
+                    actor,
+                    action: `Moved to ${nextState}`,
+                  },
+                ],
+              }
+            : c
+        );
+        return { ...prev, changeRequests: updatedChanges };
+      });
+    },
+    scheduleFreezeWindow: (window) => {
+      setState((prev) => ({
+        ...prev,
+        freezeWindows: [...prev.freezeWindows, { ...window, id: createId() }],
+      }));
+    },
+    createService: (service) => {
+      const newService: Service = {
+        id: createId(),
+        name: service.name,
+        ownerTeam: service.ownerTeam,
+        runbookLink: service.runbookLink,
+        tier: service.tier,
+        runbooks: service.runbooks ?? [],
+        checklists: service.checklists ?? [],
+      };
+      setState((prev) => ({
+        ...prev,
+        services: [...prev.services, newService],
+      }));
+      return newService;
+    },
+    updateService: (serviceId, updates) => {
+      setState((prev) => ({
+        ...prev,
+        services: prev.services.map((service) =>
+          service.id === serviceId
+            ? { ...service, ...updates }
+            : service
+        ),
+      }));
+    },
+    addServiceRunbook: (serviceId, runbook) => {
+      setState((prev) => ({
+        ...prev,
+        services: prev.services.map((service) =>
+          service.id === serviceId
+            ? {
+                ...service,
+                runbooks: [...service.runbooks, { ...runbook, id: createId() }],
+              }
+            : service
+        ),
+      }));
+    },
+    toggleServiceChecklist: (serviceId, checklistId, completedBy) => {
+      setState((prev) => ({
+        ...prev,
+        services: prev.services.map((service) =>
+          service.id === serviceId
+            ? {
+                ...service,
+                checklists: service.checklists.map((item) =>
+                  item.id === checklistId
+                    ? {
+                        ...item,
+                        completed: !item.completed,
+                        completedAt: !item.completed ? new Date().toISOString() : undefined,
+                        completedBy: !item.completed ? completedBy : undefined,
+                      }
+                    : item
+                ),
+              }
+            : service
+        ),
+      }));
+    },
+    registerDependencyItem: (item) => {
+      const newItem: DependencyItem = { ...item, id: createId() };
+      setState((prev) => ({
+        ...prev,
+        dependencyItems: [...prev.dependencyItems, newItem],
+      }));
+      return newItem;
+    },
+    saveBusinessCalendar: (calendar) => {
+      const id = calendar.id ?? createId();
+      const newCalendar: BusinessCalendar = { ...calendar, id };
+      setState((prev) => {
+        const existing = prev.businessCalendars.find((cal) => cal.id === id);
+        if (existing) {
+          return {
+            ...prev,
+            businessCalendars: prev.businessCalendars.map((cal) => (cal.id === id ? newCalendar : cal)),
+          };
+        }
+        return { ...prev, businessCalendars: [...prev.businessCalendars, newCalendar] };
+      });
+      return newCalendar;
+    },
+    escalateIfNeeded,
+    saveSearch: (search) => {
+      const newSearch: SavedSearch = {
+        id: createId(),
+        name: search.name,
+        query: search.query,
+        filters: search.filters,
+        visibility: search.visibility,
+        owner: search.owner,
+        sharedUrl: `${window.location.origin}/dashboard/search?q=${encodeURIComponent(search.query)}`,
+      };
+      setState((prev) => ({
+        ...prev,
+        savedSearches: [...prev.savedSearches, newSearch],
+      }));
+      return newSearch;
+    },
+    captureOpsMetrics: () => {
+      const now = new Date();
+      const resolvedIncidents = state.incidents.filter((incident) => incident.state === "resolved" && incident.postmortem);
+      const mtta = resolvedIncidents.length
+        ? resolvedIncidents.reduce((sum, incident) => {
+            const ackEntry = incident.workspace.timeline.find((entry) => entry.action.includes("Moved to mitigated"));
+            if (!ackEntry) return sum;
+            return sum + differenceInMinutes(parseISO(ackEntry.timestamp), parseISO(incident.createdAt));
+          }, 0) / resolvedIncidents.length
+        : 0;
+      const mttr = resolvedIncidents.length
+        ? resolvedIncidents.reduce((sum, incident) =>
+            sum + differenceInMinutes(parseISO(incident.updatedAt), parseISO(incident.createdAt))
+          , 0) / resolvedIncidents.length
+        : 0;
+      const slaCompliance = state.incidents.length
+        ? (state.incidents.filter((incident) => isBefore(parseISO(incident.updatedAt), parseISO(incident.slaDueAt))).length / state.incidents.length) * 100
+        : 100;
+      const failedChanges = state.changeRequests.filter((change) => change.state === "validated" && change.timeline.some((entry) => entry.action.includes("failure")));
+      const changeFailureRate = state.changeRequests.length
+        ? (failedChanges.length / state.changeRequests.length) * 100
+        : 0;
+      const snapshot: OpsMetricSnapshot = {
+        id: createId(),
+        capturedAt: now.toISOString(),
+        mttaMinutes: Math.round(mtta),
+        mttrMinutes: Math.round(mttr),
+        slaCompliance: Math.round(slaCompliance),
+        changeFailureRate: Math.round(changeFailureRate),
+      };
+      setState((prev) => ({
+        ...prev,
+        opsMetrics: [...prev.opsMetrics, snapshot],
+      }));
+      return snapshot;
+    },
+    saveDocument: (doc) => {
+      const now = new Date().toISOString();
+      const id = doc.id ?? createId();
+      const existing = state.documents.find((d) => d.id === id);
+      const newDocument: OpsDocument = {
+        id,
+        title: doc.title,
+        templateId: doc.templateId ?? existing?.templateId,
+        content: doc.content ?? existing?.content ?? "",
+        autosavedAt: now,
+        chips: doc.chips ?? existing?.chips ?? [],
+        boundFields: doc.boundFields ?? existing?.boundFields ?? [],
+        changes: doc.changes ?? existing?.changes ?? [],
+        approvals: doc.approvals ?? existing?.approvals ?? [],
+        requiredApprovers: doc.requiredApprovers ?? existing?.requiredApprovers ?? [],
+        status: doc.status ?? existing?.status ?? "draft",
+      };
+      setState((prev) => ({
+        ...prev,
+        documents: prev.documents.some((d) => d.id === id)
+          ? prev.documents.map((d) => (d.id === id ? newDocument : d))
+          : [...prev.documents, newDocument],
+      }));
+      return newDocument;
+    },
+    requestDocApproval: (docId, reviewer) => {
+      const approval: DocApproval = {
+        id: createId(),
+        docId,
+        reviewer,
+        status: "pending",
+        requestedAt: new Date().toISOString(),
+      };
+      setState((prev) => ({
+        ...prev,
+        documents: prev.documents.map((doc) =>
+          doc.id === docId
+            ? { ...doc, approvals: [...doc.approvals, approval] }
+            : doc
+        ),
+      }));
+    },
+    respondToDocApproval: (approvalId, status) => {
+      setState((prev) => ({
+        ...prev,
+        documents: prev.documents.map((doc) => {
+          const approvals = doc.approvals.map((approval) =>
+            approval.id === approvalId
+              ? { ...approval, status, respondedAt: new Date().toISOString() }
+              : approval
+          );
+          const allApproved = doc.requiredApprovers.length
+            ? doc.requiredApprovers.every((approver) => approvals.some((approval) => approval.reviewer === approver && approval.status === "approved"))
+            : approvals.every((approval) => approval.status === "approved");
+          return {
+            ...doc,
+            approvals,
+            status: allApproved ? "final" : doc.status,
+          };
+        }),
+      }));
+    },
+    updatePortfolio: (initiative) => {
+      const id = initiative.id ?? createId();
+      const newInitiative: Initiative = {
+        id,
+        name: initiative.name,
+        health: initiative.health,
+        progress: initiative.progress,
+        budgetPlanned: initiative.budgetPlanned,
+        budgetActual: initiative.budgetActual,
+        epicIds: initiative.epicIds,
+      };
+      setState((prev) => ({
+        ...prev,
+        initiatives: prev.initiatives.some((item) => item.id === id)
+          ? prev.initiatives.map((item) => (item.id === id ? newInitiative : item))
+          : [...prev.initiatives, newInitiative],
+      }));
+      return newInitiative;
+    },
+    savePortfolioView: (view) => {
+      const id = view.id ?? createId();
+      const newView: PortfolioView = {
+        id,
+        name: view.name,
+        filters: view.filters,
+        sharedWith: view.sharedWith,
+      };
+      setState((prev) => ({
+        ...prev,
+        portfolioViews: prev.portfolioViews.some((item) => item.id === id)
+          ? prev.portfolioViews.map((item) => (item.id === id ? newView : item))
+          : [...prev.portfolioViews, newView],
+      }));
+      return newView;
+    },
+    saveDependencyRisk: (risk) => {
+      const id = risk.id ?? createId();
+      const newRisk: DependencyRiskRecord = {
+        id,
+        blockingTeam: risk.blockingTeam,
+        blockedTeam: risk.blockedTeam,
+        severity: risk.severity,
+        count: risk.count,
+        impactedItems: risk.impactedItems,
+      };
+      setState((prev) => ({
+        ...prev,
+        dependencyRisks: prev.dependencyRisks.some((item) => item.id === id)
+          ? prev.dependencyRisks.map((item) => (item.id === id ? newRisk : item))
+          : [...prev.dependencyRisks, newRisk],
+      }));
+      return newRisk;
+    },
+    saveObjective: (objective) => {
+      const id = objective.id ?? createId();
+      const newObjective: Objective = {
+        id,
+        name: objective.name,
+        description: objective.description,
+        quarter: objective.quarter,
+        owner: objective.owner,
+        keyResults: objective.keyResults,
+      };
+      setState((prev) => ({
+        ...prev,
+        objectives: prev.objectives.some((item) => item.id === id)
+          ? prev.objectives.map((item) => (item.id === id ? newObjective : item))
+          : [...prev.objectives, newObjective],
+      }));
+      return newObjective;
+    },
+    recordImportJob: (job) => {
+      const newJob: ImportJob = {
+        id: createId(),
+        type: job.type,
+        status: job.status ?? "pending",
+        createdAt: new Date().toISOString(),
+        mapping: job.mapping,
+        errors: job.errors,
+      };
+      setState((prev) => ({
+        ...prev,
+        importJobs: [...prev.importJobs, newJob],
+      }));
+      return newJob;
+    },
+    updateImportJobStatus: (jobId, status, errors) => {
+      setState((prev) => ({
+        ...prev,
+        importJobs: prev.importJobs.map((job) =>
+          job.id === jobId
+            ? { ...job, status, errors: errors ?? job.errors }
+            : job
+        ),
+      }));
+    },
+    recordExport: (exportJob) => {
+      const newExport: ExportJob = {
+        id: createId(),
+        format: exportJob.format,
+        scope: exportJob.scope,
+        tokenId: exportJob.tokenId,
+        createdAt: new Date().toISOString(),
+      };
+      setState((prev) => ({
+        ...prev,
+        exportJobs: [...prev.exportJobs, newExport],
+      }));
+      return newExport;
+    },
+    manageToken: (token) => {
+      const id = token.id ?? createId();
+      const newToken: ApiToken = {
+        id,
+        name: token.name,
+        createdAt: token.id ? state.apiTokens.find((t) => t.id === id)?.createdAt ?? new Date().toISOString() : new Date().toISOString(),
+        lastUsedAt: token.lastUsedAt,
+        revoked: token.revoke ? true : token.revoked,
+      };
+      setState((prev) => ({
+        ...prev,
+        apiTokens: prev.apiTokens.some((item) => item.id === id)
+          ? prev.apiTokens.map((item) => (item.id === id ? newToken : item))
+          : [...prev.apiTokens, newToken],
+      }));
+      return newToken;
+    },
+    scheduleDigest: (schedule) => {
+      const id = schedule.id ?? createId();
+      const newSchedule: DigestSchedule = {
+        id,
+        scope: schedule.scope,
+        cadence: schedule.cadence,
+        channel: schedule.channel,
+        recipients: schedule.recipients,
+        lastSentAt: schedule.lastSentAt,
+      };
+      setState((prev) => ({
+        ...prev,
+        digestSchedules: prev.digestSchedules.some((item) => item.id === id)
+          ? prev.digestSchedules.map((item) => (item.id === id ? newSchedule : item))
+          : [...prev.digestSchedules, newSchedule],
+      }));
+      return newSchedule;
+    },
+    recordReport: (report) => {
+      const newReport: PortfolioReport = {
+        id: createId(),
+        type: report.type,
+        generatedAt: new Date().toISOString(),
+        url: report.url,
+      };
+      setState((prev) => ({
+        ...prev,
+        reports: [...prev.reports, newReport],
+      }));
+      return newReport;
+    },
+    definePerformanceGuardrail: (guardrail) => {
+      const id = guardrail.id ?? createId();
+      const newGuardrail: PerformanceGuardrail = {
+        id,
+        name: guardrail.name,
+        threshold: guardrail.threshold,
+        metric: guardrail.metric,
+        status: guardrail.status,
+      };
+      setState((prev) => ({
+        ...prev,
+        performanceGuardrails: prev.performanceGuardrails.some((item) => item.id === id)
+          ? prev.performanceGuardrails.map((item) => (item.id === id ? newGuardrail : item))
+          : [...prev.performanceGuardrails, newGuardrail],
+      }));
+      return newGuardrail;
+    },
+    recordBackupJob: (job) => {
+      const id = job.id ?? createId();
+      const newJob: BackupJob = {
+        id,
+        projectId: job.projectId,
+        requestedAt: job.requestedAt ?? new Date().toISOString(),
+        completedAt: job.completedAt,
+        restorePoint: job.restorePoint,
+      };
+      setState((prev) => ({
+        ...prev,
+        backupJobs: prev.backupJobs.some((item) => item.id === id)
+          ? prev.backupJobs.map((item) => (item.id === id ? newJob : item))
+          : [...prev.backupJobs, newJob],
+      }));
+      return newJob;
+    },
+    recordFailoverDrill: (drill) => {
+      const id = drill.id ?? createId();
+      const newDrill: FailoverDrill = {
+        id,
+        name: drill.name,
+        executedAt: drill.executedAt ?? new Date().toISOString(),
+        status: drill.status,
+        notes: drill.notes,
+      };
+      setState((prev) => ({
+        ...prev,
+        failoverDrills: prev.failoverDrills.some((item) => item.id === id)
+          ? prev.failoverDrills.map((item) => (item.id === id ? newDrill : item))
+          : [...prev.failoverDrills, newDrill],
+      }));
+      return newDrill;
+    },
+    recordMobileApproval: (approval) => {
+      const id = approval.id ?? createId();
+      const newApproval: MobileApproval = {
+        id,
+        itemId: approval.itemId,
+        status: approval.status,
+        requestedAt: approval.requestedAt ?? new Date().toISOString(),
+        decidedAt: approval.decidedAt,
+        comment: approval.comment,
+      };
+      setState((prev) => ({
+        ...prev,
+        mobileApprovals: prev.mobileApprovals.some((item) => item.id === id)
+          ? prev.mobileApprovals.map((item) => (item.id === id ? newApproval : item))
+          : [...prev.mobileApprovals, newApproval],
+      }));
+      return newApproval;
+    },
+    recordOfflineItem: (item) => {
+      const id = item.id ?? createId();
+      const newItem: OfflineItem = {
+        id,
+        type: item.type,
+        payload: item.payload,
+        createdAt: item.createdAt ?? new Date().toISOString(),
+        syncedAt: item.syncedAt,
+      };
+      setState((prev) => ({
+        ...prev,
+        offlineQueue: prev.offlineQueue.some((entry) => entry.id === id)
+          ? prev.offlineQueue.map((entry) => (entry.id === id ? newItem : entry))
+          : [...prev.offlineQueue, newItem],
+      }));
+      return newItem;
+    },
+    recordSandboxPromotion: (promotion) => {
+      const id = promotion.id ?? createId();
+      const newPromotion: SandboxPromotion = {
+        id,
+        name: promotion.name,
+        submittedAt: promotion.submittedAt ?? new Date().toISOString(),
+        approvedAt: promotion.approvedAt,
+        status: promotion.status,
+      };
+      setState((prev) => ({
+        ...prev,
+        sandboxPromotions: prev.sandboxPromotions.some((item) => item.id === id)
+          ? prev.sandboxPromotions.map((item) => (item.id === id ? newPromotion : item))
+          : [...prev.sandboxPromotions, newPromotion],
+      }));
+      return newPromotion;
+    },
+    recordTemplateVersion: (version) => {
+      const id = version.id ?? createId();
+      const newVersion: TemplateVersion = {
+        id,
+        templateId: version.templateId,
+        version: version.version,
+        createdAt: version.createdAt ?? new Date().toISOString(),
+        createdBy: version.createdBy,
+        changelog: version.changelog,
+        published: version.published,
+      };
+      setState((prev) => ({
+        ...prev,
+        templateVersions: prev.templateVersions.some((item) => item.id === id)
+          ? prev.templateVersions.map((item) => (item.id === id ? newVersion : item))
+          : [...prev.templateVersions, newVersion],
+      }));
+      return newVersion;
+    },
+    recordScimEvent: (event) => {
+      const newEvent: ScimEvent = {
+        id: createId(),
+        type: event.type,
+        user: event.user,
+        occurredAt: event.occurredAt ?? new Date().toISOString(),
+      };
+      setState((prev) => ({
+        ...prev,
+        scimEvents: [...prev.scimEvents, newEvent],
+      }));
+      return newEvent;
+    },
+    recordSlo: (slo) => {
+      const id = slo.id ?? createId();
+      const newSlo: SloDefinition = {
+        id,
+        name: slo.name,
+        indicator: slo.indicator,
+        target: slo.target,
+        burnRate: slo.burnRate,
+        linkedIncidents: slo.linkedIncidents,
+      };
+      setState((prev) => ({
+        ...prev,
+        sloDefinitions: prev.sloDefinitions.some((item) => item.id === id)
+          ? prev.sloDefinitions.map((item) => (item.id === id ? newSlo : item))
+          : [...prev.sloDefinitions, newSlo],
+      }));
+      return newSlo;
+    },
+  }), [state]);
+
+  return <OperationsContext.Provider value={value}>{children}</OperationsContext.Provider>;
+}
+
+export function useOperations() {
+  const context = useContext(OperationsContext);
+  if (!context) {
+    throw new Error("useOperations must be used within an OperationsProvider");
+  }
+  return context;
+}

--- a/src/components/operations/OpsDashboardPanel.tsx
+++ b/src/components/operations/OpsDashboardPanel.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useMemo, useState } from "react";
+import { Download, Gauge, TrendingDown, TrendingUp } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useOperations } from "./OperationsProvider";
+
+function exportCsv(rows: Array<Record<string, number | string>>) {
+  const header = Object.keys(rows[0]).join(",");
+  const data = rows.map((row) => Object.values(row).join(","));
+  const csv = [header, ...data].join("\n");
+  const blob = new Blob([csv], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "ops-dashboard.csv";
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+async function exportPng(metrics: string) {
+  const canvas = document.createElement("canvas");
+  canvas.width = 600;
+  canvas.height = 200;
+  const ctx = canvas.getContext("2d");
+  if (ctx) {
+    ctx.fillStyle = "#111827";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "#ffffff";
+    ctx.font = "16px Inter";
+    ctx.fillText("Operations Dashboard", 20, 40);
+    ctx.font = "14px Inter";
+    ctx.fillText(metrics, 20, 80);
+    const url = canvas.toDataURL("image/png");
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "ops-dashboard.png";
+    link.click();
+  }
+}
+
+export function OpsDashboardPanel() {
+  const { opsMetrics, captureOpsMetrics, incidents, changeRequests } = useOperations();
+  const [range, setRange] = useState("30");
+
+  useEffect(() => {
+    if (opsMetrics.length === 0) {
+      captureOpsMetrics();
+    }
+  }, [opsMetrics.length, captureOpsMetrics]);
+
+  const snapshot = useMemo(() => {
+    if (opsMetrics.length === 0) {
+      return {
+        id: "temp",
+        capturedAt: new Date().toISOString(),
+        mttaMinutes: 0,
+        mttrMinutes: 0,
+        slaCompliance: 100,
+        changeFailureRate: 0,
+      };
+    }
+    return opsMetrics[opsMetrics.length - 1];
+  }, [opsMetrics]);
+
+  const summary = useMemo(() => {
+    const recentIncidents = incidents.slice(-Number(range));
+    const recentChanges = changeRequests.slice(-Number(range));
+    const sev1Count = recentIncidents.filter((incident) => incident.severity === "Sev1").length;
+    const resolved = recentIncidents.filter((incident) => incident.state === "resolved").length;
+    const completedChanges = recentChanges.filter((change) => change.state === "done").length;
+    return { sev1Count, resolved, completedChanges };
+  }, [incidents, changeRequests, range]);
+
+  const metricsText = `MTTA ${snapshot.mttaMinutes}m | MTTR ${snapshot.mttrMinutes}m | SLA ${snapshot.slaCompliance}% | Change Failure ${snapshot.changeFailureRate}%`;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Operations dashboard</CardTitle>
+        <CardDescription>
+          Monitor response and recovery with exportable MTTA/MTTR, SLA compliance, and change stability trends.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-wrap items-center gap-4 justify-between">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Select value={range} onValueChange={setRange}>
+              <SelectTrigger className="w-[140px]">
+                <SelectValue placeholder="Time range" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="7">Last 7</SelectItem>
+                <SelectItem value="30">Last 30</SelectItem>
+                <SelectItem value="90">Last 90</SelectItem>
+              </SelectContent>
+            </Select>
+            <span>records</span>
+          </div>
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={() => exportCsv([snapshot])}>
+              <Download className="h-4 w-4 mr-2" /> Export CSV
+            </Button>
+            <Button type="button" variant="outline" onClick={() => exportPng(metricsText)}>
+              <Download className="h-4 w-4 mr-2" /> Export PNG
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-4">
+          <Card className="bg-muted">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">Mean time to acknowledge</CardTitle>
+            </CardHeader>
+            <CardContent className="flex items-center justify-between">
+              <div className="text-2xl font-semibold">{snapshot.mttaMinutes}m</div>
+              <Gauge className="h-8 w-8 text-primary" />
+            </CardContent>
+          </Card>
+          <Card className="bg-muted">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">Mean time to resolve</CardTitle>
+            </CardHeader>
+            <CardContent className="flex items-center justify-between">
+              <div className="text-2xl font-semibold">{snapshot.mttrMinutes}m</div>
+              <TrendingDown className="h-8 w-8 text-primary" />
+            </CardContent>
+          </Card>
+          <Card className="bg-muted">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">SLA compliance</CardTitle>
+            </CardHeader>
+            <CardContent className="flex items-center justify-between">
+              <div className="text-2xl font-semibold">{snapshot.slaCompliance}%</div>
+              <TrendingUp className="h-8 w-8 text-primary" />
+            </CardContent>
+          </Card>
+          <Card className="bg-muted">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">Change failure rate</CardTitle>
+            </CardHeader>
+            <CardContent className="flex items-center justify-between">
+              <div className="text-2xl font-semibold">{snapshot.changeFailureRate}%</div>
+              <TrendingDown className="h-8 w-8 text-primary" />
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-3 text-sm">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base">Sev1 volume</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-semibold">{summary.sev1Count}</div>
+              <p className="text-xs text-muted-foreground">Number of Sev1 incidents in the selected range.</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base">Incidents resolved</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-semibold">{summary.resolved}</div>
+              <p className="text-xs text-muted-foreground">Closed incidents over the selected period.</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base">Changes completed</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-semibold">{summary.completedChanges}</div>
+              <p className="text-xs text-muted-foreground">Deployment changes reaching Done state.</p>
+            </CardContent>
+          </Card>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/operations/PortfolioOkrsPanel.tsx
+++ b/src/components/operations/PortfolioOkrsPanel.tsx
@@ -1,0 +1,332 @@
+import { useMemo, useState } from "react";
+import { Flame, Target, TrendingUp } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { useOperations } from "./OperationsProvider";
+
+export function PortfolioOkrsPanel() {
+  const { initiatives, dependencyRisks, objectives, updatePortfolio, saveDependencyRisk, saveObjective } = useOperations();
+  const [initiativeDraft, setInitiativeDraft] = useState({
+    name: "",
+    health: "green" as "green" | "amber" | "red",
+    progress: 0,
+    budgetPlanned: "",
+    budgetActual: "",
+  });
+  const [riskDraft, setRiskDraft] = useState({ blockingTeam: "", blockedTeam: "", severity: "medium", count: 1 });
+  const [objectiveDraft, setObjectiveDraft] = useState({
+    name: "",
+    description: "",
+    quarter: "Q1",
+    owner: "",
+    keyResults: "",
+  });
+
+  const heatmapMatrix = useMemo(() => {
+    const matrix = new Map<string, Map<string, number>>();
+    dependencyRisks.forEach((risk) => {
+      if (!matrix.has(risk.blockingTeam)) matrix.set(risk.blockingTeam, new Map());
+      const row = matrix.get(risk.blockingTeam)!;
+      row.set(risk.blockedTeam, (row.get(risk.blockedTeam) ?? 0) + risk.count);
+    });
+    return matrix;
+  }, [dependencyRisks]);
+
+  const handleCreateInitiative = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!initiativeDraft.name) return;
+    updatePortfolio({
+      name: initiativeDraft.name,
+      health: initiativeDraft.health,
+      progress: initiativeDraft.progress,
+      budgetPlanned: initiativeDraft.budgetPlanned ? Number(initiativeDraft.budgetPlanned) : undefined,
+      budgetActual: initiativeDraft.budgetActual ? Number(initiativeDraft.budgetActual) : undefined,
+      epicIds: [],
+    });
+    setInitiativeDraft({ name: "", health: "green", progress: 0, budgetPlanned: "", budgetActual: "" });
+  };
+
+  const handleCreateRisk = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!riskDraft.blockingTeam || !riskDraft.blockedTeam) return;
+    saveDependencyRisk({
+      blockingTeam: riskDraft.blockingTeam,
+      blockedTeam: riskDraft.blockedTeam,
+      severity: riskDraft.severity as "low" | "medium" | "high",
+      count: riskDraft.count,
+      impactedItems: [],
+    });
+    setRiskDraft({ blockingTeam: "", blockedTeam: "", severity: "medium", count: 1 });
+  };
+
+  const handleCreateObjective = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!objectiveDraft.name) return;
+    const keyResults = objectiveDraft.keyResults
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line, index) => ({ id: `${Date.now()}-${index}`, name: line, target: 100, current: 0, linkedItemIds: [] }));
+    saveObjective({
+      name: objectiveDraft.name,
+      description: objectiveDraft.description,
+      quarter: objectiveDraft.quarter,
+      owner: objectiveDraft.owner,
+      keyResults,
+    });
+    setObjectiveDraft({ name: "", description: "", quarter: "Q1", owner: "", keyResults: "" });
+  };
+
+  return (
+    <Card className="col-span-2">
+      <CardHeader>
+        <CardTitle>Portfolio & OKRs</CardTitle>
+        <CardDescription>
+          Track initiative health, dependency risk hotspots, and OKR progress across the portfolio.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleCreateInitiative} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-4 space-y-2">
+            <Label htmlFor="initiative-name">Initiative</Label>
+            <Input
+              id="initiative-name"
+              value={initiativeDraft.name}
+              onChange={(event) => setInitiativeDraft((prev) => ({ ...prev, name: event.target.value }))}
+              placeholder="Improve onboarding"
+            />
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label>Health</Label>
+            <select
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+              value={initiativeDraft.health}
+              onChange={(event) => setInitiativeDraft((prev) => ({ ...prev, health: event.target.value as typeof prev.health }))}
+            >
+              <option value="green">Green</option>
+              <option value="amber">Amber</option>
+              <option value="red">Red</option>
+            </select>
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label>Progress %</Label>
+            <Input
+              type="number"
+              value={initiativeDraft.progress}
+              onChange={(event) => setInitiativeDraft((prev) => ({ ...prev, progress: Number(event.target.value) }))}
+            />
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label>Budget planned</Label>
+            <Input
+              type="number"
+              value={initiativeDraft.budgetPlanned}
+              onChange={(event) => setInitiativeDraft((prev) => ({ ...prev, budgetPlanned: event.target.value }))}
+            />
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label>Budget actual</Label>
+            <Input
+              type="number"
+              value={initiativeDraft.budgetActual}
+              onChange={(event) => setInitiativeDraft((prev) => ({ ...prev, budgetActual: event.target.value }))}
+            />
+          </div>
+          <div className="lg:col-span-12 flex justify-end">
+            <Button type="submit">Add initiative</Button>
+          </div>
+        </form>
+
+        <div className="grid gap-4 lg:grid-cols-3 text-sm">
+          {initiatives.map((initiative) => (
+            <Card key={initiative.id} className="border-dashed">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base flex items-center gap-2">
+                  <TrendingUp className="h-4 w-4" /> {initiative.name}
+                </CardTitle>
+                <CardDescription>
+                  Health {initiative.health.toUpperCase()} • {initiative.progress}% complete
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-1 text-xs">
+                {initiative.budgetPlanned && (
+                  <div>Budget: {initiative.budgetActual ?? 0}/{initiative.budgetPlanned}</div>
+                )}
+                <div className="flex gap-2">
+                  <Badge variant="outline">Initiative</Badge>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+          {initiatives.length === 0 && (
+            <div className="lg:col-span-3 text-sm text-muted-foreground border rounded-lg p-6">
+              Capture initiatives to monitor health across your portfolio.
+            </div>
+          )}
+        </div>
+
+        <form onSubmit={handleCreateRisk} className="grid gap-3 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-3 space-y-1">
+            <Label>Blocking team</Label>
+            <Input
+              value={riskDraft.blockingTeam}
+              onChange={(event) => setRiskDraft((prev) => ({ ...prev, blockingTeam: event.target.value }))}
+              placeholder="Payments"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-1">
+            <Label>Blocked team</Label>
+            <Input
+              value={riskDraft.blockedTeam}
+              onChange={(event) => setRiskDraft((prev) => ({ ...prev, blockedTeam: event.target.value }))}
+              placeholder="Mobile"
+            />
+          </div>
+          <div className="lg:col-span-2 space-y-1">
+            <Label>Severity</Label>
+            <select
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+              value={riskDraft.severity}
+              onChange={(event) => setRiskDraft((prev) => ({ ...prev, severity: event.target.value }))}
+            >
+              <option value="low">Low</option>
+              <option value="medium">Medium</option>
+              <option value="high">High</option>
+            </select>
+          </div>
+          <div className="lg:col-span-2 space-y-1">
+            <Label>Count</Label>
+            <Input
+              type="number"
+              value={riskDraft.count}
+              onChange={(event) => setRiskDraft((prev) => ({ ...prev, count: Number(event.target.value) }))}
+            />
+          </div>
+          <div className="lg:col-span-2 flex items-end justify-end">
+            <Button type="submit">Log risk</Button>
+          </div>
+        </form>
+
+        <div className="border rounded-lg p-4 space-y-3">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Flame className="h-4 w-4" /> Dependency risk heatmap
+          </div>
+          {heatmapMatrix.size === 0 ? (
+            <p className="text-sm text-muted-foreground">No cross-team risks recorded.</p>
+          ) : (
+            <div className="overflow-auto">
+              <table className="min-w-[400px] text-xs">
+                <thead>
+                  <tr>
+                    <th className="text-left p-2">Blocking \ Blocked</th>
+                    {[...heatmapMatrix.values()][0] ? Array.from(new Set(Array.from(heatmapMatrix.values()).flatMap((row) => Array.from(row.keys())))).map((team) => (
+                      <th key={team} className="text-left p-2">{team}</th>
+                    )) : null}
+                  </tr>
+                </thead>
+                <tbody>
+                  {Array.from(heatmapMatrix.entries()).map(([blockingTeam, row]) => (
+                    <tr key={blockingTeam}>
+                      <td className="p-2 font-medium">{blockingTeam}</td>
+                      {Array.from(new Set(Array.from(heatmapMatrix.values()).flatMap((r) => Array.from(r.keys())))).map((team) => (
+                        <td key={`${blockingTeam}-${team}`} className="p-2">
+                          {row.get(team) ?? 0}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
+        <form onSubmit={handleCreateObjective} className="grid gap-3 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-3 space-y-1">
+            <Label htmlFor="okr-name">Objective</Label>
+            <Input
+              id="okr-name"
+              value={objectiveDraft.name}
+              onChange={(event) => setObjectiveDraft((prev) => ({ ...prev, name: event.target.value }))}
+              placeholder="Grow weekly active users"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-1">
+            <Label htmlFor="okr-owner">Owner</Label>
+            <Input
+              id="okr-owner"
+              value={objectiveDraft.owner}
+              onChange={(event) => setObjectiveDraft((prev) => ({ ...prev, owner: event.target.value }))}
+              placeholder="VP Product"
+            />
+          </div>
+          <div className="lg:col-span-2 space-y-1">
+            <Label>Quarter</Label>
+            <select
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+              value={objectiveDraft.quarter}
+              onChange={(event) => setObjectiveDraft((prev) => ({ ...prev, quarter: event.target.value }))}
+            >
+              <option value="Q1">Q1</option>
+              <option value="Q2">Q2</option>
+              <option value="Q3">Q3</option>
+              <option value="Q4">Q4</option>
+            </select>
+          </div>
+          <div className="lg:col-span-12 space-y-1">
+            <Label>Key results</Label>
+            <Textarea
+              value={objectiveDraft.keyResults}
+              onChange={(event) => setObjectiveDraft((prev) => ({ ...prev, keyResults: event.target.value }))}
+              placeholder="KR1: Increase activation to 45%\nKR2: Ship onboarding tour"
+            />
+          </div>
+          <div className="lg:col-span-12 flex justify-end">
+            <Button type="submit">Create objective</Button>
+          </div>
+        </form>
+
+        <div className="grid gap-3 lg:grid-cols-2 text-sm">
+          {objectives.map((objective) => (
+            <Card key={objective.id} className="border-dashed">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base flex items-center gap-2">
+                  <Target className="h-4 w-4" /> {objective.name}
+                </CardTitle>
+                <CardDescription>
+                  {objective.quarter} • Owned by {objective.owner}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2 text-xs">
+                <p>{objective.description}</p>
+                <div className="space-y-1">
+                  {objective.keyResults.map((kr) => (
+                    <div key={kr.id} className="flex justify-between">
+                      <span>{kr.name}</span>
+                      <Badge variant="outline">{kr.current}% / {kr.target}%</Badge>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+          {objectives.length === 0 && (
+            <div className="lg:col-span-2 text-sm text-muted-foreground border rounded-lg p-6">
+              Capture quarterly objectives and their measurable key results here.
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/operations/ResiliencePerformancePanel.tsx
+++ b/src/components/operations/ResiliencePerformancePanel.tsx
@@ -1,0 +1,196 @@
+import { useState } from "react";
+import { AlertOctagon, Database, Server } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { useOperations } from "./OperationsProvider";
+
+export function ResiliencePerformancePanel() {
+  const { performanceGuardrails, backupJobs, failoverDrills, definePerformanceGuardrail, recordBackupJob, recordFailoverDrill } = useOperations();
+  const [guardrailDraft, setGuardrailDraft] = useState({ name: "API latency", metric: "p95_latency", threshold: 500, status: "passing" });
+  const [backupDraft, setBackupDraft] = useState({ projectId: "project-123" });
+  const [drillDraft, setDrillDraft] = useState({ name: "Quarterly failover", status: "pending" as "pending" | "completed" | "in_progress" });
+
+  const handleCreateGuardrail = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    definePerformanceGuardrail({
+      name: guardrailDraft.name,
+      metric: guardrailDraft.metric,
+      threshold: Number(guardrailDraft.threshold),
+      status: guardrailDraft.status as "passing" | "failing",
+    });
+    setGuardrailDraft({ name: "API latency", metric: "p95_latency", threshold: 500, status: "passing" });
+  };
+
+  const handleBackup = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    recordBackupJob({ projectId: backupDraft.projectId });
+    setBackupDraft({ projectId: "project-123" });
+  };
+
+  const handleDrill = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    recordFailoverDrill({ name: drillDraft.name, status: drillDraft.status });
+    setDrillDraft({ name: "Quarterly failover", status: "pending" });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Performance & resilience</CardTitle>
+        <CardDescription>
+          Track guardrails, automate daily backups, and rehearse multi-region failover drills.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleCreateGuardrail} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Guardrail</Label>
+            <Input
+              value={guardrailDraft.name}
+              onChange={(event) => setGuardrailDraft((prev) => ({ ...prev, name: event.target.value }))}
+              placeholder="API latency"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Metric</Label>
+            <Input
+              value={guardrailDraft.metric}
+              onChange={(event) => setGuardrailDraft((prev) => ({ ...prev, metric: event.target.value }))}
+              placeholder="p95_latency"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Threshold</Label>
+            <Input
+              type="number"
+              value={guardrailDraft.threshold}
+              onChange={(event) => setGuardrailDraft((prev) => ({ ...prev, threshold: Number(event.target.value) }))}
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Status</Label>
+            <Select value={guardrailDraft.status} onValueChange={(value) => setGuardrailDraft((prev) => ({ ...prev, status: value }))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="passing">Passing</SelectItem>
+                <SelectItem value="failing">Failing</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="lg:col-span-12 flex justify-end">
+            <Button type="submit">Save guardrail</Button>
+          </div>
+        </form>
+
+        <div className="space-y-3 text-sm">
+          {performanceGuardrails.length === 0 ? (
+            <p className="text-muted-foreground">No guardrails defined.</p>
+          ) : (
+            performanceGuardrails.map((guardrail) => (
+              <Card key={guardrail.id} className="border-dashed">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <Server className="h-4 w-4" /> {guardrail.name}
+                  </CardTitle>
+                  <CardDescription>
+                    Metric {guardrail.metric} ≤ {guardrail.threshold}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Badge variant={guardrail.status === "passing" ? "secondary" : "destructive"}>{guardrail.status}</Badge>
+                </CardContent>
+              </Card>
+            ))
+          )}
+        </div>
+
+        <form onSubmit={handleBackup} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-4 space-y-2">
+            <Label htmlFor="backup-project">Project ID</Label>
+            <Input
+              id="backup-project"
+              value={backupDraft.projectId}
+              onChange={(event) => setBackupDraft({ projectId: event.target.value })}
+            />
+          </div>
+          <div className="lg:col-span-8 flex items-end justify-end">
+            <Button type="submit">
+              <Database className="h-4 w-4 mr-2" /> Record backup
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-3 text-sm">
+          {backupJobs.length === 0 ? (
+            <p className="text-muted-foreground">Backups will appear here.</p>
+          ) : (
+            backupJobs.map((job) => (
+              <Card key={job.id} className="border-dashed">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">Backup {job.projectId}</CardTitle>
+                  <CardDescription>Requested {new Date(job.requestedAt).toLocaleString()}</CardDescription>
+                </CardHeader>
+              </Card>
+            ))
+          )}
+        </div>
+
+        <form onSubmit={handleDrill} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-4 space-y-2">
+            <Label>Drill name</Label>
+            <Input
+              value={drillDraft.name}
+              onChange={(event) => setDrillDraft((prev) => ({ ...prev, name: event.target.value }))}
+              placeholder="Quarterly failover"
+            />
+          </div>
+          <div className="lg:col-span-4 space-y-2">
+            <Label>Status</Label>
+            <Select value={drillDraft.status} onValueChange={(value) => setDrillDraft((prev) => ({ ...prev, status: value as typeof prev.status }))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="pending">Pending</SelectItem>
+                <SelectItem value="in_progress">In progress</SelectItem>
+                <SelectItem value="completed">Completed</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="lg:col-span-4 flex items-end justify-end">
+            <Button type="submit">
+              <AlertOctagon className="h-4 w-4 mr-2" /> Log drill
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-3 text-sm">
+          {failoverDrills.length === 0 ? (
+            <p className="text-muted-foreground">Log failover rehearsals to build multi-region confidence.</p>
+          ) : (
+            failoverDrills.map((drill) => (
+              <Card key={drill.id} className="border-dashed">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{drill.name}</CardTitle>
+                  <CardDescription>Status {drill.status}</CardDescription>
+                </CardHeader>
+              </Card>
+            ))
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/operations/SavedSearchPanel.tsx
+++ b/src/components/operations/SavedSearchPanel.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { BookmarkCheck, Link as LinkIcon, Share2 } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/hooks/use-toast";
+import { useOperations } from "./OperationsProvider";
+
+export function SavedSearchPanel() {
+  const { savedSearches, saveSearch } = useOperations();
+  const { toast } = useToast();
+  const [searchDraft, setSearchDraft] = useState({
+    name: "",
+    query: "",
+    statuses: "",
+    assignees: "",
+    visibility: "team" as "private" | "team" | "organization",
+  });
+
+  const handleSaveSearch = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!searchDraft.name || !searchDraft.query) {
+      toast({ title: "Missing name or query", variant: "destructive" });
+      return;
+    }
+    const filters: Record<string, unknown> = {};
+    if (searchDraft.statuses) filters.statuses = searchDraft.statuses.split(",").map((value) => value.trim());
+    if (searchDraft.assignees) filters.assignees = searchDraft.assignees.split(",").map((value) => value.trim());
+    const saved = saveSearch({
+      name: searchDraft.name,
+      query: searchDraft.query,
+      filters,
+      visibility: searchDraft.visibility,
+      owner: "operations",
+    });
+    toast({ title: "Search saved", description: `Share link generated for ${saved.name}.` });
+    setSearchDraft({ name: "", query: "", statuses: "", assignees: "", visibility: searchDraft.visibility });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Saved search library</CardTitle>
+        <CardDescription>
+          Store advanced filter combinations and generate shareable links respecting workspace permissions.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleSaveSearch} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-3 space-y-2">
+            <Label htmlFor="saved-search-name">Name</Label>
+            <Input
+              id="saved-search-name"
+              value={searchDraft.name}
+              onChange={(event) => setSearchDraft((prev) => ({ ...prev, name: event.target.value }))}
+              placeholder="Sev1 incidents this week"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label htmlFor="saved-search-query">Query</Label>
+            <Input
+              id="saved-search-query"
+              value={searchDraft.query}
+              onChange={(event) => setSearchDraft((prev) => ({ ...prev, query: event.target.value }))}
+              placeholder="severity:Sev1"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label htmlFor="saved-search-status">Statuses</Label>
+            <Input
+              id="saved-search-status"
+              value={searchDraft.statuses}
+              onChange={(event) => setSearchDraft((prev) => ({ ...prev, statuses: event.target.value }))}
+              placeholder="open, monitoring"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label htmlFor="saved-search-assignee">Assignees</Label>
+            <Input
+              id="saved-search-assignee"
+              value={searchDraft.assignees}
+              onChange={(event) => setSearchDraft((prev) => ({ ...prev, assignees: event.target.value }))}
+              placeholder="alice@example.com"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Visibility</Label>
+            <select
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+              value={searchDraft.visibility}
+              onChange={(event) => setSearchDraft((prev) => ({ ...prev, visibility: event.target.value as typeof prev.visibility }))}
+            >
+              <option value="private">Private</option>
+              <option value="team">Team</option>
+              <option value="organization">Organization</option>
+            </select>
+          </div>
+          <div className="lg:col-span-12 flex justify-end">
+            <Button type="submit">
+              Save search
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-3">
+          {savedSearches.length === 0 && (
+            <div className="text-sm text-muted-foreground border rounded-lg p-6">
+              Save a query to generate a shareable link accessible according to its visibility.
+            </div>
+          )}
+          {savedSearches.map((search) => (
+            <Card key={search.id}>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base flex items-center gap-2">
+                  <BookmarkCheck className="h-4 w-4 text-primary" /> {search.name}
+                </CardTitle>
+                <CardDescription>
+                  {search.visibility.toUpperCase()} visibility • Query: {search.query}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <div className="flex flex-wrap gap-2">
+                  {Object.entries(search.filters).map(([key, value]) => (
+                    <Badge key={key} variant="outline">
+                      {key}: {Array.isArray(value) ? value.join(", ") : String(value)}
+                    </Badge>
+                  ))}
+                </div>
+                <div className="flex items-center justify-between gap-2 text-xs">
+                  <a href={search.sharedUrl} className="flex items-center gap-1 text-primary hover:underline" target="_blank" rel="noreferrer">
+                    <LinkIcon className="h-3 w-3" /> {search.sharedUrl}
+                  </a>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      navigator.clipboard.writeText(search.sharedUrl);
+                      toast({ title: "Link copied", description: "Share the link to reproduce filters instantly." });
+                    }}
+                  >
+                    <Share2 className="h-3 w-3 mr-1" /> Copy link
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/operations/ServiceRegistryPanel.tsx
+++ b/src/components/operations/ServiceRegistryPanel.tsx
@@ -1,0 +1,272 @@
+import { useState } from "react";
+import { BookOpenCheck, ClipboardCheck, Plus, ShieldAlert } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import { Separator } from "@/components/ui/separator";
+import { useOperations } from "./OperationsProvider";
+
+const createId = () => (typeof globalThis.crypto !== 'undefined' && globalThis.crypto.randomUUID ? globalThis.crypto.randomUUID() : Math.random().toString(36).slice(2));
+
+export function ServiceRegistryPanel() {
+  const { services, createService, addServiceRunbook, updateService } = useOperations();
+  const [serviceDraft, setServiceDraft] = useState({
+    name: "",
+    ownerTeam: "",
+    runbookLink: "",
+    tier: "Tier 1" as "Tier 1" | "Tier 2" | "Tier 3",
+    checklist: "",
+  });
+  const [checklistDraft, setChecklistDraft] = useState<Record<string, string>>({});
+  const [runbookDraft, setRunbookDraft] = useState<Record<string, { name: string; link: string }>>({});
+
+  const handleCreateService = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!serviceDraft.name || !serviceDraft.ownerTeam) return;
+    createService({
+      name: serviceDraft.name,
+      ownerTeam: serviceDraft.ownerTeam,
+      runbookLink: serviceDraft.runbookLink,
+      tier: serviceDraft.tier,
+      runbooks: serviceDraft.runbookLink
+        ? [
+            {
+              id: createId(),
+              name: `${serviceDraft.name} default runbook`,
+              link: serviceDraft.runbookLink,
+              type: "link" as const,
+            },
+          ]
+        : [],
+      checklists: serviceDraft.checklist
+        ? serviceDraft.checklist.split("\n").map((item) => ({
+            id: createId(),
+            label: item,
+            completed: false,
+          }))
+        : [],
+    });
+    setServiceDraft({ name: "", ownerTeam: "", runbookLink: "", tier: "Tier 1", checklist: "" });
+  };
+
+  const handleAddRunbook = (serviceId: string) => {
+    const draft = runbookDraft[serviceId];
+    if (!draft?.name || !draft.link) return;
+    addServiceRunbook(serviceId, { name: draft.name, link: draft.link, type: "link" });
+    setRunbookDraft((prev) => ({ ...prev, [serviceId]: { name: "", link: "" } }));
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Service registry & runbooks</CardTitle>
+        <CardDescription>
+          Define ownership, on-call context, and operational readiness for every service consumed by incidents and changes.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleCreateService} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-3 space-y-2">
+            <Label htmlFor="service-name">Service</Label>
+            <Input
+              id="service-name"
+              value={serviceDraft.name}
+              onChange={(event) => setServiceDraft((prev) => ({ ...prev, name: event.target.value }))}
+              placeholder="Payments API"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label htmlFor="service-owner">Owner team</Label>
+            <Input
+              id="service-owner"
+              value={serviceDraft.ownerTeam}
+              onChange={(event) => setServiceDraft((prev) => ({ ...prev, ownerTeam: event.target.value }))}
+              placeholder="Payments Platform"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label htmlFor="service-tier">Tier</Label>
+            <select
+              id="service-tier"
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+              value={serviceDraft.tier}
+              onChange={(event) => setServiceDraft((prev) => ({ ...prev, tier: event.target.value as typeof prev.tier }))}
+            >
+              <option value="Tier 1">Tier 1 - Critical</option>
+              <option value="Tier 2">Tier 2</option>
+              <option value="Tier 3">Tier 3</option>
+            </select>
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label htmlFor="service-runbook">Default runbook</Label>
+            <Input
+              id="service-runbook"
+              value={serviceDraft.runbookLink}
+              onChange={(event) => setServiceDraft((prev) => ({ ...prev, runbookLink: event.target.value }))}
+              placeholder="https://runbooks.example.com/payments"
+            />
+          </div>
+          <div className="lg:col-span-12 space-y-2">
+            <Label htmlFor="service-checklist">Operational checklist</Label>
+            <Textarea
+              id="service-checklist"
+              value={serviceDraft.checklist}
+              onChange={(event) => setServiceDraft((prev) => ({ ...prev, checklist: event.target.value }))}
+              placeholder="Document runbook owner\nEnsure feature flags documented"
+              rows={2}
+            />
+          </div>
+          <div className="lg:col-span-12 flex justify-end">
+            <Button type="submit">
+              <Plus className="mr-2 h-4 w-4" /> Register service
+            </Button>
+          </div>
+        </form>
+
+        <div className="grid gap-4 lg:grid-cols-3">
+          {services.map((service) => (
+            <Card key={service.id} className="border-dashed">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base flex items-center gap-2">
+                  <ShieldAlert className="h-4 w-4 text-primary" /> {service.name}
+                </CardTitle>
+                <CardDescription>
+                  {service.ownerTeam} • {service.tier}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm">
+                <div className="space-y-1">
+                  <p className="text-xs text-muted-foreground">Default runbook</p>
+                  {service.runbookLink ? (
+                    <a
+                      href={service.runbookLink}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-primary hover:underline text-xs"
+                    >
+                      {service.runbookLink}
+                    </a>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">Not provided</span>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <BookOpenCheck className="h-3 w-3" /> Supplemental runbooks
+                  </div>
+                  <div className="space-y-1">
+                    {service.runbooks.length === 0 && (
+                      <p className="text-xs text-muted-foreground">Attach runbooks relevant to this service.</p>
+                    )}
+                    {service.runbooks.map((runbook) => (
+                      <a
+                        key={runbook.id}
+                        href={runbook.link}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-xs text-primary hover:underline"
+                      >
+                        {runbook.name}
+                      </a>
+                    ))}
+                  </div>
+                  <div className="flex gap-2">
+                    <Input
+                      value={runbookDraft[service.id]?.name ?? ""}
+                      onChange={(event) =>
+                        setRunbookDraft((prev) => ({
+                          ...prev,
+                          [service.id]: { name: event.target.value, link: prev[service.id]?.link ?? "" },
+                        }))
+                      }
+                      placeholder="Runbook name"
+                      className="h-8"
+                    />
+                    <Input
+                      value={runbookDraft[service.id]?.link ?? ""}
+                      onChange={(event) =>
+                        setRunbookDraft((prev) => ({
+                          ...prev,
+                          [service.id]: { name: prev[service.id]?.name ?? "", link: event.target.value },
+                        }))
+                      }
+                      placeholder="https://"
+                      className="h-8"
+                    />
+                    <Button type="button" size="sm" onClick={() => handleAddRunbook(service.id)}>
+                      Attach
+                    </Button>
+                  </div>
+                </div>
+
+                <Separator />
+
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <ClipboardCheck className="h-3 w-3" /> Readiness checklist
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {service.checklists.length === 0 && (
+                      <Badge variant="outline">No items configured</Badge>
+                    )}
+                    {service.checklists.map((item) => (
+                      <Badge
+                        key={item.id}
+                        variant={item.completed ? "secondary" : "outline"}
+                        className={item.completed ? "line-through" : ""}
+                      >
+                        {item.label}
+                      </Badge>
+                    ))}
+                  </div>
+                  <div className="flex gap-2">
+                    <Input
+                      value={checklistDraft[service.id] ?? ""}
+                      onChange={(event) =>
+                        setChecklistDraft((prev) => ({ ...prev, [service.id]: event.target.value }))
+                      }
+                      placeholder="Add checklist item"
+                      className="h-8"
+                    />
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={() => {
+                        const label = checklistDraft[service.id];
+                        if (!label) return;
+                        const updated = service.checklists.concat({
+                          id: createId(),
+                          label,
+                          completed: false,
+                        });
+                        updateService(service.id, { checklists: updated });
+                        setChecklistDraft((prev) => ({ ...prev, [service.id]: "" }));
+                      }}
+                    >
+                      Add
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+          {services.length === 0 && (
+            <div className="lg:col-span-3 text-sm text-muted-foreground border rounded-lg p-6">
+              Register services to automatically map incidents and change requests to accountable teams.
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/operations/SlaEscalationPanel.tsx
+++ b/src/components/operations/SlaEscalationPanel.tsx
@@ -1,0 +1,213 @@
+import { useState } from "react";
+import { AlertTriangle, CalendarClock, PauseCircle, PlayCircle } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+import { useOperations, IncidentState } from "./OperationsProvider";
+
+const PAUSEABLE_STATES: IncidentState[] = ["open", "mitigated", "monitoring", "resolved"];
+
+export function SlaEscalationPanel() {
+  const { businessCalendars, saveBusinessCalendar, incidents } = useOperations();
+  const [calendarDraft, setCalendarDraft] = useState({
+    name: "",
+    timezone: "UTC",
+    startHour: 9,
+    endHour: 17,
+    pauseStates: ["monitoring" as IncidentState],
+    nearBreachContacts: "",
+    breachContacts: "",
+  });
+
+  const handleCreateCalendar = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!calendarDraft.name) return;
+    const hours = [1, 2, 3, 4, 5].map((day) => ({ day, start: `${calendarDraft.startHour}:00`, end: `${calendarDraft.endHour}:00` }));
+    saveBusinessCalendar({
+      id: undefined,
+      name: calendarDraft.name,
+      timezone: calendarDraft.timezone,
+      hours,
+      pauseStates: calendarDraft.pauseStates,
+      escalationContacts: {
+        nearBreach: calendarDraft.nearBreachContacts.split(",").map((s) => s.trim()).filter(Boolean),
+        breach: calendarDraft.breachContacts.split(",").map((s) => s.trim()).filter(Boolean),
+      },
+    });
+    setCalendarDraft({ name: "", timezone: "UTC", startHour: 9, endHour: 17, pauseStates: ["monitoring"], nearBreachContacts: "", breachContacts: "" });
+  };
+
+  const escalatedIncidents = incidents.filter((incident) => incident.nearBreachEscalated || incident.breachEscalated);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Business hour calendars & escalations</CardTitle>
+        <CardDescription>
+          Pause SLA timers during approved states and surface near-breach notifications to on-call responders and leads.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleCreateCalendar} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-3 space-y-2">
+            <Label htmlFor="calendar-name">Calendar name</Label>
+            <Input
+              id="calendar-name"
+              value={calendarDraft.name}
+              onChange={(event) => setCalendarDraft((prev) => ({ ...prev, name: event.target.value }))}
+              placeholder="Americas business hours"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label htmlFor="calendar-timezone">Timezone</Label>
+            <Input
+              id="calendar-timezone"
+              value={calendarDraft.timezone}
+              onChange={(event) => setCalendarDraft((prev) => ({ ...prev, timezone: event.target.value }))}
+              placeholder="UTC"
+            />
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label>Start hour</Label>
+            <Input
+              type="number"
+              min={0}
+              max={23}
+              value={calendarDraft.startHour}
+              onChange={(event) => setCalendarDraft((prev) => ({ ...prev, startHour: Number(event.target.value) }))}
+            />
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label>End hour</Label>
+            <Input
+              type="number"
+              min={0}
+              max={23}
+              value={calendarDraft.endHour}
+              onChange={(event) => setCalendarDraft((prev) => ({ ...prev, endHour: Number(event.target.value) }))}
+            />
+          </div>
+          <div className="lg:col-span-6 space-y-2">
+            <Label>Pause SLA when incident is in:</Label>
+            <div className="flex flex-wrap gap-3 text-sm">
+              {PAUSEABLE_STATES.map((state) => {
+                const checked = calendarDraft.pauseStates.includes(state);
+                return (
+                  <label key={state} className="flex items-center gap-2">
+                    <Checkbox
+                      checked={checked}
+                      onCheckedChange={(value) =>
+                        setCalendarDraft((prev) => ({
+                          ...prev,
+                          pauseStates: value === true
+                            ? Array.from(new Set([...prev.pauseStates, state]))
+                            : prev.pauseStates.filter((item) => item !== state),
+                        }))
+                      }
+                    />
+                    <span className="capitalize">{state}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Near-breach contacts</Label>
+            <Input
+              value={calendarDraft.nearBreachContacts}
+              onChange={(event) => setCalendarDraft((prev) => ({ ...prev, nearBreachContacts: event.target.value }))}
+              placeholder="oncall@example.com, lead@example.com"
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Breach escalation</Label>
+            <Input
+              value={calendarDraft.breachContacts}
+              onChange={(event) => setCalendarDraft((prev) => ({ ...prev, breachContacts: event.target.value }))}
+              placeholder="director@example.com"
+            />
+          </div>
+          <div className="lg:col-span-12 flex justify-end">
+            <Button type="submit">Save calendar</Button>
+          </div>
+        </form>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          {businessCalendars.map((calendar) => (
+            <Card key={calendar.id} className="border-dashed">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base flex items-center gap-2">
+                  <CalendarClock className="h-4 w-4 text-primary" /> {calendar.name}
+                </CardTitle>
+                <CardDescription>
+                  {calendar.timezone} • Pauses {calendar.pauseStates.join(", ")}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2 text-xs">
+                <div>Working hours:</div>
+                <div className="flex flex-wrap gap-2">
+                  {calendar.hours.map((hour) => (
+                    <Badge key={`${calendar.id}-${hour.day}-${hour.start}`} variant="outline">
+                      Day {hour.day}: {hour.start} - {hour.end}
+                    </Badge>
+                  ))}
+                </div>
+                <div className="text-muted-foreground">
+                  Near breach → {calendar.escalationContacts.nearBreach.join(", ") || "None"}
+                </div>
+                <div className="text-muted-foreground">
+                  Breach → {calendar.escalationContacts.breach.join(", ") || "None"}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+          {businessCalendars.length === 0 && (
+            <div className="col-span-2 text-sm text-muted-foreground border rounded-lg p-6">
+              Define calendars to align SLA expectations to local business hours.
+            </div>
+          )}
+        </div>
+
+        <div className="border rounded-lg p-4 space-y-3">
+          <h4 className="font-semibold flex items-center gap-2 text-sm">
+            <AlertTriangle className="h-4 w-4" /> Active escalations
+          </h4>
+          <div className="space-y-2 text-sm">
+            {escalatedIncidents.length === 0 && <p className="text-muted-foreground">All incidents are within SLA.</p>}
+            {escalatedIncidents.map((incident) => (
+              <div key={incident.id} className="flex flex-wrap items-center justify-between gap-2 rounded-md border p-3">
+                <div>
+                  <div className="font-medium">{incident.title}</div>
+                  <div className="text-xs text-muted-foreground">
+                    Severity {incident.severity} • SLA due {new Date(incident.slaDueAt).toLocaleString()}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {incident.nearBreachEscalated && !incident.breachEscalated && (
+                    <Badge variant="secondary" className="flex items-center gap-1">
+                      <PauseCircle className="h-3 w-3" /> Near breach
+                    </Badge>
+                  )}
+                  {incident.breachEscalated && (
+                    <Badge variant="destructive" className="flex items-center gap-1">
+                      <PlayCircle className="h-3 w-3" /> Breached
+                    </Badge>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/operations/SloDashboardPanel.tsx
+++ b/src/components/operations/SloDashboardPanel.tsx
@@ -1,0 +1,131 @@
+import { useState } from "react";
+import { Activity, LineChart } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { useOperations } from "./OperationsProvider";
+
+export function SloDashboardPanel() {
+  const { sloDefinitions, recordSlo } = useOperations();
+  const [sloDraft, setSloDraft] = useState({
+    name: "API availability",
+    indicator: "availability" as "availability" | "latency" | "error_rate",
+    target: 99.9,
+    burnRate: 1.0,
+    incidents: "",
+  });
+
+  const handleCreateSlo = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    recordSlo({
+      name: sloDraft.name,
+      indicator: sloDraft.indicator,
+      target: sloDraft.target,
+      burnRate: sloDraft.burnRate,
+      linkedIncidents: sloDraft.incidents.split(",").map((id) => id.trim()).filter(Boolean),
+    });
+    setSloDraft({ name: "API availability", indicator: sloDraft.indicator, target: sloDraft.target, burnRate: sloDraft.burnRate, incidents: "" });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>SLO dashboard</CardTitle>
+        <CardDescription>
+          Track service-level objectives, burn rates, and related incidents.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleCreateSlo} className="grid gap-4 lg:grid-cols-12 border rounded-lg p-4">
+          <div className="lg:col-span-4 space-y-2">
+            <Label>SLO name</Label>
+            <Input
+              value={sloDraft.name}
+              onChange={(event) => setSloDraft((prev) => ({ ...prev, name: event.target.value }))}
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Indicator</Label>
+            <Select value={sloDraft.indicator} onValueChange={(value) => setSloDraft((prev) => ({ ...prev, indicator: value as typeof prev.indicator }))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="availability">Availability</SelectItem>
+                <SelectItem value="latency">Latency</SelectItem>
+                <SelectItem value="error_rate">Error rate</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="lg:col-span-2 space-y-2">
+            <Label>Target %</Label>
+            <Input
+              type="number"
+              value={sloDraft.target}
+              onChange={(event) => setSloDraft((prev) => ({ ...prev, target: Number(event.target.value) }))}
+            />
+          </div>
+          <div className="lg:col-span-3 space-y-2">
+            <Label>Burn rate</Label>
+            <Input
+              type="number"
+              step="0.1"
+              value={sloDraft.burnRate}
+              onChange={(event) => setSloDraft((prev) => ({ ...prev, burnRate: Number(event.target.value) }))}
+            />
+          </div>
+          <div className="lg:col-span-12 space-y-2">
+            <Label>Linked incidents</Label>
+            <Input
+              value={sloDraft.incidents}
+              onChange={(event) => setSloDraft((prev) => ({ ...prev, incidents: event.target.value }))}
+              placeholder="INC-1, INC-2"
+            />
+          </div>
+          <div className="lg:col-span-12 flex justify-end">
+            <Button type="submit">
+              <LineChart className="h-4 w-4 mr-2" /> Save SLO
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-2 text-sm">
+          {sloDefinitions.length === 0 ? (
+            <p className="text-muted-foreground">No SLOs defined yet.</p>
+          ) : (
+            sloDefinitions.map((slo) => (
+              <Card key={slo.id} className="border-dashed">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <Activity className="h-4 w-4" /> {slo.name}
+                  </CardTitle>
+                  <CardDescription>
+                    {slo.indicator} • Target {slo.target}% • Burn {slo.burnRate ?? 1}x
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-wrap gap-2">
+                  {slo.linkedIncidents.length === 0 ? (
+                    <Badge variant="outline">No incidents</Badge>
+                  ) : (
+                    slo.linkedIncidents.map((incident) => (
+                      <Badge key={incident} variant="outline">{incident}</Badge>
+                    ))
+                  )}
+                </CardContent>
+              </Card>
+            ))
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/OperationsCenter.tsx
+++ b/src/pages/OperationsCenter.tsx
@@ -1,0 +1,65 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { IncidentManagementPanel } from "@/components/operations/IncidentManagementPanel";
+import { OnCallRotationPanel } from "@/components/operations/OnCallRotationPanel";
+import { ChangeManagementPanel } from "@/components/operations/ChangeManagementPanel";
+import { ServiceRegistryPanel } from "@/components/operations/ServiceRegistryPanel";
+import { DependencyImpactPanel } from "@/components/operations/DependencyImpactPanel";
+import { SlaEscalationPanel } from "@/components/operations/SlaEscalationPanel";
+import { SavedSearchPanel } from "@/components/operations/SavedSearchPanel";
+import { OpsDashboardPanel } from "@/components/operations/OpsDashboardPanel";
+import { DocsWorkspacePanel } from "@/components/operations/DocsWorkspacePanel";
+import { PortfolioOkrsPanel } from "@/components/operations/PortfolioOkrsPanel";
+import { ImportExportPanel } from "@/components/operations/ImportExportPanel";
+import { ExecutiveReportingPanel } from "@/components/operations/ExecutiveReportingPanel";
+import { ResiliencePerformancePanel } from "@/components/operations/ResiliencePerformancePanel";
+import { MobileOfflinePanel } from "@/components/operations/MobileOfflinePanel";
+import { AdminGovernancePanel } from "@/components/operations/AdminGovernancePanel";
+import { SloDashboardPanel } from "@/components/operations/SloDashboardPanel";
+
+export default function OperationsCenter() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Operations control center</h1>
+        <p className="text-muted-foreground">
+          Coordinate incident response, change enablement, service ownership, and executive reporting in a single workspace.
+        </p>
+      </div>
+
+      <Tabs defaultValue="phase4" className="space-y-6">
+        <TabsList>
+          <TabsTrigger value="phase4">Phase 4 • Incident & Change</TabsTrigger>
+          <TabsTrigger value="phase5">Phase 5 • Portfolio & Docs</TabsTrigger>
+          <TabsTrigger value="phase6">Phase 6 • Resilience & Governance</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="phase4" className="space-y-6">
+          <IncidentManagementPanel />
+          <div className="grid gap-6 lg:grid-cols-2">
+            <OnCallRotationPanel />
+            <SlaEscalationPanel />
+          </div>
+          <ChangeManagementPanel />
+          <ServiceRegistryPanel />
+          <DependencyImpactPanel />
+          <SavedSearchPanel />
+          <OpsDashboardPanel />
+        </TabsContent>
+
+        <TabsContent value="phase5" className="space-y-6">
+          <DocsWorkspacePanel />
+          <PortfolioOkrsPanel />
+          <ImportExportPanel />
+          <ExecutiveReportingPanel />
+        </TabsContent>
+
+        <TabsContent value="phase6" className="space-y-6">
+          <ResiliencePerformancePanel />
+          <MobileOfflinePanel />
+          <AdminGovernancePanel />
+          <SloDashboardPanel />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an OperationsProvider context that models incidents, on-call paging, changes, services, dependencies, SLAs, saved searches, docs, portfolio, imports/exports, executive reporting, resilience, governance, and SLOs
- build dedicated panels for the Phase 4–6 workflows (incidents, on-call, change, service registry, dependency impact, SLA calendars, saved search sharing, ops dashboard, docs workspace, portfolio/OKRs, import/export, executive digest/reporting, resilience/performance, mobile/offline, admin governance, SLO dashboards)
- expose a new Operations Center page with Phase 4/5/6 tabs, wrap the app in the provider, and surface the route via the sidebar navigation

## Testing
- npm run type-check
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce688b3b60832799ec98dd324933cc