### PR TITLE
Fix Supabase client storage initialization for SSR

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -3,15 +3,18 @@ import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
 const SUPABASE_URL = "https://aoubfejqyifdefyrbjip.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFvdWJmZWpxeWlmZGVmeXJiamlwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTMwMzcyNTAsImV4cCI6MjA2ODYxMzI1MH0.iUe1T28-T_vT1rUzXOpWTFrv6DRAN9Zwt24ligHdCaM";
+const SUPABASE_PUBLISHABLE_KEY =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFvdWJmZWpxeWlmZGVmeXJiaWlwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTMwMzcyNTAsImV4cCI6MjA2ODYxMzI1MH0.iUe1T28-T_vT1rUzXOpWTFrv6DRAN9Zwt24ligHdCaM";
+
+const storage = typeof localStorage === "undefined" ? undefined : localStorage;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
 export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
   auth: {
-    storage: localStorage,
-    persistSession: true,
-    autoRefreshToken: true,
-  }
+    storage,
+    persistSession: Boolean(storage),
+    autoRefreshToken: Boolean(storage),
+  },
 });


### PR DESCRIPTION
## Summary
- guard the Supabase client against non-browser environments by safely resolving localStorage
- only persist Supabase sessions when browser storage is available to avoid SSR and build-time crashes

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce7cdd23e08327b0553fe99c1d62e0