### PR TITLE
Support multiple Supabase env keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 # Supabase configuration
+# The app will read the first value it finds from the following variables:
+# URL: VITE_SUPABASE_URL, SUPABASE_URL, NEXT_PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_URL
+# Key: VITE_SUPABASE_ANON_KEY, SUPABASE_ANON_KEY, SUPABASE_KEY, NEXT_PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_ANON_KEY
 VITE_SUPABASE_URL="https://your-project-ref.supabase.co"
 VITE_SUPABASE_ANON_KEY="your-public-anon-key"
 VITE_SUPABASE_PROJECT_ID="your-project-ref"

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,7 +2,16 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-type SupabaseEnvKey = "VITE_SUPABASE_URL" | "VITE_SUPABASE_ANON_KEY";
+type SupabaseEnvKey =
+  | "VITE_SUPABASE_URL"
+  | "VITE_SUPABASE_ANON_KEY"
+  | "SUPABASE_URL"
+  | "SUPABASE_ANON_KEY"
+  | "SUPABASE_KEY"
+  | "NEXT_PUBLIC_SUPABASE_URL"
+  | "NEXT_PUBLIC_SUPABASE_ANON_KEY"
+  | "PUBLIC_SUPABASE_URL"
+  | "PUBLIC_SUPABASE_ANON_KEY";
 
 const getImportMetaEnv = () => {
   try {
@@ -18,20 +27,39 @@ const processEnv =
     ? (process.env as Record<SupabaseEnvKey, string | undefined>)
     : undefined;
 
-const SUPABASE_URL =
-  processEnv?.VITE_SUPABASE_URL ?? importMetaEnv?.VITE_SUPABASE_URL;
-const SUPABASE_ANON_KEY =
-  processEnv?.VITE_SUPABASE_ANON_KEY ?? importMetaEnv?.VITE_SUPABASE_ANON_KEY;
+const getEnvValue = (...keys: SupabaseEnvKey[]) => {
+  for (const key of keys) {
+    const value = importMetaEnv?.[key] ?? processEnv?.[key];
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const SUPABASE_URL = getEnvValue(
+  "VITE_SUPABASE_URL",
+  "SUPABASE_URL",
+  "NEXT_PUBLIC_SUPABASE_URL",
+  "PUBLIC_SUPABASE_URL"
+);
+const SUPABASE_ANON_KEY = getEnvValue(
+  "VITE_SUPABASE_ANON_KEY",
+  "SUPABASE_ANON_KEY",
+  "SUPABASE_KEY",
+  "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+  "PUBLIC_SUPABASE_ANON_KEY"
+);
 
 if (!SUPABASE_URL) {
   throw new Error(
-    "Missing Supabase URL. Please set the VITE_SUPABASE_URL environment variable."
+    "Missing Supabase URL. Please set one of VITE_SUPABASE_URL, SUPABASE_URL, NEXT_PUBLIC_SUPABASE_URL, or PUBLIC_SUPABASE_URL."
   );
 }
 
 if (!SUPABASE_ANON_KEY) {
   throw new Error(
-    "Missing Supabase anon key. Please set the VITE_SUPABASE_ANON_KEY environment variable."
+    "Missing Supabase anon key. Please set one of VITE_SUPABASE_ANON_KEY, SUPABASE_ANON_KEY, SUPABASE_KEY, NEXT_PUBLIC_SUPABASE_ANON_KEY, or PUBLIC_SUPABASE_ANON_KEY."
   );
 }
 


### PR DESCRIPTION
## Summary
- allow the Supabase client to read additional environment variable names commonly used in deployment environments
- update the example environment file to document the supported Supabase URL and key variables

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cec40f5cd48327a14d594bcf88359f