### PR TITLE
Implement marketing and release workflows

### DIFF
--- a/scripts/generateEnterpriseBacklog.mjs
+++ b/scripts/generateEnterpriseBacklog.mjs
@@ -1,0 +1,220 @@
+import fs from "node:fs";
+
+const rawData = `Phase,ID,Title,Description,Acceptance Criteria,Team,Priority
+Phase 2,OP-MKT-001,Marketing Workflow States,"As a Marketing user, I want a workflow from Intake → Plan → Copy Draft → Asset Production → Channel Build → QA → Scheduled → Live → Wrap so I can manage campaigns end-to-end.","States are available in sequence; Invalid transitions are blocked; QA requires at least one Marketing Lead approval.",Marketing,P1
+Phase 2,OP-MKT-002,Link Campaigns to Design Assets,"As a Marketing user, I want to link my campaign to Design assets so I can ensure creative is finalized before scheduling.","Scheduled requires at least one linked Design asset when asset-dependent; Block transition to Scheduled if no linked asset.",Marketing,P1
+Phase 2,OP-MKT-003,Block Scheduling on Release Readiness,"As a Marketing user, I want scheduling to be blocked until the Software Release is Released so go-lives don't misfire.","Transition to Scheduled is blocked when linked Release ≠ Released; Unblock automatically once Release=Released.",Marketing,P1
+Phase 2,OP-MKT-004,Campaign Wrap Metrics,"As a Marketing user, I want to complete campaigns with a Wrap state including metrics so performance is recorded.","Wrap requires Performance Summary (text) and Metrics Link (URL); On Wrap, optional digest can be sent.",Marketing,P2
+Phase 2,OP-OPS-001,Operations Workflow States,"As an Operations user, I want a workflow Submitted → Triage → Approved → In Progress → Waiting on Vendor → QA/Validation → Done to run Ops tasks.","Triage requires SLA classification (P1–P4); Approved requires named approver; Done requires QA/Validation checked.",Operations,P1
+Phase 2,OP-OPS-002,Change Request Fields & Gate,"As an Operations user, I want Change Requests with risk, impact, and backout plan so high-risk work is controlled.","Cannot move to Approved unless Risk, Impact, Backout Plan are filled; Approver and timestamp recorded.",Operations,P1
+Phase 2,OP-OPS-003,Vendor Dependency Handling,"As an Operations user, I want to record vendor info and SLA when waiting externally so we can escalate properly.","Waiting on Vendor requires Vendor Name, Contact, SLA Target; Escalation timer visible and counts down.",Operations,P2
+Phase 2,OP-HAND-003,Design→Marketing Handoff,"As a Designer, I want moving to Packaged to create a Marketing item in Assets Received so marketing can start.","On status=Packaged, create Marketing item with mapped fields + attachments; Notify Marketing Lead in-app and email.",Design,P1
+Phase 2,OP-HAND-004,Software→Marketing Handoff,"As an Engineer, I want Ready to Release to auto-create Marketing Launch Prep so launch tasks begin on time.","On status=Ready to Release, create Marketing item with release notes; Marketing item blocked until Release=Released.",Engineering,P1
+Phase 2,OP-HAND-005,Marketing→Ops Handoff,"As a Marketing user, I want moving to Scheduled to create Ops go-live tasks so operations can execute cutover.","On status=Scheduled, create Ops item with Go-Live Date + Systems list; Link back to campaign; Notify Ops channel.",Marketing,P1
+Phase 2,OP-SLACK-001,Slack DMs for Mentions/Assignments/Approvals,"As a user, I want Slack DMs for key events so I can act quickly without email.","DM includes item title/ID/status/due date; Buttons: Open/Approve/Snooze; Respects notification preferences.",Platform,P1
+Phase 2,OP-SLACK-002,Slack Link Unfurls,"As a user, I want OutPaged links to unfurl in Slack so I can see context at a glance.","Unfurl shows title/ID/status/assignee/due date; If viewer lacks permission, show Restricted.",Platform,P1
+Phase 2,OP-SLACK-003,Project→Slack Channel Notifications,"As a Project Lead, I want to configure Slack channel notifications for project events so the team stays aligned.","Configurable events: new items, releases, status changes, SLA breaches; Posts to chosen channel; Audit of deliveries.",Platform,P2
+Phase 2,OP-BACK-001,Backlog View with Ranking,"As a user, I want a Backlog list to drag-rank items so prioritization is explicit.","Drag reorder persists project rank; Rank changes recorded in item history.",Frontend,P1
+Phase 2,OP-SPRINT-001,Create Sprint & Commit Items,"As a Project Lead, I want to create a sprint window and commit items so the team has a plan.","Sprint has start/end dates; Commitment line visible; Mid-sprint added/removed items flagged in scope-change log.",Frontend,P1
+Phase 2,OP-SPRINT-002,Sprint Board with Swimlanes,"As a team member, I want a sprint board with swimlanes so work is organized by Epic or Assignee.","Swimlanes by Epic/Assignee; Dragging cards updates status; Board respects WIP limits.",Frontend,P1
+Phase 2,OP-RM-001,Roadmap by Quarter,"As Leadership, I want a quarterly roadmap so I can see initiatives and key milestones.","Swimlanes=Initiatives; Bars colored by health (Green/Amber/Red); Milestones as diamonds with dates.",Frontend,P2
+Phase 2,OP-RM-002,Roadmap Filters & Saved Views,"As Leadership, I want to filter Roadmap by Team/Quarter/Health and save views so I can share perspectives.","Filters persist in URL; Saved views shareable; Permission-aware.",Frontend,P2
+Phase 2,OP-RM-003,Roadmap Dependencies,"As Leadership, I want to see dependency lines so I understand schedule risk.","Dependency lines in Orange; Hover tooltip shows impact statement (e.g., slip of 7 days impacts X).",Frontend,P2
+Phase 3,OP-EST-001,Enable Story Points & Time Estimates,"As a Project Lead, I want items to support points and time so we can plan capacity.","Items accept Story Points (number) and Time Estimate (hours); Fields appear in Table/Board/Backlog; Editable inline.",Frontend,P1
+Phase 3,OP-EST-002,Team Capacity per Sprint,"As a Project Lead, I want to set team capacity so sprint commitments are realistic.","Capacity configurable per sprint and per person; Warning when commitment exceeds capacity.",Frontend,P1
+Phase 3,OP-EST-003,Velocity Calculation & Forecast,"As a Project Lead, I want past velocity and a forecast so I can plan future sprints.","Velocity chart over last 3–6 sprints; Forecast band for next sprint; Uses completed points only.",Frontend,P1
+Phase 3,OP-REL-001,Release Entity & Versions,"As an Engineer, I want Releases with versions so we can track cutlines.","Create Release with semantic version; Link items; Release state (Planning/Ready/Released).",Backend,P1
+Phase 3,OP-REL-002,Release Readiness Checklist,"As a Release Manager, I want a readiness checklist so release quality is consistent.","Checklist template per project; Must pass before marking Released; Missing items block transition.",Backend,P1
+Phase 3,OP-REL-003,Auto-Generate Release Notes,"As a PM, I want release notes compiled from items so communication is easy.","Release notes page compiles item titles/summaries by type; Export to Markdown; Editable pre-publish.",Frontend,P2
+Phase 3,OP-GANTT-001,Timeline/Gantt View,"As a Planner, I want a timeline with dependencies and baselines so I can manage schedules.","Drag tasks to adjust dates; Dependencies create critical path; Baseline vs Actual shows drift.",Frontend,P1
+Phase 3,OP-GANTT-002,Date Constraints & Auto-Shift,"As a Planner, I want dependent tasks to auto-shift so changes propagate safely.","Shifting a predecessor moves successors by the same delta; Conflicts flagged with warnings.",Frontend,P2
+Phase 3,OP-WORK-001,Workload Heatmap,"As a Manager, I want a workload heatmap so I can balance assignments.","Heatmap by person/team; Highlights over/under capacity; Filters by type/team/date range.",Frontend,P1
+Phase 3,OP-NOTIF-001,SLA Alerts (Ops),"As Operations, I want SLA breach alerts so we can respond quickly.","Start/Pause rules by state; Imminent breach and breach events trigger notifications; Escalation policy configurable.",Operations,P1
+Phase 3,OP-NOTIF-002,Scheduled Digests,"As a Leader, I want scheduled digests so I stay informed without noise.","Daily/Weekly digests by team/project; Email and Slack channel delivery; Only include items user has access to.",Platform,P2
+Phase 3,OP-SEARCH-001,Advanced Query Builder,"As a power user, I want an advanced search builder so I can slice data precisely.","AND/OR groups; Field operators; Save and share queries; Results linkable.",Frontend,P2
+Phase 3,OP-REPORT-001,Agile Reports Pack,"As a PM, I want burndown/burnup/CSD/CFD/velocity so we can inspect and adapt.","Burndown and burnup for current sprint; Cumulative Flow Diagram; Control Chart or Aging WIP; Export PNG/CSV.",Frontend,P2
+Phase 3,OP-ADMIN-001,Notification Preference Policy Overrides,"As an Admin, I want to set org/project overrides so critical alerts always deliver.","Org/project critical categories bypass quiet hours; Audit of overrides; User UI shows enforced settings.",Admin,P2
+Phase 3,OP-SEC-001,Data Retention & Export Controls,"As an Admin, I want retention policies and export controls so we meet compliance.","Per-project retention (e.g., 365 days) with scheduled purge; Export permission gated; Audit log of exports.",Admin,P2
+Phase 4,OP-INC-001,Incident Entity & Severity Ladder,"As Operations, I want incidents with severities (Sev1–Sev4) so we can classify and route response.","Create Incident with title/desc/severity/affected services; Default SLA by severity applied; Incident states: Open → Mitigated → Monitoring → Resolved.",Operations,P1
+Phase 4,OP-INC-002,On-Call Rotation & Paging,"As Operations, I want on-call schedules and paging so Sev1 alerts reach the right engineer.","Admin can define rotations and time windows; Sev1 creates page to active on-call; Audit log shows who was paged and when.",Operations,P1
+Phase 4,OP-INC-003,Incident Workspace (War Room),"As Operations, I want an incident workspace so cross-team collaboration is organized.","On incident Open: create workspace with timeline, tasks, links; Add responders; All actions timestamped in incident timeline.",Operations,P1
+Phase 4,OP-INC-004,Postmortem Template & Actions,"As Operations, I want a postmortem template to capture learnings and action items.","On Resolved: prompt to create Postmortem doc; Required fields: impact, root cause, corrective actions; Action items auto-created and linked.",Operations,P1
+Phase 4,OP-CHG-001,Change Request Workflow,"As Operations, I want a change workflow (Draft → Review → Approved → Implementing → Validated → Done) with gates.","Risk, Impact, Backout Plan required before Approved; Named approver recorded; Implementing blocked without approved state.",Operations,P1
+Phase 4,OP-CHG-002,Change Calendar & Freeze Windows,"As Operations, I want a change calendar and freeze windows to avoid risky deployments.","Calendar shows scheduled changes; Freeze windows block Approved→Implementing unless override by Admin; Conflicts flagged.",Operations,P2
+Phase 4,OP-SRV-001,Service Registry & Ownership,"As a Platform Lead, I want a service catalog with owners so incidents map to responsible teams.","Create Service with name, team owner, runbook link, tier; Items can link to Services; Ownership appears on incidents and changes.",Platform,P1
+Phase 4,OP-SRV-002,Runbooks & Checklists,"As Engineers, we want runbooks attached to services/incidents for faster resolution.","Attach runbooks (links/files) to Services; Incident shows relevant runbooks; Checklists can be marked complete and logged.",Platform,P2
+Phase 4,OP-DEP-001,Dependency Graph View,"As a Planner, I want a dependency graph so I can see cross-item dependencies visually.","Graph nodes = items/epics, edges = depends-on; Zoom, pan, filter by team/status; Clickthrough opens item.",Frontend,P1
+Phase 4,OP-DEP-002,Impact Analysis (“What Breaks If This Slips”),"As a PM, I want to know downstream impact when a dependency slips.","Adjusting a date shows impacted items and delay estimate; Critical paths highlighted; Export impact list (CSV).",Frontend,P2
+Phase 4,OP-SLA-001,Business Hour Calendars & Escalations,"As Operations, I want SLA timers that respect business hours and escalate on breach.","Define business calendars; SLA pauses on specified states; Near-breach and breach escalate via notifications to on-call and leads.",Operations,P1
+Phase 4,OP-SEARCH-002,Saved Searches & Sharing,"As a power user, I want to save and share advanced queries.","Save query with name/visibility; Share link reproduces filters; Permission-aware visibility.",Frontend,P2
+Phase 4,OP-OPS-004,Ops Dashboard,"As Leadership, I want an Ops dashboard for MTTA/MTTR, SLA trends, change success rate.","Widgets show MTTA, MTTR, SLA compliance %, change failure rate; Time range filters; Export PNG/CSV.",Frontend,P2
+Phase 5,OP-DOC-001,Docs Editor with Templates,"As a PM, I want a docs editor with PRD/RFC templates so specs live with work.","Create doc with rich text, headings, tables; Start from PRD/RFC templates; Autosave; Permission-aware sharing.",Frontend,P1
+Phase 5,OP-DOC-002,Status Chips & Field Bindings in Docs,"As a PM, I want live item chips and bound fields inside docs.","Insert item chip showing ID/status/assignee; Bind fields (e.g., due date) to items; Chips update live when items change.",Frontend,P1
+Phase 5,OP-DOC-003,Doc Change Tracking & Approvals,"As a Lead, I want tracked changes and approvals on docs.","Track insert/delete with author and timestamp; Request approval from reviewers; Doc cannot be marked Final without required approvals.",Frontend,P1
+Phase 5,OP-PORT-001,Portfolio Dashboard & Initiative Health,"As Leadership, I want a portfolio view to track initiative health and progress.","Initiatives with health (G/A/R), progress %, budget vs plan (optional); Drill-down to epics; Save/share views.",Frontend,P1
+Phase 5,OP-PORT-002,Dependency Risk Heatmap,"As Leadership, I want a heatmap of cross-team dependency risk.","Grid by team x team shows count/severity of blocking dependencies; Click reveals list; Export CSV.",Frontend,P2
+Phase 5,OP-OKR-001,OKRs Linked to Work,"As Leadership, I want OKRs connected to initiatives and items.","Create Objectives and KRs; Link KRs to epics/items; Rollup progress to Objective; Quarterly view and check-ins.",Frontend,P2
+Phase 5,OP-IMP-001,CSV Importer Wizard,"As an Admin, I want to import items from CSV with mapping and validation.","Upload CSV; Map columns to fields; Validate and preview; Import in batches with error report.",Admin,P1
+Phase 5,OP-IMP-002,Jira Import (Projects/Issues/Sprints),"As an Admin, I want to import from Jira to accelerate migration.","OAuth/API or CSV; Map issue types/fields/statuses; Preserve comments/attachments when possible; Dry-run preview.",Admin,P1
+Phase 5,OP-IMP-003,Monday Import (Boards/Groups/Items),"As an Admin, I want to import from Monday boards into projects.","API token; Map columns to fields; Convert groups to statuses or tags; Preview before import.",Admin,P2
+Phase 5,OP-EXP-001,Exports & API Tokens,"As a Data Analyst, I want CSV/JSON exports and personal API tokens.","Export current view to CSV/JSON; Create/revoke API tokens; All exports audited.",Platform,P1
+Phase 5,OP-DIG-001,Executive Digest v2 (Email/Slack),"As Leadership, I want weekly executive digests with key deltas and risks.","Schedule digest by portfolio/team; Include top risks, slips, releases; Delivered to email and Slack channel; Permission-aware.",Platform,P2
+Phase 5,OP-REP-001,Portfolio Reports Pack,"As Leadership, I want printable/exportable portfolio reports.","Generate PDF/PNG for roadmap snapshot, initiative status, dependency risk; Time-stamped and shareable.",Frontend,P2
+Phase 6,OP-PERF-001,10k+ Item Performance Hardening,"As a user, I want smooth lists and filters even with 10k+ items.","Virtualized lists; Indexed queries; Sub-second filter on common fields; Performance budget CI checks.",Platform,P1
+Phase 6,OP-PERF-002,Query Caching & N+1 Guardrails,"As a Platform engineer, I want caching and safeguards to avoid N+1 and slow queries.","Add server-side caching on heavy endpoints; Query analyzer warnings in CI; Telemetry for slow queries.",Platform,P2
+Phase 6,OP-BCK-001,Daily Backups & Project-Level PITR,"As an Admin, I want backups and point-in-time restore for a single project.","Automated daily backups; Request restore of a project to timestamp T; Admin UI to initiate restore; Audit of restores.",Admin,P1
+Phase 6,OP-REL-004,Multi-Region Readiness,"As an Admin, I want failover readiness to improve resilience.","Health checks; Replication strategy documented/validated; Runbook for failover drill; Status banner during failover.",Admin,P2
+Phase 6,OP-MOB-001,Mobile Apps v1 (iOS/Android) Sign-In & Inbox,"As a user, I want to sign in on mobile and see my notifications/inbox.","Google SSO; Notification list with deep links; Mark read; Push enabled via provider.",Mobile,P1
+Phase 6,OP-MOB-002,Quick Approvals & Comments (Mobile),"As a user, I want to approve and comment from my phone.","Approve/Reject on approvals; Comment composer with mentions; Offline queue for pending actions.",Mobile,P1
+Phase 6,OP-OFF-001,Offline Create & Comment (Web/Mobile),"As a user, I want to create items and comment offline and have them sync later.","Local queue persists across reload; Automatic retry on reconnect; Conflict resolution prompts.",Platform,P2
+Phase 6,OP-ADM-001,Sandbox & Config Promotion,"As an Admin, I want a sandbox and promotion pipeline for workflows/templates.","Create sandbox env; Edit workflows/templates; Promote to prod with diff/approval; Version history retained.",Admin,P1
+Phase 6,OP-TEMP-001,Template Governance & Versioning,"As a PMO, I want template versioning and publishing approvals.","Templates have versions, changelog, owners; Publishing requires approval; Projects can pin to specific version.",Admin,P2
+Phase 6,OP-SCIM-001,SCIM Provisioning & Deprovisioning,"As an Admin, I want automated user lifecycle with our IdP.","SCIM integration to create/update/deprovision users and teams; Deprovision revokes sessions within 1 minute.",Admin,P2
+Phase 6,OP-ANA-001,Operational Metrics & SLO Dashboard,"As Engineering, I want SLO dashboards for API/UI health.","Define SLOs (availability/latency/error rate); Display burn-rate alerts; Export incidents linked to SLO breaches.",Platform,P2`;
+
+function parseCsv(text) {
+  const rows = [];
+  let current = [];
+  let value = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+
+    if (char === "\r") {
+      continue;
+    }
+
+    if (char === '"') {
+      const nextChar = text[i + 1];
+      if (inQuotes && nextChar === '"') {
+        value += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === "," && !inQuotes) {
+      current.push(value);
+      value = "";
+      continue;
+    }
+
+    if (char === "\n" && !inQuotes) {
+      current.push(value);
+      rows.push(current);
+      current = [];
+      value = "";
+      continue;
+    }
+
+    value += char;
+  }
+
+  if (value.length > 0 || current.length > 0) {
+    current.push(value);
+    rows.push(current);
+  }
+
+  return rows;
+}
+
+const rows = parseCsv(rawData);
+const headers = rows[0];
+const records = rows
+  .slice(1)
+  .filter((row) => row.length === headers.length && row[1] && row[1] !== "ID")
+  .map((row) => Object.fromEntries(headers.map((header, index) => [header, row[index]])));
+
+const priorityMap = {
+  P1: {
+    priority: "urgent",
+    storyPoints: 8,
+    businessValue: 9,
+    effort: 8,
+  },
+  P2: {
+    priority: "high",
+    storyPoints: 5,
+    businessValue: 7,
+    effort: 6,
+  },
+};
+
+function formatDate(index) {
+  const baseDate = new Date("2024-05-01T00:00:00Z");
+  const date = new Date(baseDate.getTime());
+  date.setDate(baseDate.getDate() + index);
+  return date.toISOString().split("T")[0];
+}
+
+const backlogItems = records.map((record, index) => {
+  const phaseTag = record["Phase"].trim();
+  const teamTag = record.Team.trim();
+  const priorityConfig = priorityMap[record.Priority] ?? priorityMap.P2;
+
+  const acceptanceCriteria = record["Acceptance Criteria"]
+    .split(";")
+    .map((criterion) => criterion.trim())
+    .filter(Boolean);
+
+  return {
+    id: record.ID,
+    title: record.Title,
+    description: record.Description,
+    status: "ready",
+    priority: priorityConfig.priority,
+    storyPoints: priorityConfig.storyPoints,
+    tags: [phaseTag, `Team: ${teamTag}`, `Priority: ${record.Priority}`],
+    acceptanceCriteria,
+    businessValue: priorityConfig.businessValue,
+    effort: priorityConfig.effort,
+    createdAt: formatDate(index),
+    sprintId: phaseTag.toLowerCase().replace(/\s+/g, "-"),
+  };
+});
+
+function formatBacklog(items) {
+  const lines = items.map((item) => {
+    const acceptanceLines = item.acceptanceCriteria
+      .map((criterion) => `      ${JSON.stringify(criterion)}`)
+      .join(",\n");
+
+    const tagLines = item.tags.map((tag) => `      ${JSON.stringify(tag)}`).join(",\n");
+
+    return `  {
+    id: ${JSON.stringify(item.id)},
+    title: ${JSON.stringify(item.title)},
+    description: ${JSON.stringify(item.description)},
+    status: ${JSON.stringify(item.status)},
+    priority: ${JSON.stringify(item.priority)},
+    storyPoints: ${item.storyPoints},
+    tags: [
+${tagLines}
+    ],
+    acceptanceCriteria: [
+${acceptanceLines}
+    ],
+    businessValue: ${item.businessValue},
+    effort: ${item.effort},
+    createdAt: new Date(${JSON.stringify(item.createdAt)}),
+    sprintId: ${JSON.stringify(item.sprintId)},
+  }`;
+  });
+
+  return `export const enterpriseBacklog: BacklogItem[] = [
+${lines.join(",\n")}
+];`;
+}
+
+const formatted = `import { BacklogItem } from "@/types/backlog";
+
+${formatBacklog(backlogItems)}
+
+export default enterpriseBacklog;
+`;
+
+fs.writeFileSync("src/data/enterpriseBacklog.ts", formatted);
+console.log("Generated enterprise backlog with", backlogItems.length, "items.");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,9 @@ import NotFound from "./pages/NotFound";
 import OperationsCenter from "./pages/OperationsCenter";
 import { OutpagedThemeProvider } from "./components/theme/OutpagedThemeProvider";
 import AppShell from "./layouts/AppShell";
+import { SlackProvider } from "./components/integrations/SlackProvider";
+import { ReleaseProvider } from "./components/releases/ReleaseProvider";
+import { MarketingProvider } from "./components/marketing/MarketingProvider";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -66,74 +69,80 @@ const App = () => (
       <AuthProvider>
         <SecurityProvider>
           <AccessibilityProvider>
-            <OperationsProvider>
-              <ErrorBoundary>
-                <TooltipProvider>
-                  <Toaster />
-                  <Sonner />
-                  <BrowserRouter>
-                    <CommandPalette />
-                    <KeyboardShortcuts />
-                    <Routes>
-                      {/* Public routes */}
-                      <Route path="/login" element={<Login />} handle={{ public: true }} />
-                      <Route path="/auth" element={<Navigate to="/login" replace />} handle={{ public: true }} />
-                      <Route path="/auth/callback" element={<AuthCallback />} handle={{ public: true }} />
-                      <Route path="/" element={<AuthRedirect />} handle={{ public: true }} />
+            <SlackProvider>
+              <ReleaseProvider>
+                <OperationsProvider>
+                  <MarketingProvider>
+                    <ErrorBoundary>
+                      <TooltipProvider>
+                        <Toaster />
+                        <Sonner />
+                        <BrowserRouter>
+                          <CommandPalette />
+                          <KeyboardShortcuts />
+                          <Routes>
+                            {/* Public routes */}
+                            <Route path="/login" element={<Login />} handle={{ public: true }} />
+                            <Route path="/auth" element={<Navigate to="/login" replace />} handle={{ public: true }} />
+                            <Route path="/auth/callback" element={<AuthCallback />} handle={{ public: true }} />
+                            <Route path="/" element={<AuthRedirect />} handle={{ public: true }} />
 
-                      {/* Protected routes with layout */}
-                      <Route path="/dashboard" element={<AppShell />}>
-                        <Route index element={<Dashboard />} />
-                        <Route path="projects" element={<Projects />} />
-                        <Route path="projects/:projectId" element={<ProjectDetailsResolver />} />
-                        <Route path="projects/:projectId/settings" element={<ProjectSettingsResolver />} />
-                        <Route path="projects/code/:code" element={<ProjectDetailsResolver />} />
-                        <Route path="projects/code/:code/settings" element={<ProjectSettingsResolver />} />
-                        <Route path="projects/code/:code/tasks/:taskNumber" element={<TaskView />} />
-                        <Route path="projects/:projectId/tasks/:taskNumber" element={<TaskView />} />
-                        <Route path="profile" element={<Profile />} />
-                        <Route path="tasks" element={<Tasks />} />
-                        <Route path="board" element={<KanbanBoard />} />
-                        <Route path="backlog" element={<Backlog />} />
-                        <Route path="sprints" element={<SprintPlanning />} />
-                        <Route path="roadmap" element={<Roadmap />} />
-                        <Route path="notifications" element={<Notifications />} />
-                        <Route path="analytics" element={<Analytics />} />
-                        <Route path="reports" element={<Reports />} />
-                        <Route path="templates" element={<ProjectTemplates />} />
-                        <Route path="automation" element={<Automation />} />
-                        <Route path="search" element={<Search />} />
-                        <Route path="settings" element={<Settings />} />
-                        <Route path="team" element={<TeamDirectory />} />
-                        <Route path="team/:identifier" element={<TeamMemberHandler />} />
-                        <Route path="tickets" element={<Tickets />} />
-                        <Route
-                          path="security"
-                          element={
-                            <AdminGuard>
-                              <SecurityDashboard />
-                            </AdminGuard>
-                          }
-                        />
-                        <Route
-                          path="enterprise"
-                          element={
-                            <AdminGuard>
-                              <EnterpriseControlPanel />
-                            </AdminGuard>
-                          }
-                        />
-                        <Route path="operations" element={<OperationsCenter />} />
-                      </Route>
+                            {/* Protected routes with layout */}
+                            <Route path="/dashboard" element={<AppShell />}>
+                              <Route index element={<Dashboard />} />
+                              <Route path="projects" element={<Projects />} />
+                              <Route path="projects/:projectId" element={<ProjectDetailsResolver />} />
+                              <Route path="projects/:projectId/settings" element={<ProjectSettingsResolver />} />
+                              <Route path="projects/code/:code" element={<ProjectDetailsResolver />} />
+                              <Route path="projects/code/:code/settings" element={<ProjectSettingsResolver />} />
+                              <Route path="projects/code/:code/tasks/:taskNumber" element={<TaskView />} />
+                              <Route path="projects/:projectId/tasks/:taskNumber" element={<TaskView />} />
+                              <Route path="profile" element={<Profile />} />
+                              <Route path="tasks" element={<Tasks />} />
+                              <Route path="board" element={<KanbanBoard />} />
+                              <Route path="backlog" element={<Backlog />} />
+                              <Route path="sprints" element={<SprintPlanning />} />
+                              <Route path="roadmap" element={<Roadmap />} />
+                              <Route path="notifications" element={<Notifications />} />
+                              <Route path="analytics" element={<Analytics />} />
+                              <Route path="reports" element={<Reports />} />
+                              <Route path="templates" element={<ProjectTemplates />} />
+                              <Route path="automation" element={<Automation />} />
+                              <Route path="search" element={<Search />} />
+                              <Route path="settings" element={<Settings />} />
+                              <Route path="team" element={<TeamDirectory />} />
+                              <Route path="team/:identifier" element={<TeamMemberHandler />} />
+                              <Route path="tickets" element={<Tickets />} />
+                              <Route
+                                path="security"
+                                element={
+                                  <AdminGuard>
+                                    <SecurityDashboard />
+                                  </AdminGuard>
+                                }
+                              />
+                              <Route
+                                path="enterprise"
+                                element={
+                                  <AdminGuard>
+                                    <EnterpriseControlPanel />
+                                  </AdminGuard>
+                                }
+                              />
+                              <Route path="operations" element={<OperationsCenter />} />
+                            </Route>
 
-                      {/* Catch-all route */}
-                      <Route path="*" element={<NotFound />} handle={{ public: true }} />
-                    </Routes>
-            </BrowserRouter>
-          </TooltipProvider>
-        </ErrorBoundary>
-      </OperationsProvider>
-    </AccessibilityProvider>
+                            {/* Catch-all route */}
+                            <Route path="*" element={<NotFound />} handle={{ public: true }} />
+                          </Routes>
+                        </BrowserRouter>
+                      </TooltipProvider>
+                    </ErrorBoundary>
+                  </MarketingProvider>
+                </OperationsProvider>
+              </ReleaseProvider>
+            </SlackProvider>
+          </AccessibilityProvider>
         </SecurityProvider>
       </AuthProvider>
     </QueryClientProvider>

--- a/src/components/integrations/SlackProvider.tsx
+++ b/src/components/integrations/SlackProvider.tsx
@@ -1,0 +1,182 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+export type SlackDmType = "mention" | "assignment" | "approval";
+
+export interface SlackDmPayload {
+  itemId: string;
+  itemTitle: string;
+  status: string;
+  dueDate?: string;
+  actions: Array<"open" | "approve" | "snooze">;
+}
+
+export interface SlackDmMessage extends SlackDmPayload {
+  id: string;
+  userId: string;
+  sentAt: string;
+}
+
+export interface SlackUnfurl {
+  url: string;
+  itemId: string;
+  title: string;
+  status: string;
+  assignee?: string;
+  dueDate?: string;
+  restricted: boolean;
+}
+
+export type SlackProjectEvent = "new_item" | "release" | "status_change" | "sla_breach";
+
+export interface SlackChannelConfig {
+  channelId: string;
+  events: SlackProjectEvent[];
+}
+
+export interface SlackAuditEntry {
+  id: string;
+  channelId: string;
+  event: SlackProjectEvent;
+  itemId: string;
+  deliveredAt: string;
+}
+
+interface SlackPreferences {
+  dmEnabled: boolean;
+  mutedDmTypes: SlackDmType[];
+}
+
+interface SlackContextValue {
+  dms: SlackDmMessage[];
+  unfurls: SlackUnfurl[];
+  auditLog: SlackAuditEntry[];
+  userPreferences: Record<string, SlackPreferences>;
+  setUserPreferences: (userId: string, prefs: Partial<SlackPreferences>) => void;
+  sendDirectMessage: (userId: string, type: SlackDmType, payload: SlackDmPayload) => SlackDmMessage | null;
+  generateUnfurl: (input: Omit<SlackUnfurl, "restricted"> & { viewerHasAccess: boolean }) => SlackUnfurl;
+  configureProjectChannel: (projectId: string, config: SlackChannelConfig) => void;
+  postProjectEvent: (projectId: string, event: SlackProjectEvent, itemId: string) => SlackAuditEntry | null;
+}
+
+const SlackContext = createContext<SlackContextValue | null>(null);
+
+const STORAGE_KEY = "slack_state_v1";
+
+interface SlackState {
+  dms: SlackDmMessage[];
+  unfurls: SlackUnfurl[];
+  auditLog: SlackAuditEntry[];
+  userPreferences: Record<string, SlackPreferences>;
+  projectChannels: Record<string, SlackChannelConfig>;
+}
+
+const defaultState: SlackState = {
+  dms: [],
+  unfurls: [],
+  auditLog: [],
+  userPreferences: {},
+  projectChannels: {},
+};
+
+const createId = () => (typeof crypto !== "undefined" && crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2));
+
+export function SlackProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<SlackState>(() => {
+    const raw = typeof window !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
+    if (!raw) return defaultState;
+    try {
+      const parsed = JSON.parse(raw) as SlackState;
+      return { ...defaultState, ...parsed };
+    } catch {
+      return defaultState;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }, [state]);
+
+  const value = useMemo<SlackContextValue>(() => ({
+    dms: state.dms,
+    unfurls: state.unfurls,
+    auditLog: state.auditLog,
+    userPreferences: state.userPreferences,
+    setUserPreferences: (userId, prefs) => {
+      setState((prev) => ({
+        ...prev,
+        userPreferences: {
+          ...prev.userPreferences,
+          [userId]: {
+            dmEnabled: prefs.dmEnabled ?? prev.userPreferences[userId]?.dmEnabled ?? true,
+            mutedDmTypes: prefs.mutedDmTypes ?? prev.userPreferences[userId]?.mutedDmTypes ?? [],
+          },
+        },
+      }));
+    },
+    sendDirectMessage: (userId, type, payload) => {
+      const prefs = state.userPreferences[userId] ?? { dmEnabled: true, mutedDmTypes: [] };
+      if (!prefs.dmEnabled || prefs.mutedDmTypes.includes(type)) {
+        return null;
+      }
+      if (!payload.dueDate) {
+        throw new Error("Slack DM payload must include a due date");
+      }
+      const message: SlackDmMessage = {
+        id: createId(),
+        userId,
+        sentAt: new Date().toISOString(),
+        ...payload,
+      };
+      const requiredActions: SlackDmPayload["actions"] = ["open", "approve", "snooze"];
+      const missing = requiredActions.filter((action) => !payload.actions.includes(action));
+      if (missing.length > 0) {
+        throw new Error(`Slack DM must include actions: ${missing.join(", ")}`);
+      }
+      setState((prev) => ({ ...prev, dms: [...prev.dms, message] }));
+      return message;
+    },
+    generateUnfurl: ({ viewerHasAccess, ...rest }) => {
+      const unfurl: SlackUnfurl = {
+        ...rest,
+        restricted: !viewerHasAccess,
+      };
+      setState((prev) => ({ ...prev, unfurls: [...prev.unfurls, unfurl] }));
+      return unfurl;
+    },
+    configureProjectChannel: (projectId, config) => {
+      setState((prev) => ({
+        ...prev,
+        projectChannels: {
+          ...prev.projectChannels,
+          [projectId]: config,
+        },
+      }));
+    },
+    postProjectEvent: (projectId, event, itemId) => {
+      const config = state.projectChannels[projectId];
+      if (!config || !config.events.includes(event)) {
+        return null;
+      }
+      const entry: SlackAuditEntry = {
+        id: createId(),
+        channelId: config.channelId,
+        event,
+        itemId,
+        deliveredAt: new Date().toISOString(),
+      };
+      setState((prev) => ({ ...prev, auditLog: [...prev.auditLog, entry] }));
+      return entry;
+    },
+  }), [state]);
+
+  return <SlackContext.Provider value={value}>{children}</SlackContext.Provider>;
+}
+
+export function useSlack() {
+  const context = useContext(SlackContext);
+  if (!context) {
+    throw new Error("useSlack must be used within a SlackProvider");
+  }
+  return context;
+}

--- a/src/components/integrations/__tests__/SlackProvider.test.tsx
+++ b/src/components/integrations/__tests__/SlackProvider.test.tsx
@@ -1,0 +1,132 @@
+import { act, renderHook } from "@testing-library/react";
+import { SlackProvider, useSlack, type SlackDmMessage } from "../SlackProvider";
+
+describe("SlackProvider", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <SlackProvider>{children}</SlackProvider>
+  );
+
+  it("sends direct messages when preferences allow", () => {
+    const { result } = renderHook(() => useSlack(), { wrapper });
+
+    let messageId: string | null = null;
+    act(() => {
+      result.current.setUserPreferences("user-1", { dmEnabled: true });
+      const message = result.current.sendDirectMessage("user-1", "mention", {
+        itemId: "item-123",
+        itemTitle: "Release readiness",
+        status: "QA",
+        dueDate: new Date().toISOString(),
+        actions: ["open", "approve", "snooze"],
+      });
+      messageId = message?.id ?? null;
+    });
+
+    expect(messageId).not.toBeNull();
+    expect(result.current.dms).toHaveLength(1);
+    expect(result.current.dms[0]).toMatchObject({
+      itemId: "item-123",
+      userId: "user-1",
+    });
+  });
+
+  it("respects notification preferences for muted types", () => {
+    const { result } = renderHook(() => useSlack(), { wrapper });
+
+    let response: SlackDmMessage | null = null;
+    act(() => {
+      result.current.setUserPreferences("user-1", {
+        dmEnabled: true,
+        mutedDmTypes: ["assignment"],
+      });
+    });
+    act(() => {
+      response = result.current.sendDirectMessage("user-1", "assignment", {
+        itemId: "item-123",
+        itemTitle: "Ops task",
+        status: "In Progress",
+        dueDate: new Date().toISOString(),
+        actions: ["open", "approve", "snooze"],
+      });
+    });
+
+    expect(response).toBeNull();
+    expect(result.current.dms).toHaveLength(0);
+  });
+
+  it("validates required fields when sending a DM", () => {
+    const { result } = renderHook(() => useSlack(), { wrapper });
+
+    expect(() =>
+      act(() => {
+        result.current.sendDirectMessage("user-1", "mention", {
+          itemId: "missing-due-date",
+          itemTitle: "Broken payload",
+          status: "QA",
+          // dueDate intentionally omitted
+          actions: ["open", "approve", "snooze"],
+        });
+      })
+    ).toThrow("Slack DM payload must include a due date");
+
+    expect(() =>
+      act(() => {
+        result.current.sendDirectMessage("user-1", "mention", {
+          itemId: "missing-action",
+          itemTitle: "Broken payload",
+          status: "QA",
+          dueDate: new Date().toISOString(),
+          actions: ["open", "approve"],
+        });
+      })
+    ).toThrow("Slack DM must include actions: snooze");
+  });
+
+  it("records project channel deliveries when configured", () => {
+    const { result } = renderHook(() => useSlack(), { wrapper });
+
+    act(() => {
+      result.current.configureProjectChannel("project-1", {
+        channelId: "channel-123",
+        events: ["status_change"],
+      });
+    });
+
+    let auditId: string | null = null;
+    act(() => {
+      const entry = result.current.postProjectEvent("project-1", "status_change", "item-9");
+      auditId = entry?.id ?? null;
+    });
+
+    expect(auditId).not.toBeNull();
+    expect(result.current.auditLog).toHaveLength(1);
+    expect(result.current.auditLog[0]).toMatchObject({
+      channelId: "channel-123",
+      itemId: "item-9",
+    });
+  });
+
+  it("generates unfurls and flags restricted viewers", () => {
+    const { result } = renderHook(() => useSlack(), { wrapper });
+
+    act(() => {
+      result.current.generateUnfurl({
+        url: "https://example.com/item/1",
+        itemId: "item-1",
+        title: "Example item",
+        status: "Open",
+        viewerHasAccess: false,
+      });
+    });
+
+    expect(result.current.unfurls).toHaveLength(1);
+    expect(result.current.unfurls[0]).toMatchObject({
+      url: "https://example.com/item/1",
+      restricted: true,
+    });
+  });
+});

--- a/src/components/marketing/MarketingProvider.tsx
+++ b/src/components/marketing/MarketingProvider.tsx
@@ -1,0 +1,506 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useReleases } from "@/components/releases/ReleaseProvider";
+import { useOperations } from "@/components/operations/OperationsProvider";
+import { useSlack } from "@/components/integrations/SlackProvider";
+
+export type MarketingCampaignStatus =
+  | "intake"
+  | "plan"
+  | "copy_draft"
+  | "asset_production"
+  | "channel_build"
+  | "qa"
+  | "scheduled"
+  | "live"
+  | "wrap";
+
+const MARKETING_FLOW: MarketingCampaignStatus[] = [
+  "intake",
+  "plan",
+  "copy_draft",
+  "asset_production",
+  "channel_build",
+  "qa",
+  "scheduled",
+  "live",
+  "wrap",
+];
+
+export interface CampaignAsset {
+  id: string;
+  name: string;
+  type: "design" | "copy" | "video" | "other";
+  url: string;
+}
+
+export interface QaApproval {
+  id: string;
+  approver: string;
+  role: "marketing_lead" | "reviewer";
+  approvedAt: string;
+}
+
+export interface CampaignHistoryEntry {
+  id: string;
+  timestamp: string;
+  actor: string;
+  action: string;
+}
+
+export interface WrapMetrics {
+  performanceSummary: string;
+  metricsLink: string;
+  recordedAt: string;
+  digestSentAt?: string;
+}
+
+export interface MarketingCampaign {
+  id: string;
+  projectId?: string;
+  name: string;
+  status: MarketingCampaignStatus;
+  requiresAssets: boolean;
+  linkedAssets: CampaignAsset[];
+  linkedReleaseId?: string;
+  qaApprovals: QaApproval[];
+  goLiveDate?: string;
+  systems?: string[];
+  pendingState?: MarketingCampaignStatus;
+  blockedReason?: string | null;
+  history: CampaignHistoryEntry[];
+  wrapMetrics?: WrapMetrics;
+  attachments: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface DesignHandoffPayload {
+  designItemId: string;
+  title: string;
+  summary: string;
+  attachments: string[];
+  projectId?: string;
+}
+
+interface ReleaseHandoffPayload {
+  releaseId: string;
+  releaseNotes: string;
+  campaignName: string;
+  projectId?: string;
+}
+
+interface MarketingContextValue {
+  campaigns: MarketingCampaign[];
+  createCampaign: (input: {
+    name: string;
+    requiresAssets: boolean;
+    linkedReleaseId?: string;
+    projectId?: string;
+    initialStatus?: MarketingCampaignStatus;
+  }) => MarketingCampaign;
+  linkAsset: (campaignId: string, asset: CampaignAsset) => void;
+  requestQaApproval: (campaignId: string, approver: { name: string; role: QaApproval["role"] }) => void;
+  setGoLiveDetails: (campaignId: string, details: { goLiveDate: string; systems: string[] }) => void;
+  transitionCampaign: (campaignId: string, nextState: MarketingCampaignStatus, actor: string) => void;
+  recordWrapMetrics: (
+    campaignId: string,
+    metrics: { performanceSummary: string; metricsLink: string; sendDigest?: boolean; recipients?: string[] },
+    actor: string
+  ) => void;
+  registerDesignHandoff: (payload: DesignHandoffPayload) => MarketingCampaign;
+  registerReleaseHandoff: (payload: ReleaseHandoffPayload) => MarketingCampaign;
+  getCampaignById: (campaignId: string) => MarketingCampaign | undefined;
+}
+
+const MarketingContext = createContext<MarketingContextValue | null>(null);
+
+const STORAGE_KEY = "marketing_state_v1";
+
+const createId = () => (typeof crypto !== "undefined" && crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2));
+
+export function MarketingProvider({ children }: { children: React.ReactNode }) {
+  const { getReleaseById, releases } = useReleases();
+  const operations = useOperations();
+  const slack = useSlack();
+  const pendingSideEffects = useRef<Array<() => void>>([]);
+  const [campaigns, setCampaigns] = useState<MarketingCampaign[]>(() => {
+    if (typeof window === "undefined") return [];
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    try {
+      const parsed = JSON.parse(raw) as MarketingCampaign[];
+      return parsed.map((campaign) => ({
+        ...campaign,
+        linkedAssets: campaign.linkedAssets ?? [],
+        qaApprovals: campaign.qaApprovals ?? [],
+        history: campaign.history ?? [],
+        attachments: campaign.attachments ?? [],
+      }));
+    } catch {
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(campaigns));
+  }, [campaigns]);
+
+  const enqueueSideEffect = useCallback((effect: () => void) => {
+    pendingSideEffects.current.push(effect);
+  }, []);
+
+  useEffect(() => {
+    if (pendingSideEffects.current.length === 0) return;
+    const effects = pendingSideEffects.current.splice(0, pendingSideEffects.current.length);
+    effects.forEach((effect) => effect());
+  }, [campaigns]);
+
+  useEffect(() => {
+    if (releases.length === 0) return;
+    setCampaigns((prev) =>
+      prev.map((campaign) => {
+        if (!campaign.linkedReleaseId || campaign.pendingState !== "scheduled" || campaign.blockedReason !== "release") {
+          return campaign;
+        }
+        const release = releases.find((item) => item.id === campaign.linkedReleaseId);
+        if (release?.state === "released") {
+          const now = new Date().toISOString();
+          const historyEntry: CampaignHistoryEntry = {
+            id: createId(),
+            timestamp: now,
+            actor: "system",
+            action: "Release marked Released - campaign auto-scheduled",
+          };
+          const updated: MarketingCampaign = {
+            ...campaign,
+            status: "scheduled",
+            pendingState: undefined,
+            blockedReason: null,
+            history: [...campaign.history, historyEntry],
+            updatedAt: now,
+          };
+          enqueueSideEffect(() => {
+            operations.createGoLiveTask({
+              campaignId: campaign.id,
+              title: campaign.name,
+              goLiveDate: campaign.goLiveDate ?? new Date().toISOString(),
+              systems: campaign.systems ?? [],
+            });
+            if (campaign.projectId) {
+              slack.postProjectEvent(campaign.projectId, "status_change", campaign.id);
+            }
+          });
+          return updated;
+        }
+        return campaign;
+      })
+    );
+  }, [releases, operations, slack, enqueueSideEffect]);
+
+  const createCampaignInternal = useCallback(
+    ({
+      name,
+      requiresAssets,
+      linkedReleaseId,
+      projectId,
+      initialStatus,
+    }: {
+      name: string;
+      requiresAssets: boolean;
+      linkedReleaseId?: string;
+      projectId?: string;
+      initialStatus?: MarketingCampaignStatus;
+    }) => {
+      const now = new Date().toISOString();
+      const status = initialStatus ?? "intake";
+      const campaign: MarketingCampaign = {
+        id: createId(),
+        name,
+        requiresAssets,
+        linkedAssets: [],
+        linkedReleaseId,
+        qaApprovals: [],
+        goLiveDate: undefined,
+        systems: undefined,
+        pendingState: undefined,
+        blockedReason: null,
+        attachments: [],
+        history: [
+          {
+            id: createId(),
+            timestamp: now,
+            actor: "system",
+            action: `Campaign created in ${status}`,
+          },
+        ],
+        wrapMetrics: undefined,
+        status,
+        createdAt: now,
+        updatedAt: now,
+        projectId,
+      };
+      setCampaigns((prev) => [...prev, campaign]);
+      return campaign;
+    },
+    []
+  );
+
+  const value = useMemo<MarketingContextValue>(() => ({
+    campaigns,
+    createCampaign: createCampaignInternal,
+    linkAsset: (campaignId, asset) => {
+      setCampaigns((prev) =>
+        prev.map((campaign) =>
+          campaign.id === campaignId
+            ? {
+                ...campaign,
+                linkedAssets: campaign.linkedAssets.some((item) => item.id === asset.id)
+                  ? campaign.linkedAssets
+                  : [...campaign.linkedAssets, asset],
+                history: [
+                  ...campaign.history,
+                  {
+                    id: createId(),
+                    timestamp: new Date().toISOString(),
+                    actor: "system",
+                    action: `Linked asset ${asset.name}`,
+                  },
+                ],
+              }
+            : campaign
+        )
+      );
+    },
+    requestQaApproval: (campaignId, approver) => {
+      setCampaigns((prev) =>
+        prev.map((campaign) =>
+          campaign.id === campaignId
+            ? {
+                ...campaign,
+                qaApprovals: [
+                  ...campaign.qaApprovals,
+                  {
+                    id: createId(),
+                    approver: approver.name,
+                    role: approver.role,
+                    approvedAt: new Date().toISOString(),
+                  },
+                ],
+              }
+            : campaign
+        )
+      );
+    },
+    setGoLiveDetails: (campaignId, details) => {
+      setCampaigns((prev) =>
+        prev.map((campaign) =>
+          campaign.id === campaignId
+            ? { ...campaign, goLiveDate: details.goLiveDate, systems: details.systems }
+            : campaign
+        )
+      );
+    },
+    transitionCampaign: (campaignId, nextState, actor) => {
+      setCampaigns((prev) =>
+        prev.map((campaign) => {
+          if (campaign.id !== campaignId) return campaign;
+          if (campaign.status === nextState) return campaign;
+          const currentIndex = MARKETING_FLOW.indexOf(campaign.status);
+          const nextIndex = MARKETING_FLOW.indexOf(nextState);
+          if (nextIndex !== currentIndex + 1) {
+            throw new Error("Invalid marketing workflow transition");
+          }
+          if (nextState === "qa" && campaign.requiresAssets && campaign.linkedAssets.length === 0) {
+            throw new Error("Assets must be linked before QA");
+          }
+          if (nextState === "scheduled") {
+            if (campaign.requiresAssets && campaign.linkedAssets.length === 0) {
+              throw new Error("At least one design asset is required before scheduling");
+            }
+            const hasLeadApproval = campaign.qaApprovals.some((approval) => approval.role === "marketing_lead");
+            if (!hasLeadApproval) {
+              throw new Error("Marketing Lead approval is required before scheduling");
+            }
+            if (campaign.linkedReleaseId) {
+              const release = getReleaseById(campaign.linkedReleaseId);
+              if (!release || release.state !== "released") {
+                return {
+                  ...campaign,
+                  pendingState: "scheduled",
+                  blockedReason: "release",
+                  history: [
+                    ...campaign.history,
+                    {
+                      id: createId(),
+                      timestamp: new Date().toISOString(),
+                      actor,
+                      action: "Scheduling blocked pending release readiness",
+                    },
+                  ],
+                };
+              }
+            }
+            enqueueSideEffect(() => {
+              operations.createGoLiveTask({
+                campaignId: campaign.id,
+                title: campaign.name,
+                goLiveDate: campaign.goLiveDate ?? new Date().toISOString(),
+                systems: campaign.systems ?? [],
+              });
+              if (campaign.projectId) {
+                slack.postProjectEvent(campaign.projectId, "status_change", campaign.id);
+              }
+            });
+          }
+          const now = new Date().toISOString();
+          return {
+            ...campaign,
+            status: nextState,
+            pendingState: undefined,
+            blockedReason: null,
+            updatedAt: now,
+            history: [
+              ...campaign.history,
+              {
+                id: createId(),
+                timestamp: now,
+                actor,
+                action: `Moved to ${nextState}`,
+              },
+            ],
+          };
+        })
+      );
+    },
+    recordWrapMetrics: (campaignId, metrics, actor) => {
+      if (!metrics.performanceSummary.trim() || !metrics.metricsLink.trim()) {
+        throw new Error("Wrap metrics require both summary and metrics link");
+      }
+      setCampaigns((prev) =>
+        prev.map((campaign) => {
+          if (campaign.id !== campaignId) return campaign;
+          if (campaign.status !== "wrap") {
+            throw new Error("Campaign must be in wrap state to record metrics");
+          }
+          const now = new Date().toISOString();
+          if (metrics.sendDigest && campaign.projectId) {
+            const targetProjectId = campaign.projectId;
+            enqueueSideEffect(() => {
+              if (targetProjectId) {
+                slack.postProjectEvent(targetProjectId, "status_change", campaign.id);
+              }
+            });
+          }
+          return {
+            ...campaign,
+            wrapMetrics: {
+              performanceSummary: metrics.performanceSummary,
+              metricsLink: metrics.metricsLink,
+              recordedAt: now,
+              digestSentAt: metrics.sendDigest ? now : undefined,
+            },
+            history: [
+              ...campaign.history,
+              {
+                id: createId(),
+                timestamp: now,
+                actor,
+                action: "Recorded wrap metrics",
+              },
+            ],
+          };
+        })
+      );
+    },
+    registerDesignHandoff: (payload) => {
+      const campaign = createCampaignInternal({
+        name: payload.title,
+        requiresAssets: true,
+        projectId: payload.projectId,
+        initialStatus: "asset_production",
+      });
+      setCampaigns((prev) =>
+        prev.map((item) =>
+          item.id === campaign.id
+            ? {
+                ...item,
+                attachments: payload.attachments,
+                history: [
+                  ...item.history,
+                  {
+                    id: createId(),
+                    timestamp: new Date().toISOString(),
+                    actor: "system",
+                    action: `Created from design package ${payload.designItemId}`,
+                  },
+                ],
+              }
+            : item
+        )
+      );
+      slack.sendDirectMessage("marketing-lead", "assignment", {
+        itemId: campaign.id,
+        itemTitle: campaign.name,
+        status: campaign.status,
+        dueDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 3).toISOString(),
+        actions: ["open", "approve", "snooze"],
+      });
+      return campaign;
+    },
+    registerReleaseHandoff: (payload) => {
+      const campaign = createCampaignInternal({
+        name: payload.campaignName,
+        requiresAssets: false,
+        linkedReleaseId: payload.releaseId,
+        projectId: payload.projectId,
+        initialStatus: "plan",
+      });
+      setCampaigns((prev) =>
+        prev.map((item) =>
+          item.id === campaign.id
+            ? {
+                ...item,
+                history: [
+                  ...item.history,
+                  {
+                    id: createId(),
+                    timestamp: new Date().toISOString(),
+                    actor: "system",
+                    action: "Created from software release handoff",
+                  },
+                ],
+              }
+            : item
+        )
+      );
+      slack.sendDirectMessage("marketing-lead", "mention", {
+        itemId: campaign.id,
+        itemTitle: campaign.name,
+        status: campaign.status,
+        dueDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 5).toISOString(),
+        actions: ["open", "approve", "snooze"],
+      });
+      return campaign;
+    },
+    getCampaignById: (campaignId) => campaigns.find((campaign) => campaign.id === campaignId),
+  }), [campaigns, createCampaignInternal, getReleaseById, operations, slack, enqueueSideEffect]);
+
+  return <MarketingContext.Provider value={value}>{children}</MarketingContext.Provider>;
+}
+
+export function useMarketing() {
+  const context = useContext(MarketingContext);
+  if (!context) {
+    throw new Error("useMarketing must be used within a MarketingProvider");
+  }
+  return context;
+}

--- a/src/components/marketing/__tests__/MarketingProvider.test.tsx
+++ b/src/components/marketing/__tests__/MarketingProvider.test.tsx
@@ -1,0 +1,149 @@
+import { act, renderHook } from "@testing-library/react";
+import { SlackProvider } from "@/components/integrations/SlackProvider";
+import { ReleaseProvider, useReleases } from "@/components/releases/ReleaseProvider";
+import { OperationsProvider, useOperations } from "@/components/operations/OperationsProvider";
+import { MarketingProvider, useMarketing, type MarketingCampaignStatus } from "../MarketingProvider";
+
+describe("MarketingProvider", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <SlackProvider>
+      <ReleaseProvider>
+        <OperationsProvider>
+          <MarketingProvider>{children}</MarketingProvider>
+        </OperationsProvider>
+      </ReleaseProvider>
+    </SlackProvider>
+  );
+
+  const useContextValues = () => {
+    const marketing = useMarketing();
+    const releases = useReleases();
+    const operations = useOperations();
+    return { marketing, releases, operations };
+  };
+
+  const advanceWorkflow = (
+    marketing: ReturnType<typeof useMarketing>,
+    campaignId: string,
+    steps: MarketingCampaignStatus[],
+    actor: string
+  ) => {
+    steps.forEach((state) => {
+      act(() => {
+        marketing.transitionCampaign(campaignId, state, actor);
+      });
+    });
+  };
+
+  it("requires marketing lead approval before scheduling", () => {
+    const { result } = renderHook(useContextValues, { wrapper });
+
+    let campaignId = "";
+    act(() => {
+      const campaign = result.current.marketing.createCampaign({
+        name: "Campaign A",
+        requiresAssets: true,
+      });
+      campaignId = campaign.id;
+      result.current.marketing.linkAsset(campaignId, {
+        id: "asset-1",
+        name: "Hero",
+        type: "design",
+        url: "https://example.com/asset",
+      });
+    });
+
+    advanceWorkflow(
+      result.current.marketing,
+      campaignId,
+      ["plan", "copy_draft", "asset_production", "channel_build", "qa"],
+      "planner"
+    );
+
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() =>
+      act(() => {
+        result.current.marketing.transitionCampaign(campaignId, "scheduled", "planner");
+      })
+    ).toThrow("Marketing Lead approval is required before scheduling");
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("blocks scheduling until the linked release is marked released", () => {
+    const { result } = renderHook(useContextValues, { wrapper });
+
+    let releaseId = "";
+    act(() => {
+      const release = result.current.releases.createRelease({
+        name: "Q4 Launch",
+        version: "1.0.0",
+        checklistTemplate: ["QA sign-off"],
+      });
+      releaseId = release.id;
+    });
+
+    let campaignId = "";
+    act(() => {
+      const campaign = result.current.marketing.createCampaign({
+        name: "Launch Campaign",
+        requiresAssets: false,
+        linkedReleaseId: releaseId,
+        projectId: "project-123",
+      });
+      campaignId = campaign.id;
+    });
+
+    advanceWorkflow(
+      result.current.marketing,
+      campaignId,
+      ["plan", "copy_draft", "asset_production", "channel_build", "qa"],
+      "owner"
+    );
+
+    act(() => {
+      result.current.marketing.requestQaApproval(campaignId, {
+        name: "Marketing Lead",
+        role: "marketing_lead",
+      });
+    });
+
+    act(() => {
+      result.current.marketing.transitionCampaign(campaignId, "scheduled", "owner");
+    });
+
+    let campaign = result.current.marketing.getCampaignById(campaignId);
+    expect(campaign).toBeDefined();
+    expect(campaign?.status).toBe("qa");
+    expect(campaign?.pendingState).toBe("scheduled");
+    expect(campaign?.blockedReason).toBe("release");
+    expect(result.current.operations.opsTasks).toHaveLength(0);
+
+    const release = result.current.releases.getReleaseById(releaseId);
+    expect(release).toBeDefined();
+
+    act(() => {
+      if (release?.checklist[0]) {
+        result.current.releases.toggleChecklistItem(releaseId, release.checklist[0].id, "release-manager");
+      }
+      result.current.releases.transitionRelease(releaseId, "ready");
+      result.current.releases.transitionRelease(releaseId, "released");
+    });
+
+    campaign = result.current.marketing.getCampaignById(campaignId);
+    expect(campaign?.status).toBe("scheduled");
+    expect(campaign?.pendingState).toBeUndefined();
+    expect(campaign?.blockedReason).toBeNull();
+
+    expect(result.current.operations.opsTasks).toHaveLength(1);
+    expect(result.current.operations.opsTasks[0]).toMatchObject({
+      type: "go_live",
+      relatedCampaignId: campaignId,
+    });
+  });
+});

--- a/src/components/operations/__tests__/OperationsProvider.test.tsx
+++ b/src/components/operations/__tests__/OperationsProvider.test.tsx
@@ -1,0 +1,39 @@
+import { act, renderHook } from "@testing-library/react";
+import { SlackProvider } from "@/components/integrations/SlackProvider";
+import { OperationsProvider, useOperations } from "../OperationsProvider";
+
+describe("OperationsProvider", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <SlackProvider>
+      <OperationsProvider>{children}</OperationsProvider>
+    </SlackProvider>
+  );
+
+  it("creates go-live execution tasks linked to campaigns", () => {
+    const { result } = renderHook(() => useOperations(), { wrapper });
+
+    act(() => {
+      result.current.createGoLiveTask({
+        campaignId: "OP-MKT-001",
+        title: "Campaign Launch",
+        goLiveDate: "2024-05-01T10:00:00.000Z",
+        systems: ["crm", "web"],
+      });
+    });
+
+    expect(result.current.opsTasks).toHaveLength(1);
+    expect(result.current.opsTasks[0]).toMatchObject({
+      type: "go_live",
+      relatedCampaignId: "OP-MKT-001",
+      goLiveDate: "2024-05-01T10:00:00.000Z",
+      systems: ["crm", "web"],
+    });
+    expect(result.current.opsTasks[0].history[0]).toMatchObject({
+      action: "Task created",
+    });
+  });
+});

--- a/src/components/releases/ReleaseProvider.tsx
+++ b/src/components/releases/ReleaseProvider.tsx
@@ -1,0 +1,195 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+export type ReleaseState = "planning" | "ready" | "released";
+
+export interface ReleaseChecklistItem {
+  id: string;
+  label: string;
+  completed: boolean;
+  completedAt?: string;
+  completedBy?: string;
+}
+
+export interface LinkedItemSummary {
+  id: string;
+  title: string;
+  type: "story" | "bug" | "task" | "doc";
+  summary: string;
+}
+
+export interface ReleaseRecord {
+  id: string;
+  name: string;
+  version: string;
+  state: ReleaseState;
+  createdAt: string;
+  updatedAt: string;
+  checklist: ReleaseChecklistItem[];
+  linkedItems: LinkedItemSummary[];
+  notesDraft: string;
+}
+
+interface ReleaseContextValue {
+  releases: ReleaseRecord[];
+  createRelease: (input: { name: string; version: string; checklistTemplate?: string[] }) => ReleaseRecord;
+  linkItemToRelease: (releaseId: string, item: LinkedItemSummary) => void;
+  toggleChecklistItem: (releaseId: string, itemId: string, actor: string) => void;
+  transitionRelease: (releaseId: string, nextState: ReleaseState) => void;
+  updateNotesDraft: (releaseId: string, notes: string) => void;
+  generateReleaseNotes: (releaseId: string) => string;
+  getReleaseById: (releaseId: string) => ReleaseRecord | undefined;
+}
+
+const ReleaseContext = createContext<ReleaseContextValue | null>(null);
+
+const STORAGE_KEY = "release_state_v1";
+
+const createId = () => (typeof crypto !== "undefined" && crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2));
+
+const SEMVER_REGEX = /^(?:v)?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-.]+)?$/;
+
+export function ReleaseProvider({ children }: { children: React.ReactNode }) {
+  const [releases, setReleases] = useState<ReleaseRecord[]>(() => {
+    if (typeof window === "undefined") return [];
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    try {
+      const parsed = JSON.parse(raw) as ReleaseRecord[];
+      return parsed.map((release) => ({
+        ...release,
+        checklist: release.checklist ?? [],
+        linkedItems: release.linkedItems ?? [],
+      }));
+    } catch {
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(releases));
+  }, [releases]);
+
+  const value = useMemo<ReleaseContextValue>(() => ({
+    releases,
+    createRelease: ({ name, version, checklistTemplate }) => {
+      if (!SEMVER_REGEX.test(version)) {
+        throw new Error("Release version must follow semantic versioning");
+      }
+      const now = new Date().toISOString();
+      const checklist: ReleaseChecklistItem[] = (checklistTemplate ?? []).map((label) => ({
+        id: createId(),
+        label,
+        completed: false,
+      }));
+      const release: ReleaseRecord = {
+        id: createId(),
+        name,
+        version,
+        state: "planning",
+        createdAt: now,
+        updatedAt: now,
+        checklist,
+        linkedItems: [],
+        notesDraft: "",
+      };
+      setReleases((prev) => [...prev, release]);
+      return release;
+    },
+    linkItemToRelease: (releaseId, item) => {
+      setReleases((prev) =>
+        prev.map((release) =>
+          release.id === releaseId
+            ? {
+                ...release,
+                linkedItems: release.linkedItems.some((linked) => linked.id === item.id)
+                  ? release.linkedItems
+                  : [...release.linkedItems, item],
+              }
+            : release
+        )
+      );
+    },
+    toggleChecklistItem: (releaseId, itemId, actor) => {
+      setReleases((prev) =>
+        prev.map((release) =>
+          release.id === releaseId
+            ? {
+                ...release,
+                checklist: release.checklist.map((item) =>
+                  item.id === itemId
+                    ? {
+                        ...item,
+                        completed: !item.completed,
+                        completedAt: !item.completed ? new Date().toISOString() : undefined,
+                        completedBy: !item.completed ? actor : undefined,
+                      }
+                    : item
+                ),
+              }
+            : release
+        )
+      );
+    },
+    transitionRelease: (releaseId, nextState) => {
+      setReleases((prev) =>
+        prev.map((release) => {
+          if (release.id !== releaseId) return release;
+          if (nextState === "released") {
+            const hasIncomplete = release.checklist.some((item) => !item.completed);
+            if (hasIncomplete) {
+              throw new Error("All checklist items must be completed before releasing");
+            }
+          }
+          return {
+            ...release,
+            state: nextState,
+            updatedAt: new Date().toISOString(),
+          };
+        })
+      );
+    },
+    updateNotesDraft: (releaseId, notes) => {
+      setReleases((prev) =>
+        prev.map((release) =>
+          release.id === releaseId
+            ? { ...release, notesDraft: notes }
+            : release
+        )
+      );
+    },
+    generateReleaseNotes: (releaseId) => {
+      const release = releases.find((item) => item.id === releaseId);
+      if (!release) {
+        throw new Error("Release not found");
+      }
+      const grouped = release.linkedItems.reduce<Record<LinkedItemSummary["type"], LinkedItemSummary[]>>((acc, item) => {
+        if (!acc[item.type]) acc[item.type] = [];
+        acc[item.type].push(item);
+        return acc;
+      }, {} as Record<LinkedItemSummary["type"], LinkedItemSummary[]>);
+      const lines: string[] = [`# Release ${release.version}`, "", `State: ${release.state}`];
+      Object.entries(grouped).forEach(([type, items]) => {
+        lines.push("", `## ${type.charAt(0).toUpperCase()}${type.slice(1)}s`);
+        items.forEach((item) => {
+          lines.push(`- **${item.title}** — ${item.summary}`);
+        });
+      });
+      if (release.notesDraft.trim()) {
+        lines.push("", "## Additional Notes", release.notesDraft.trim());
+      }
+      return lines.join("\n");
+    },
+    getReleaseById: (releaseId) => releases.find((release) => release.id === releaseId),
+  }), [releases]);
+
+  return <ReleaseContext.Provider value={value}>{children}</ReleaseContext.Provider>;
+}
+
+export function useReleases() {
+  const context = useContext(ReleaseContext);
+  if (!context) {
+    throw new Error("useReleases must be used within a ReleaseProvider");
+  }
+  return context;
+}

--- a/src/data/enterpriseBacklog.ts
+++ b/src/data/enterpriseBacklog.ts
@@ -1,0 +1,1545 @@
+import { BacklogItem } from "@/types/backlog";
+
+export const enterpriseBacklog: BacklogItem[] = [
+  {
+    id: "OP-MKT-001",
+    title: "Marketing Workflow States",
+    description: "As a Marketing user, I want a workflow from Intake → Plan → Copy Draft → Asset Production → Channel Build → QA → Scheduled → Live → Wrap so I can manage campaigns end-to-end.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 2",
+      "Team: Marketing",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "States are available in sequence",
+      "Invalid transitions are blocked",
+      "QA requires at least one Marketing Lead approval."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-01"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-MKT-002",
+    title: "Link Campaigns to Design Assets",
+    description: "As a Marketing user, I want to link my campaign to Design assets so I can ensure creative is finalized before scheduling.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 2",
+      "Team: Marketing",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Scheduled requires at least one linked Design asset when asset-dependent",
+      "Block transition to Scheduled if no linked asset."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-02"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-MKT-003",
+    title: "Block Scheduling on Release Readiness",
+    description: "As a Marketing user, I want scheduling to be blocked until the Software Release is Released so go-lives don't misfire.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 2",
+      "Team: Marketing",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Transition to Scheduled is blocked when linked Release ≠ Released",
+      "Unblock automatically once Release=Released."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-03"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-MKT-004",
+    title: "Campaign Wrap Metrics",
+    description: "As a Marketing user, I want to complete campaigns with a Wrap state including metrics so performance is recorded.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 2",
+      "Team: Marketing",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Wrap requires Performance Summary (text) and Metrics Link (URL)",
+      "On Wrap, optional digest can be sent."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-05-04"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-OPS-001",
+    title: "Operations Workflow States",
+    description: "As an Operations user, I want a workflow Submitted → Triage → Approved → In Progress → Waiting on Vendor → QA/Validation → Done to run Ops tasks.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 2",
+      "Team: Operations",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Triage requires SLA classification (P1–P4)",
+      "Approved requires named approver",
+      "Done requires QA/Validation checked."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-05"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-OPS-002",
+    title: "Change Request Fields & Gate",
+    description: "As an Operations user, I want Change Requests with risk, impact, and backout plan so high-risk work is controlled.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 2",
+      "Team: Operations",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Cannot move to Approved unless Risk, Impact, Backout Plan are filled",
+      "Approver and timestamp recorded."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-06"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-OPS-003",
+    title: "Vendor Dependency Handling",
+    description: "As an Operations user, I want to record vendor info and SLA when waiting externally so we can escalate properly.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 2",
+      "Team: Operations",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Waiting on Vendor requires Vendor Name, Contact, SLA Target",
+      "Escalation timer visible and counts down."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-05-07"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-HAND-003",
+    title: "Design→Marketing Handoff",
+    description: "As a Designer, I want moving to Packaged to create a Marketing item in Assets Received so marketing can start.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 2",
+      "Team: Design",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "On status=Packaged, create Marketing item with mapped fields + attachments",
+      "Notify Marketing Lead in-app and email."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-08"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-HAND-004",
+    title: "Software→Marketing Handoff",
+    description: "As an Engineer, I want Ready to Release to auto-create Marketing Launch Prep so launch tasks begin on time.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 2",
+      "Team: Engineering",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "On status=Ready to Release, create Marketing item with release notes",
+      "Marketing item blocked until Release=Released."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-09"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-HAND-005",
+    title: "Marketing→Ops Handoff",
+    description: "As a Marketing user, I want moving to Scheduled to create Ops go-live tasks so operations can execute cutover.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 2",
+      "Team: Marketing",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "On status=Scheduled, create Ops item with Go-Live Date + Systems list",
+      "Link back to campaign",
+      "Notify Ops channel."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-10"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-SLACK-001",
+    title: "Slack DMs for Mentions/Assignments/Approvals",
+    description: "As a user, I want Slack DMs for key events so I can act quickly without email.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 2",
+      "Team: Platform",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "DM includes item title/ID/status/due date",
+      "Buttons: Open/Approve/Snooze",
+      "Respects notification preferences."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-11"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-SLACK-002",
+    title: "Slack Link Unfurls",
+    description: "As a user, I want OutPaged links to unfurl in Slack so I can see context at a glance.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 2",
+      "Team: Platform",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Unfurl shows title/ID/status/assignee/due date",
+      "If viewer lacks permission, show Restricted."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-12"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-SLACK-003",
+    title: "Project→Slack Channel Notifications",
+    description: "As a Project Lead, I want to configure Slack channel notifications for project events so the team stays aligned.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 2",
+      "Team: Platform",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Configurable events: new items, releases, status changes, SLA breaches",
+      "Posts to chosen channel",
+      "Audit of deliveries."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-05-13"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-BACK-001",
+    title: "Backlog View with Ranking",
+    description: "As a user, I want a Backlog list to drag-rank items so prioritization is explicit.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 2",
+      "Team: Frontend",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Drag reorder persists project rank",
+      "Rank changes recorded in item history."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-14"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-SPRINT-001",
+    title: "Create Sprint & Commit Items",
+    description: "As a Project Lead, I want to create a sprint window and commit items so the team has a plan.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 2",
+      "Team: Frontend",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Sprint has start/end dates",
+      "Commitment line visible",
+      "Mid-sprint added/removed items flagged in scope-change log."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-15"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-SPRINT-002",
+    title: "Sprint Board with Swimlanes",
+    description: "As a team member, I want a sprint board with swimlanes so work is organized by Epic or Assignee.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 2",
+      "Team: Frontend",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Swimlanes by Epic/Assignee",
+      "Dragging cards updates status",
+      "Board respects WIP limits."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-16"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-RM-001",
+    title: "Roadmap by Quarter",
+    description: "As Leadership, I want a quarterly roadmap so I can see initiatives and key milestones.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 2",
+      "Team: Frontend",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Swimlanes=Initiatives",
+      "Bars colored by health (Green/Amber/Red)",
+      "Milestones as diamonds with dates."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-05-17"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-RM-002",
+    title: "Roadmap Filters & Saved Views",
+    description: "As Leadership, I want to filter Roadmap by Team/Quarter/Health and save views so I can share perspectives.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 2",
+      "Team: Frontend",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Filters persist in URL",
+      "Saved views shareable",
+      "Permission-aware."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-05-18"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-RM-003",
+    title: "Roadmap Dependencies",
+    description: "As Leadership, I want to see dependency lines so I understand schedule risk.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 2",
+      "Team: Frontend",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Dependency lines in Orange",
+      "Hover tooltip shows impact statement (e.g., slip of 7 days impacts X)."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-05-19"),
+    sprintId: "phase-2",
+  },
+  {
+    id: "OP-EST-001",
+    title: "Enable Story Points & Time Estimates",
+    description: "As a Project Lead, I want items to support points and time so we can plan capacity.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 3",
+      "Team: Frontend",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Items accept Story Points (number) and Time Estimate (hours)",
+      "Fields appear in Table/Board/Backlog",
+      "Editable inline."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-20"),
+    sprintId: "phase-3",
+  },
+  {
+    id: "OP-EST-002",
+    title: "Team Capacity per Sprint",
+    description: "As a Project Lead, I want to set team capacity so sprint commitments are realistic.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 3",
+      "Team: Frontend",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Capacity configurable per sprint and per person",
+      "Warning when commitment exceeds capacity."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-21"),
+    sprintId: "phase-3",
+  },
+  {
+    id: "OP-EST-003",
+    title: "Velocity Calculation & Forecast",
+    description: "As a Project Lead, I want past velocity and a forecast so I can plan future sprints.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 3",
+      "Team: Frontend",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Velocity chart over last 3–6 sprints",
+      "Forecast band for next sprint",
+      "Uses completed points only."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-22"),
+    sprintId: "phase-3",
+  },
+  {
+    id: "OP-REL-001",
+    title: "Release Entity & Versions",
+    description: "As an Engineer, I want Releases with versions so we can track cutlines.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 3",
+      "Team: Backend",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Create Release with semantic version",
+      "Link items",
+      "Release state (Planning/Ready/Released)."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-23"),
+    sprintId: "phase-3",
+  },
+  {
+    id: "OP-REL-002",
+    title: "Release Readiness Checklist",
+    description: "As a Release Manager, I want a readiness checklist so release quality is consistent.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 3",
+      "Team: Backend",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Checklist template per project",
+      "Must pass before marking Released",
+      "Missing items block transition."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-24"),
+    sprintId: "phase-3",
+  },
+  {
+    id: "OP-REL-003",
+    title: "Auto-Generate Release Notes",
+    description: "As a PM, I want release notes compiled from items so communication is easy.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 3",
+      "Team: Frontend",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Release notes page compiles item titles/summaries by type",
+      "Export to Markdown",
+      "Editable pre-publish."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-05-25"),
+    sprintId: "phase-3",
+  },
+  {
+    id: "OP-GANTT-001",
+    title: "Timeline/Gantt View",
+    description: "As a Planner, I want a timeline with dependencies and baselines so I can manage schedules.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 3",
+      "Team: Frontend",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Drag tasks to adjust dates",
+      "Dependencies create critical path",
+      "Baseline vs Actual shows drift."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-26"),
+    sprintId: "phase-3",
+  },
+  {
+    id: "OP-GANTT-002",
+    title: "Date Constraints & Auto-Shift",
+    description: "As a Planner, I want dependent tasks to auto-shift so changes propagate safely.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 3",
+      "Team: Frontend",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Shifting a predecessor moves successors by the same delta",
+      "Conflicts flagged with warnings."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-05-27"),
+    sprintId: "phase-3",
+  },
+  {
+    id: "OP-WORK-001",
+    title: "Workload Heatmap",
+    description: "As a Manager, I want a workload heatmap so I can balance assignments.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 3",
+      "Team: Frontend",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Heatmap by person/team",
+      "Highlights over/under capacity",
+      "Filters by type/team/date range."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-28"),
+    sprintId: "phase-3",
+  },
+  {
+    id: "OP-NOTIF-001",
+    title: "SLA Alerts (Ops)",
+    description: "As Operations, I want SLA breach alerts so we can respond quickly.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 3",
+      "Team: Operations",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Start/Pause rules by state",
+      "Imminent breach and breach events trigger notifications",
+      "Escalation policy configurable."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-05-29"),
+    sprintId: "phase-3",
+  },
+  {
+    id: "OP-NOTIF-002",
+    title: "Scheduled Digests",
+    description: "As a Leader, I want scheduled digests so I stay informed without noise.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 3",
+      "Team: Platform",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Daily/Weekly digests by team/project",
+      "Email and Slack channel delivery",
+      "Only include items user has access to."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-05-30"),
+    sprintId: "phase-3",
+  },
+  {
+    id: "OP-SEARCH-001",
+    title: "Advanced Query Builder",
+    description: "As a power user, I want an advanced search builder so I can slice data precisely.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 3",
+      "Team: Frontend",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "AND/OR groups",
+      "Field operators",
+      "Save and share queries",
+      "Results linkable."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-05-31"),
+    sprintId: "phase-3",
+  },
+  {
+    id: "OP-REPORT-001",
+    title: "Agile Reports Pack",
+    description: "As a PM, I want burndown/burnup/CSD/CFD/velocity so we can inspect and adapt.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 3",
+      "Team: Frontend",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Burndown and burnup for current sprint",
+      "Cumulative Flow Diagram",
+      "Control Chart or Aging WIP",
+      "Export PNG/CSV."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-06-01"),
+    sprintId: "phase-3",
+  },
+  {
+    id: "OP-ADMIN-001",
+    title: "Notification Preference Policy Overrides",
+    description: "As an Admin, I want to set org/project overrides so critical alerts always deliver.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 3",
+      "Team: Admin",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Org/project critical categories bypass quiet hours",
+      "Audit of overrides",
+      "User UI shows enforced settings."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-06-02"),
+    sprintId: "phase-3",
+  },
+  {
+    id: "OP-SEC-001",
+    title: "Data Retention & Export Controls",
+    description: "As an Admin, I want retention policies and export controls so we meet compliance.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 3",
+      "Team: Admin",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Per-project retention (e.g., 365 days) with scheduled purge",
+      "Export permission gated",
+      "Audit log of exports."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-06-03"),
+    sprintId: "phase-3",
+  },
+  {
+    id: "OP-INC-001",
+    title: "Incident Entity & Severity Ladder",
+    description: "As Operations, I want incidents with severities (Sev1–Sev4) so we can classify and route response.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 4",
+      "Team: Operations",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Create Incident with title/desc/severity/affected services",
+      "Default SLA by severity applied",
+      "Incident states: Open → Mitigated → Monitoring → Resolved."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-04"),
+    sprintId: "phase-4",
+  },
+  {
+    id: "OP-INC-002",
+    title: "On-Call Rotation & Paging",
+    description: "As Operations, I want on-call schedules and paging so Sev1 alerts reach the right engineer.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 4",
+      "Team: Operations",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Admin can define rotations and time windows",
+      "Sev1 creates page to active on-call",
+      "Audit log shows who was paged and when."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-05"),
+    sprintId: "phase-4",
+  },
+  {
+    id: "OP-INC-003",
+    title: "Incident Workspace (War Room)",
+    description: "As Operations, I want an incident workspace so cross-team collaboration is organized.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 4",
+      "Team: Operations",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "On incident Open: create workspace with timeline, tasks, links",
+      "Add responders",
+      "All actions timestamped in incident timeline."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-06"),
+    sprintId: "phase-4",
+  },
+  {
+    id: "OP-INC-004",
+    title: "Postmortem Template & Actions",
+    description: "As Operations, I want a postmortem template to capture learnings and action items.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 4",
+      "Team: Operations",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "On Resolved: prompt to create Postmortem doc",
+      "Required fields: impact, root cause, corrective actions",
+      "Action items auto-created and linked."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-07"),
+    sprintId: "phase-4",
+  },
+  {
+    id: "OP-CHG-001",
+    title: "Change Request Workflow",
+    description: "As Operations, I want a change workflow (Draft → Review → Approved → Implementing → Validated → Done) with gates.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 4",
+      "Team: Operations",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Risk, Impact, Backout Plan required before Approved",
+      "Named approver recorded",
+      "Implementing blocked without approved state."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-08"),
+    sprintId: "phase-4",
+  },
+  {
+    id: "OP-CHG-002",
+    title: "Change Calendar & Freeze Windows",
+    description: "As Operations, I want a change calendar and freeze windows to avoid risky deployments.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 4",
+      "Team: Operations",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Calendar shows scheduled changes",
+      "Freeze windows block Approved→Implementing unless override by Admin",
+      "Conflicts flagged."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-06-09"),
+    sprintId: "phase-4",
+  },
+  {
+    id: "OP-SRV-001",
+    title: "Service Registry & Ownership",
+    description: "As a Platform Lead, I want a service catalog with owners so incidents map to responsible teams.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 4",
+      "Team: Platform",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Create Service with name, team owner, runbook link, tier",
+      "Items can link to Services",
+      "Ownership appears on incidents and changes."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-10"),
+    sprintId: "phase-4",
+  },
+  {
+    id: "OP-SRV-002",
+    title: "Runbooks & Checklists",
+    description: "As Engineers, we want runbooks attached to services/incidents for faster resolution.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 4",
+      "Team: Platform",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Attach runbooks (links/files) to Services",
+      "Incident shows relevant runbooks",
+      "Checklists can be marked complete and logged."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-06-11"),
+    sprintId: "phase-4",
+  },
+  {
+    id: "OP-DEP-001",
+    title: "Dependency Graph View",
+    description: "As a Planner, I want a dependency graph so I can see cross-item dependencies visually.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 4",
+      "Team: Frontend",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Graph nodes = items/epics, edges = depends-on",
+      "Zoom, pan, filter by team/status",
+      "Clickthrough opens item."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-12"),
+    sprintId: "phase-4",
+  },
+  {
+    id: "OP-DEP-002",
+    title: "Impact Analysis (“What Breaks If This Slips”)",
+    description: "As a PM, I want to know downstream impact when a dependency slips.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 4",
+      "Team: Frontend",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Adjusting a date shows impacted items and delay estimate",
+      "Critical paths highlighted",
+      "Export impact list (CSV)."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-06-13"),
+    sprintId: "phase-4",
+  },
+  {
+    id: "OP-SLA-001",
+    title: "Business Hour Calendars & Escalations",
+    description: "As Operations, I want SLA timers that respect business hours and escalate on breach.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 4",
+      "Team: Operations",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Define business calendars",
+      "SLA pauses on specified states",
+      "Near-breach and breach escalate via notifications to on-call and leads."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-14"),
+    sprintId: "phase-4",
+  },
+  {
+    id: "OP-SEARCH-002",
+    title: "Saved Searches & Sharing",
+    description: "As a power user, I want to save and share advanced queries.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 4",
+      "Team: Frontend",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Save query with name/visibility",
+      "Share link reproduces filters",
+      "Permission-aware visibility."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-06-15"),
+    sprintId: "phase-4",
+  },
+  {
+    id: "OP-OPS-004",
+    title: "Ops Dashboard",
+    description: "As Leadership, I want an Ops dashboard for MTTA/MTTR, SLA trends, change success rate.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 4",
+      "Team: Frontend",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Widgets show MTTA, MTTR, SLA compliance %, change failure rate",
+      "Time range filters",
+      "Export PNG/CSV."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-06-16"),
+    sprintId: "phase-4",
+  },
+  {
+    id: "OP-DOC-001",
+    title: "Docs Editor with Templates",
+    description: "As a PM, I want a docs editor with PRD/RFC templates so specs live with work.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 5",
+      "Team: Frontend",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Create doc with rich text, headings, tables",
+      "Start from PRD/RFC templates",
+      "Autosave",
+      "Permission-aware sharing."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-17"),
+    sprintId: "phase-5",
+  },
+  {
+    id: "OP-DOC-002",
+    title: "Status Chips & Field Bindings in Docs",
+    description: "As a PM, I want live item chips and bound fields inside docs.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 5",
+      "Team: Frontend",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Insert item chip showing ID/status/assignee",
+      "Bind fields (e.g., due date) to items",
+      "Chips update live when items change."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-18"),
+    sprintId: "phase-5",
+  },
+  {
+    id: "OP-DOC-003",
+    title: "Doc Change Tracking & Approvals",
+    description: "As a Lead, I want tracked changes and approvals on docs.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 5",
+      "Team: Frontend",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Track insert/delete with author and timestamp",
+      "Request approval from reviewers",
+      "Doc cannot be marked Final without required approvals."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-19"),
+    sprintId: "phase-5",
+  },
+  {
+    id: "OP-PORT-001",
+    title: "Portfolio Dashboard & Initiative Health",
+    description: "As Leadership, I want a portfolio view to track initiative health and progress.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 5",
+      "Team: Frontend",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Initiatives with health (G/A/R), progress %, budget vs plan (optional)",
+      "Drill-down to epics",
+      "Save/share views."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-20"),
+    sprintId: "phase-5",
+  },
+  {
+    id: "OP-PORT-002",
+    title: "Dependency Risk Heatmap",
+    description: "As Leadership, I want a heatmap of cross-team dependency risk.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 5",
+      "Team: Frontend",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Grid by team x team shows count/severity of blocking dependencies",
+      "Click reveals list",
+      "Export CSV."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-06-21"),
+    sprintId: "phase-5",
+  },
+  {
+    id: "OP-OKR-001",
+    title: "OKRs Linked to Work",
+    description: "As Leadership, I want OKRs connected to initiatives and items.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 5",
+      "Team: Frontend",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Create Objectives and KRs",
+      "Link KRs to epics/items",
+      "Rollup progress to Objective",
+      "Quarterly view and check-ins."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-06-22"),
+    sprintId: "phase-5",
+  },
+  {
+    id: "OP-IMP-001",
+    title: "CSV Importer Wizard",
+    description: "As an Admin, I want to import items from CSV with mapping and validation.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 5",
+      "Team: Admin",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Upload CSV",
+      "Map columns to fields",
+      "Validate and preview",
+      "Import in batches with error report."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-23"),
+    sprintId: "phase-5",
+  },
+  {
+    id: "OP-IMP-002",
+    title: "Jira Import (Projects/Issues/Sprints)",
+    description: "As an Admin, I want to import from Jira to accelerate migration.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 5",
+      "Team: Admin",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "OAuth/API or CSV",
+      "Map issue types/fields/statuses",
+      "Preserve comments/attachments when possible",
+      "Dry-run preview."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-24"),
+    sprintId: "phase-5",
+  },
+  {
+    id: "OP-IMP-003",
+    title: "Monday Import (Boards/Groups/Items)",
+    description: "As an Admin, I want to import from Monday boards into projects.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 5",
+      "Team: Admin",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "API token",
+      "Map columns to fields",
+      "Convert groups to statuses or tags",
+      "Preview before import."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-06-25"),
+    sprintId: "phase-5",
+  },
+  {
+    id: "OP-EXP-001",
+    title: "Exports & API Tokens",
+    description: "As a Data Analyst, I want CSV/JSON exports and personal API tokens.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 5",
+      "Team: Platform",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Export current view to CSV/JSON",
+      "Create/revoke API tokens",
+      "All exports audited."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-26"),
+    sprintId: "phase-5",
+  },
+  {
+    id: "OP-DIG-001",
+    title: "Executive Digest v2 (Email/Slack)",
+    description: "As Leadership, I want weekly executive digests with key deltas and risks.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 5",
+      "Team: Platform",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Schedule digest by portfolio/team",
+      "Include top risks, slips, releases",
+      "Delivered to email and Slack channel",
+      "Permission-aware."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-06-27"),
+    sprintId: "phase-5",
+  },
+  {
+    id: "OP-REP-001",
+    title: "Portfolio Reports Pack",
+    description: "As Leadership, I want printable/exportable portfolio reports.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 5",
+      "Team: Frontend",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Generate PDF/PNG for roadmap snapshot, initiative status, dependency risk",
+      "Time-stamped and shareable."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-06-28"),
+    sprintId: "phase-5",
+  },
+  {
+    id: "OP-PERF-001",
+    title: "10k+ Item Performance Hardening",
+    description: "As a user, I want smooth lists and filters even with 10k+ items.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 6",
+      "Team: Platform",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Virtualized lists",
+      "Indexed queries",
+      "Sub-second filter on common fields",
+      "Performance budget CI checks."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-06-29"),
+    sprintId: "phase-6",
+  },
+  {
+    id: "OP-PERF-002",
+    title: "Query Caching & N+1 Guardrails",
+    description: "As a Platform engineer, I want caching and safeguards to avoid N+1 and slow queries.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 6",
+      "Team: Platform",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Add server-side caching on heavy endpoints",
+      "Query analyzer warnings in CI",
+      "Telemetry for slow queries."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-06-30"),
+    sprintId: "phase-6",
+  },
+  {
+    id: "OP-BCK-001",
+    title: "Daily Backups & Project-Level PITR",
+    description: "As an Admin, I want backups and point-in-time restore for a single project.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 6",
+      "Team: Admin",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Automated daily backups",
+      "Request restore of a project to timestamp T",
+      "Admin UI to initiate restore",
+      "Audit of restores."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-07-01"),
+    sprintId: "phase-6",
+  },
+  {
+    id: "OP-REL-004",
+    title: "Multi-Region Readiness",
+    description: "As an Admin, I want failover readiness to improve resilience.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 6",
+      "Team: Admin",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Health checks",
+      "Replication strategy documented/validated",
+      "Runbook for failover drill",
+      "Status banner during failover."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-07-02"),
+    sprintId: "phase-6",
+  },
+  {
+    id: "OP-MOB-001",
+    title: "Mobile Apps v1 (iOS/Android) Sign-In & Inbox",
+    description: "As a user, I want to sign in on mobile and see my notifications/inbox.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 6",
+      "Team: Mobile",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Google SSO",
+      "Notification list with deep links",
+      "Mark read",
+      "Push enabled via provider."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-07-03"),
+    sprintId: "phase-6",
+  },
+  {
+    id: "OP-MOB-002",
+    title: "Quick Approvals & Comments (Mobile)",
+    description: "As a user, I want to approve and comment from my phone.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 6",
+      "Team: Mobile",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Approve/Reject on approvals",
+      "Comment composer with mentions",
+      "Offline queue for pending actions."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-07-04"),
+    sprintId: "phase-6",
+  },
+  {
+    id: "OP-OFF-001",
+    title: "Offline Create & Comment (Web/Mobile)",
+    description: "As a user, I want to create items and comment offline and have them sync later.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 6",
+      "Team: Platform",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Local queue persists across reload",
+      "Automatic retry on reconnect",
+      "Conflict resolution prompts."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-07-05"),
+    sprintId: "phase-6",
+  },
+  {
+    id: "OP-ADM-001",
+    title: "Sandbox & Config Promotion",
+    description: "As an Admin, I want a sandbox and promotion pipeline for workflows/templates.",
+    status: "ready",
+    priority: "urgent",
+    storyPoints: 8,
+    tags: [
+      "Phase 6",
+      "Team: Admin",
+      "Priority: P1"
+    ],
+    acceptanceCriteria: [
+      "Create sandbox env",
+      "Edit workflows/templates",
+      "Promote to prod with diff/approval",
+      "Version history retained."
+    ],
+    businessValue: 9,
+    effort: 8,
+    createdAt: new Date("2024-07-06"),
+    sprintId: "phase-6",
+  },
+  {
+    id: "OP-TEMP-001",
+    title: "Template Governance & Versioning",
+    description: "As a PMO, I want template versioning and publishing approvals.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 6",
+      "Team: Admin",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Templates have versions, changelog, owners",
+      "Publishing requires approval",
+      "Projects can pin to specific version."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-07-07"),
+    sprintId: "phase-6",
+  },
+  {
+    id: "OP-SCIM-001",
+    title: "SCIM Provisioning & Deprovisioning",
+    description: "As an Admin, I want automated user lifecycle with our IdP.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 6",
+      "Team: Admin",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "SCIM integration to create/update/deprovision users and teams",
+      "Deprovision revokes sessions within 1 minute."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-07-08"),
+    sprintId: "phase-6",
+  },
+  {
+    id: "OP-ANA-001",
+    title: "Operational Metrics & SLO Dashboard",
+    description: "As Engineering, I want SLO dashboards for API/UI health.",
+    status: "ready",
+    priority: "high",
+    storyPoints: 5,
+    tags: [
+      "Phase 6",
+      "Team: Platform",
+      "Priority: P2"
+    ],
+    acceptanceCriteria: [
+      "Define SLOs (availability/latency/error rate)",
+      "Display burn-rate alerts",
+      "Export incidents linked to SLO breaches."
+    ],
+    businessValue: 7,
+    effort: 6,
+    createdAt: new Date("2024-07-09"),
+    sprintId: "phase-6",
+  }
+];
+
+export default enterpriseBacklog;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -14,3 +14,21 @@ if (!globalThis.ResizeObserver) {
     writable: true,
   });
 }
+
+const randomUUID = () => `test-uuid-${Math.random().toString(16).slice(2)}`;
+
+if (!globalThis.crypto) {
+  Object.defineProperty(globalThis, "crypto", {
+    value: {
+      getRandomValues: <T extends ArrayBufferView>(array: T) => array,
+      randomUUID,
+      subtle: {} as SubtleCrypto,
+    } as unknown as Crypto,
+    configurable: true,
+  });
+} else if (!globalThis.crypto.randomUUID) {
+  Object.defineProperty(globalThis.crypto, "randomUUID", {
+    value: randomUUID,
+    configurable: true,
+  });
+}

--- a/src/types/backlog.ts
+++ b/src/types/backlog.ts
@@ -5,6 +5,7 @@ export interface BacklogItem {
   status: "new" | "refined" | "estimated" | "ready" | "in_sprint";
   priority: "low" | "medium" | "high" | "urgent";
   storyPoints?: number;
+  timeEstimateHours?: number;
   assignee?: {
     name: string;
     avatar?: string;
@@ -16,4 +17,13 @@ export interface BacklogItem {
   effort: number;
   createdAt: Date;
   sprintId?: string;
+  rank?: number;
+  history?: BacklogHistoryEntry[];
+}
+
+export interface BacklogHistoryEntry {
+  id: string;
+  timestamp: string;
+  type: "rank_change" | "status_change" | "estimate_update" | "story_points_update" | "moved_to_sprint";
+  detail: string;
 }


### PR DESCRIPTION
## Summary
- introduce Slack, Release, and Marketing providers and extend operations logic for handoffs and workflow gating
- enhance backlog data and UI with ranking, history, and inline estimate editing and rebuild the sprint planning interface with capacity controls
- add unit tests covering the new providers and go-live task creation

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ced1136e208327aff2f760907ff1a8