### PR TITLE
Enable Google SSO feature flag

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -3,7 +3,7 @@
  * All flags default to false so new functionality can ship safely.
  */
 export const enableOutpagedBrand = true;
-export const enableGoogleSSO = false;
+export const enableGoogleSSO = true;
 export const enableDomainAllowlist = false;
 export const enableTeamsAndRoles = false;
 export const enableWorkflowEngine = false;


### PR DESCRIPTION
## Summary
- enable the Google single sign-on feature flag so the login button is available when Supabase is configured

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cef1396120832786c7e0e808185cdf