### PR TITLE
Fix project routing to use stable IDs and add detail loading states

### DIFF
--- a/src/pages/__tests__/ProjectDetails.test.tsx
+++ b/src/pages/__tests__/ProjectDetails.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import ProjectDetails from "../ProjectDetails";
+
+jest.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: jest.fn(),
+  },
+}));
+
+const { supabase } = jest.requireMock("@/integrations/supabase/client") as {
+  supabase: { from: jest.Mock };
+};
+
+jest.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "user-1" } }),
+}));
+
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+jest.mock("@/lib/featureFlags", () => ({
+  enableOutpagedBrand: false,
+}));
+
+describe("ProjectDetails", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("fetches a project by id", async () => {
+    const mockProject = {
+      id: "project-456",
+      name: "Important Project",
+      status: "active",
+      created_at: new Date().toISOString(),
+      description: "A test project",
+      end_date: null,
+    };
+
+    const maybeSingleMock = jest.fn().mockResolvedValue({ data: mockProject, error: null });
+    const projectEqMock = jest.fn(() => ({ maybeSingle: maybeSingleMock }));
+    const projectSelectMock = jest.fn(() => ({ eq: projectEqMock }));
+
+    const tasksOrderMock = jest.fn().mockResolvedValue({ data: [], error: null });
+    const tasksEqMock = jest.fn(() => ({ order: tasksOrderMock }));
+    const tasksSelectMock = jest.fn(() => ({ eq: tasksEqMock }));
+
+    const membersEqMock = jest.fn().mockResolvedValue({ data: [], error: null });
+    const membersSelectMock = jest.fn(() => ({ eq: membersEqMock }));
+
+    supabase.from.mockImplementation((table: string) => {
+      if (table === "projects") {
+        return { select: projectSelectMock };
+      }
+      if (table === "tasks") {
+        return { select: tasksSelectMock };
+      }
+      if (table === "project_members") {
+        return { select: membersSelectMock };
+      }
+      return { select: jest.fn() };
+    });
+
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ProjectDetails overrideProjectId={mockProject.id} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => expect(screen.getByText(mockProject.name)).toBeInTheDocument());
+
+    expect(projectEqMock).toHaveBeenCalledWith("id", mockProject.id);
+    expect(maybeSingleMock).toHaveBeenCalled();
+  });
+});

--- a/src/pages/__tests__/Projects.test.tsx
+++ b/src/pages/__tests__/Projects.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Projects from "../Projects";
+
+jest.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: jest.fn(),
+  },
+}));
+
+const { supabase } = jest.requireMock("@/integrations/supabase/client") as {
+  supabase: { from: jest.Mock };
+};
+
+jest.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "user-1" } }),
+}));
+
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+describe("Projects", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders project links using the project id", async () => {
+    const mockProjects = [
+      {
+        id: "project-123",
+        name: "Demo Project",
+        status: "active",
+        created_at: new Date().toISOString(),
+        description: null,
+        end_date: null,
+        code: null,
+      },
+    ];
+
+    const orderMock = jest.fn().mockResolvedValue({ data: mockProjects, error: null });
+    const selectMock = jest.fn(() => ({ order: orderMock }));
+
+    supabase.from.mockImplementation((table: string) => {
+      if (table === "projects") {
+        return { select: selectMock };
+      }
+      return { select: jest.fn() };
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/dashboard/projects"]}>
+        <Projects />
+      </MemoryRouter>
+    );
+
+    const link = await waitFor(() => screen.getByTestId(`project-link-${mockProjects[0].id}`));
+
+    expect(link).toHaveAttribute("href", `/dashboard/projects/${mockProjects[0].id}`);
+    expect(selectMock).toHaveBeenCalledWith("id, name, code, description, status, created_at, end_date");
+  });
+});


### PR DESCRIPTION
## Summary
- update project navigation helpers and list page links to always route by project id
- load project details with React Query, providing explicit loading, error, and not-found states
- add regression tests covering project link generation and detail fetching filters

## Testing
- npm test -- --runTestsByPath src/pages/__tests__/Projects.test.tsx src/pages/__tests__/ProjectDetails.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e26437218483278978fe9f2a2ce4c5