### PR TITLE
feat: replace navigation with role-aware IA layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,59 +3,18 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 import { AuthProvider } from "./hooks/useAuth";
 import { SecurityProvider } from "./components/security/SecurityProvider";
 import { AccessibilityProvider } from "./components/accessibility/AccessibilityProvider";
 import { OperationsProvider } from "./components/operations/OperationsProvider";
-import { AuthRedirect } from "./components/AuthRedirect";
 import { CommandPalette } from "./components/advanced-ux/CommandPalette";
 import { KeyboardShortcuts } from "./components/advanced-ux/KeyboardShortcuts";
-import { EnterpriseControlPanel } from "./components/enterprise/EnterpriseControlPanel";
-import { AdminGuard } from "./components/security/AdminGuard";
-import { SecurityDashboard } from "./components/security/SecurityDashboard";
-import { ProjectDetailsResolver } from "./components/projects/ProjectDetailsResolver";
-import { ProjectSettingsResolver } from "./components/projects/ProjectSettingsResolver";
-import { ErrorBoundary } from "./components/ui/error-boundary";
-import TaskView from "./pages/TaskView";
-import Dashboard from "./pages/Dashboard";
-import Projects from "./pages/Projects";
-import Profile from "./pages/Profile";
-import Tasks from "./pages/Tasks";
-import KanbanBoard from "./pages/KanbanBoard";
-import TeamDirectory from "./pages/TeamDirectory";
-import { TeamMemberHandler } from "./components/team/TeamMemberHandler";
-import Backlog from "./pages/Backlog";
-import Tickets from "./pages/Tickets";
-import SprintPlanning from "./pages/SprintPlanning";
-import Roadmap from "./pages/Roadmap";
-import Notifications from "./pages/Notifications";
-import TimeAnalytics from "./pages/TimeAnalytics";
-import Reports from "./pages/Reports";
-import ProjectTemplates from "./pages/ProjectTemplates";
-import Settings from "./pages/Settings";
-import Search from "./pages/Search";
-import Automation from "./pages/Automation";
-import Analytics from "./pages/Analytics";
-import Login from "./pages/Login";
-import AuthCallback from "./pages/AuthCallback";
-import NotFound from "./pages/NotFound";
-import OperationsCenter from "./pages/OperationsCenter";
-import WorkflowManagement from "./pages/WorkflowManagement";
-import Portfolio from "./pages/Portfolio";
-import Planning from "./pages/Planning";
-import Integrations from "./pages/Integrations";
-import Documents from "./pages/Documents";
-import MobileView from "./pages/MobileView";
-import AdminCenter from "./pages/AdminCenter";
-import Performance from "./pages/Performance";
-import SecurityCompliance from "./pages/SecurityCompliance";
-import QualityAssurance from "./pages/QualityAssurance";
 import { OutpagedThemeProvider } from "./components/theme/OutpagedThemeProvider";
-import AppShell from "./layouts/AppShell";
 import { SlackProvider } from "./components/integrations/SlackProvider";
 import { ReleaseProvider } from "./components/releases/ReleaseProvider";
 import { MarketingProvider } from "./components/marketing/MarketingProvider";
+import { AppRoutes } from "./routes";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -83,101 +42,15 @@ const App = () => (
               <ReleaseProvider>
                 <OperationsProvider>
                   <MarketingProvider>
-                    <ErrorBoundary>
-                      <TooltipProvider>
-                        <Toaster />
-                        <Sonner />
-                        <BrowserRouter>
-                          <CommandPalette />
-                          <KeyboardShortcuts />
-                          <Routes>
-                            {/* Public routes */}
-                            <Route path="/login" element={<Login />} handle={{ public: true }} />
-                            <Route path="/auth" element={<Navigate to="/login" replace />} handle={{ public: true }} />
-                            <Route path="/auth/callback" element={<AuthCallback />} handle={{ public: true }} />
-                            <Route path="/" element={<AuthRedirect />} handle={{ public: true }} />
-
-                            {/* Protected routes with layout */}
-                            <Route path="/dashboard" element={<AppShell />}>
-                              <Route index element={<Dashboard />} />
-                              <Route path="projects" element={<Projects />} />
-                              <Route path="projects/:projectId" element={<ProjectDetailsResolver />} />
-                              <Route path="projects/:projectId/settings" element={<ProjectSettingsResolver />} />
-                              <Route path="projects/code/:code" element={<ProjectDetailsResolver />} />
-                              <Route path="projects/code/:code/settings" element={<ProjectSettingsResolver />} />
-                              <Route path="projects/code/:code/tasks/:taskNumber" element={<TaskView />} />
-                              <Route path="projects/:projectId/tasks/:taskNumber" element={<TaskView />} />
-                              <Route path="profile" element={<Profile />} />
-                              <Route path="tasks" element={<Tasks />} />
-                              <Route path="board" element={<KanbanBoard />} />
-                              <Route path="backlog" element={<Backlog />} />
-                              <Route path="sprints" element={<SprintPlanning />} />
-                              <Route path="roadmap" element={<Roadmap />} />
-                              <Route path="notifications" element={<Notifications />} />
-                              <Route path="analytics" element={<Analytics />} />
-                              <Route path="reports" element={<Reports />} />
-                              <Route path="templates" element={<ProjectTemplates />} />
-                              <Route path="automation" element={<Automation />} />
-                              <Route path="workflows" element={<WorkflowManagement />} />
-                              <Route path="planning" element={<Planning />} />
-                              <Route path="integrations" element={<Integrations />} />
-                              <Route path="documents" element={<Documents />} />
-                              <Route path="portfolio" element={<Portfolio />} />
-                              <Route path="search" element={<Search />} />
-                              <Route path="settings" element={<Settings />} />
-                              <Route path="team" element={<TeamDirectory />} />
-                              <Route path="team/:identifier" element={<TeamMemberHandler />} />
-                              <Route path="tickets" element={<Tickets />} />
-                              <Route
-                                path="security"
-                                element={
-                                  <AdminGuard>
-                                    <SecurityCompliance />
-                                  </AdminGuard>
-                                }
-                              />
-                              <Route
-                                path="enterprise"
-                                element={
-                                  <AdminGuard>
-                                    <EnterpriseControlPanel />
-                                  </AdminGuard>
-                                }
-                              />
-                              <Route
-                                path="admin"
-                                element={
-                                  <AdminGuard>
-                                    <AdminCenter />
-                                  </AdminGuard>
-                                }
-                              />
-                              <Route
-                                path="performance"
-                                element={
-                                  <AdminGuard>
-                                    <Performance />
-                                  </AdminGuard>
-                                }
-                              />
-                              <Route
-                                path="qa"
-                                element={
-                                  <AdminGuard>
-                                    <QualityAssurance />
-                                  </AdminGuard>
-                                }
-                              />
-                              <Route path="operations" element={<OperationsCenter />} />
-                              <Route path="mobile" element={<MobileView />} />
-                            </Route>
-
-                            {/* Catch-all route */}
-                            <Route path="*" element={<NotFound />} handle={{ public: true }} />
-                          </Routes>
-                        </BrowserRouter>
-                      </TooltipProvider>
-                    </ErrorBoundary>
+                    <TooltipProvider>
+                      <Toaster />
+                      <Sonner />
+                      <BrowserRouter>
+                        <CommandPalette />
+                        <KeyboardShortcuts />
+                        <AppRoutes />
+                      </BrowserRouter>
+                    </TooltipProvider>
                   </MarketingProvider>
                 </OperationsProvider>
               </ReleaseProvider>

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import { Component, ErrorInfo, ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {
+    hasError: false,
+  };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("App crashed", error, info);
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: undefined });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
+          <div>
+            <h1 className="text-2xl font-semibold">Something went wrong</h1>
+            <p className="mt-2 max-w-lg text-muted-foreground">
+              {this.state.error?.message ?? "We hit an unexpected error. Try refreshing or contact your admin."}
+            </p>
+          </div>
+          <Button onClick={this.handleReset}>Try again</Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/common/TabBar.tsx
+++ b/src/components/common/TabBar.tsx
@@ -1,0 +1,77 @@
+import { useMemo, useRef } from "react";
+import { NavLink, useLocation, useParams } from "react-router-dom";
+import { cn } from "@/lib/utils";
+
+export const PROJECT_TABS = [
+  { label: "Overview", path: "overview" },
+  { label: "List", path: "list" },
+  { label: "Board", path: "board" },
+  { label: "Backlog", path: "backlog" },
+  { label: "Sprints", path: "sprints" },
+  { label: "Calendar", path: "calendar" },
+  { label: "Timeline", path: "timeline" },
+  { label: "Dependencies", path: "dependencies" },
+  { label: "Reports", path: "reports" },
+  { label: "Docs", path: "docs" },
+  { label: "Files", path: "files" },
+  { label: "Automations", path: "automations" },
+  { label: "Settings", path: "settings" },
+] as const;
+
+export function TabBar() {
+  const { id } = useParams();
+  const location = useLocation();
+  const tabRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+
+  const tabItems = useMemo(() => PROJECT_TABS.map((tab) => ({ ...tab })), []);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLAnchorElement>, index: number) => {
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      const next = tabRefs.current[(index + 1) % tabItems.length];
+      next?.focus();
+    }
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      const prev = tabRefs.current[(index - 1 + tabItems.length) % tabItems.length];
+      prev?.focus();
+    }
+  };
+
+  return (
+    <nav className="overflow-x-auto" role="tablist" aria-label="Project navigation">
+      <div className="flex min-w-max gap-1 rounded-md border bg-background p-1">
+        {tabItems.map((tab, index) => {
+          const projectId = id ?? "";
+          const tabPath = `/projects/${projectId}/${tab.path}`;
+          const isActive =
+            location.pathname === tabPath ||
+            (tab.path === "overview" && location.pathname === `/projects/${projectId}`);
+
+          return (
+            <NavLink
+              key={tab.path}
+              to={tabPath}
+              ref={(el) => {
+                tabRefs.current[index] = el;
+              }}
+              onKeyDown={(event) => handleKeyDown(event, index)}
+              role="tab"
+              aria-selected={isActive}
+              className={({ isActive: navActive }) =>
+                cn(
+                  "flex items-center rounded-sm px-3 py-1.5 text-sm font-medium outline-none transition",
+                  navActive || isActive
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                )
+              }
+            >
+              {tab.label}
+            </NavLink>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { AppLayout } from "./AppLayout";
+import HomePage from "@/pages/ia/HomePage";
+import ProjectsPage from "@/pages/ia/ProjectsPage";
+import HelpPage from "@/pages/ia/HelpPage";
+
+describe("AppLayout", () => {
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  const renderWithRoute = (initialEntry: string) =>
+    render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/" element={<AppLayout />}>
+            <Route index element={<HomePage />} />
+            <Route path="projects" element={<ProjectsPage />} />
+            <Route path="help" element={<HelpPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+  it("renders the home page content", () => {
+    renderWithRoute("/");
+    expect(screen.getByRole("heading", { name: "Home" })).toBeInTheDocument();
+  });
+
+  it("renders secondary routes without crashing", () => {
+    renderWithRoute("/projects");
+    expect(screen.getByRole("heading", { name: "Projects" })).toBeInTheDocument();
+
+    renderWithRoute("/help");
+    expect(screen.getByRole("heading", { name: "Help" })).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,37 +1,80 @@
+import { useCallback, useEffect, useState } from "react";
 import { Outlet } from "react-router-dom";
-import { SidebarProvider } from "@/components/ui/sidebar";
-import { AppSidebar } from "./AppSidebar";
-import { AppHeader } from "./AppHeader";
-import { OnboardingFlow } from "@/components/onboarding/OnboardingFlow";
-import { enableOutpagedBrand } from "@/lib/featureFlags";
+import { Sidebar } from "./Sidebar";
+import { Topbar } from "./Topbar";
+import { BadgesProvider } from "@/state/badges";
+import { cn } from "@/lib/utils";
+
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia("(max-width: 1023px)").matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handler = () => setIsMobile(window.matchMedia("(max-width: 1023px)").matches);
+    window.addEventListener("resize", handler);
+    return () => window.removeEventListener("resize", handler);
+  }, []);
+
+  return isMobile;
+}
 
 export function AppLayout() {
-  if (enableOutpagedBrand) {
-    return (
-      <SidebarProvider>
-        <div className="min-h-screen bg-[hsl(var(--background))] text-[hsl(var(--foreground))]">
-          <AppHeader />
-          <main className="mx-auto w-full max-w-6xl px-6 pb-[max(env(safe-area-inset-bottom),theme(spacing.10))] pt-10">
-            <Outlet />
-          </main>
-        </div>
-        <OnboardingFlow />
-      </SidebarProvider>
-    );
-  }
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isMobileOpen, setIsMobileOpen] = useState(false);
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    if (!isMobile) {
+      setIsMobileOpen(false);
+    }
+  }, [isMobile]);
+
+  const toggleSidebar = useCallback(() => {
+    if (isMobile) {
+      setIsMobileOpen((open) => !open);
+    } else {
+      setIsCollapsed((value) => !value);
+    }
+  }, [isMobile]);
+
+  const closeMobile = useCallback(() => setIsMobileOpen(false), []);
 
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-background">
-        <AppSidebar />
-        <div className="flex-1 flex flex-col min-w-0">
-          <AppHeader />
-          <main className="flex-1 p-4 sm:p-6 overflow-auto pb-[max(env(safe-area-inset-bottom),theme(spacing.4))] supports-[height:100svh]:min-h-[calc(100svh-4rem)]">
+    <BadgesProvider>
+      <div className="flex min-h-screen w-full bg-background">
+        <div className={cn("hidden lg:flex", isCollapsed ? "w-[72px]" : "w-[280px]")}>
+          <Sidebar isCollapsed={isCollapsed} onCollapseToggle={toggleSidebar} />
+        </div>
+
+        {isMobileOpen && (
+          <div className="fixed inset-0 z-50 flex lg:hidden">
+            <button
+              type="button"
+              className="absolute inset-0 bg-black/40"
+              onClick={closeMobile}
+              aria-label="Close navigation"
+            />
+            <div className="relative h-full w-[280px]">
+              <Sidebar
+                isCollapsed={false}
+                onCollapseToggle={toggleSidebar}
+                onNavigate={closeMobile}
+                className="h-full w-full bg-background shadow-xl"
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="flex flex-1 flex-col">
+          <Topbar onToggleSidebar={toggleSidebar} />
+          <main className="flex-1 overflow-y-auto bg-muted/20 p-6">
             <Outlet />
           </main>
         </div>
       </div>
-      <OnboardingFlow />
-    </SidebarProvider>
+    </BadgesProvider>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,147 @@
+import { useMemo, useRef } from "react";
+import { NavLink, useLocation } from "react-router-dom";
+import { cn } from "@/lib/utils";
+import { getNavForRole, type NavItem } from "@/lib/navConfig";
+import { getCurrentUser, type Role } from "@/lib/auth";
+import { useBadges } from "@/state/badges";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+type SidebarProps = {
+  isCollapsed: boolean;
+  onCollapseToggle: () => void;
+  onNavigate?: () => void;
+  className?: string;
+};
+
+export function Sidebar({ isCollapsed, onCollapseToggle, onNavigate, className }: SidebarProps) {
+  const user = getCurrentUser();
+  const role: Role = user?.role ?? "viewer";
+  const navItems = useMemo(() => getNavForRole(role), [role]);
+  const { inboxCount, myWorkCount } = useBadges();
+  const badgeCounts = { inboxCount, myWorkCount } as const;
+  const location = useLocation();
+  const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+
+  const flattened = useMemo(() => {
+    const acc: Array<{ item: NavItem; depth: number }> = [];
+    const walk = (items: NavItem[], depth: number) => {
+      items.forEach((item) => {
+        acc.push({ item, depth });
+        if (item.children) {
+          walk(item.children, depth + 1);
+        }
+      });
+    };
+    walk(navItems, 0);
+    return acc;
+  }, [navItems]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLAnchorElement>, index: number) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      const next = itemRefs.current[index + 1] ?? itemRefs.current[0];
+      next?.focus();
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      const prev = itemRefs.current[index - 1] ?? itemRefs.current[itemRefs.current.length - 1];
+      prev?.focus();
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      event.currentTarget.click();
+    }
+  };
+
+  const renderNavItem = (item: NavItem, index: number, depth = 0) => {
+    const isActive = location.pathname === item.path || location.pathname.startsWith(`${item.path}/`);
+    const badgeValue = item.badgeKey ? badgeCounts[item.badgeKey] : 0;
+    const showBadge = item.badgeKey ? badgeValue > 0 : false;
+
+    const content = (
+      <NavLink
+        key={item.id}
+        to={item.path}
+        ref={(el) => {
+          itemRefs.current[index] = el;
+        }}
+        onClick={onNavigate}
+        onKeyDown={(event) => handleKeyDown(event, index)}
+        className={({ isActive: navActive }) =>
+          cn(
+            "group relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium outline-none transition", // base
+            "focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring",
+            depth > 0 && !isCollapsed ? "ml-6" : "",
+            navActive || isActive
+              ? "bg-primary/10 font-semibold text-primary"
+              : "text-muted-foreground hover:bg-muted hover:text-foreground",
+            isCollapsed ? "justify-center px-0" : ""
+          )
+        }
+        aria-current={isActive ? "page" : undefined}
+      >
+        {item.icon}
+        {!isCollapsed && <span className="truncate">{item.label}</span>}
+        {showBadge && (
+          <span className="ml-auto inline-flex min-w-[1.5rem] justify-center rounded-full bg-primary/10 px-2 text-xs font-semibold text-primary">
+            {badgeValue}
+          </span>
+        )}
+        {isActive && (
+          <span
+            aria-hidden="true"
+            className="absolute left-0 top-1/2 h-8 w-0.5 -translate-y-1/2 rounded-full bg-primary"
+          />
+        )}
+      </NavLink>
+    );
+
+    if (isCollapsed) {
+      return (
+        <Tooltip key={item.id} delayDuration={200}>
+          <TooltipTrigger asChild>{content}</TooltipTrigger>
+          <TooltipContent side="right" align="center" className="max-w-[200px]">
+            {item.label}
+          </TooltipContent>
+        </Tooltip>
+      );
+    }
+
+    return <div key={item.id}>{content}</div>;
+  };
+
+  return (
+    <aside
+      className={cn(
+        "flex h-full flex-col border-r bg-background p-4 transition-all duration-200",
+        isCollapsed ? "w-[72px]" : "w-[280px]",
+        className
+      )}
+      role="navigation"
+      aria-label="Primary"
+    >
+      <div className={cn("flex items-center justify-between", isCollapsed && "justify-center")}>
+        {!isCollapsed && <p className="text-lg font-semibold">Workspace</p>}
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onCollapseToggle}
+          aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+        >
+          {isCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+        </Button>
+      </div>
+      <TooltipProvider delayDuration={200}>
+        <nav className="mt-6 flex-1 space-y-1" aria-label="Main navigation">
+          {flattened.map(({ item, depth }, index) => renderNavItem(item, index, depth))}
+        </nav>
+      </TooltipProvider>
+      {!isCollapsed && (
+        <div className="mt-auto pt-4 text-xs text-muted-foreground">
+          <p>Signed in as {user?.email ?? "Guest"}</p>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -1,0 +1,186 @@
+import { Fragment, useMemo, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Menu, Plus, Search } from "lucide-react";
+import { NAV } from "@/lib/navConfig";
+import { getCurrentUser } from "@/lib/auth";
+import { PROJECT_TABS } from "@/components/common/TabBar";
+
+function findNavLabel(path: string) {
+  const walk = (items = NAV): string | undefined => {
+    for (const item of items) {
+      if (item.path === path) {
+        return item.label;
+      }
+      if (item.children) {
+        const found = walk(item.children);
+        if (found) {
+          return found;
+        }
+      }
+    }
+    return undefined;
+  };
+
+  return walk();
+}
+
+function formatSegment(segment: string) {
+  return segment
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+type TopbarProps = {
+  onToggleSidebar: () => void;
+};
+
+export function Topbar({ onToggleSidebar }: TopbarProps) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const user = getCurrentUser();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const actions = useMemo(
+    () => [
+      { label: "New Project", path: "/projects/new" },
+      { label: "New Board", path: "/boards/new" },
+      { label: "New Task", path: "/tasks/new" },
+      { label: "New Dashboard", path: "/dashboards/new" },
+    ],
+    []
+  );
+
+  const breadcrumbs = useMemo(() => {
+    const segments = location.pathname.split("/").filter(Boolean);
+    if (segments.length === 0) {
+      return [{ label: "Home", href: "/" }];
+    }
+
+    const crumbs: Array<{ label: string; href: string }> = [];
+    let href = "";
+
+    segments.forEach((segment, index) => {
+      href += `/${segment}`;
+      let label = findNavLabel(href);
+
+      if (!label && segments[0] === "projects") {
+        if (index === 1) {
+          label = `Project ${segment}`;
+        } else if (index > 1) {
+          label = PROJECT_TABS.find((tab) => tab.path === segment)?.label ?? formatSegment(segment);
+        }
+      }
+
+      if (!label) {
+        label = formatSegment(segment);
+      }
+
+      crumbs.push({ label, href });
+    });
+
+    return [{ label: "Home", href: "/" }, ...crumbs];
+  }, [location.pathname]);
+
+  const handleAction = (path: string) => {
+    setIsDialogOpen(false);
+    navigate(path);
+  };
+
+  const canCreate = user?.role !== "viewer";
+
+  return (
+    <header className="flex h-14 items-center gap-4 border-b bg-background px-4">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" onClick={onToggleSidebar} aria-label="Toggle navigation">
+          <Menu className="h-5 w-5" />
+        </Button>
+        <Breadcrumb>
+          <BreadcrumbList>
+            {breadcrumbs.map((crumb, index) => (
+              <Fragment key={crumb.href}>
+                <BreadcrumbItem>
+                  {index === breadcrumbs.length - 1 ? (
+                    <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+                  ) : (
+                    <BreadcrumbLink href={crumb.href}>{crumb.label}</BreadcrumbLink>
+                  )}
+                </BreadcrumbItem>
+                {index < breadcrumbs.length - 1 && <BreadcrumbSeparator />}
+              </Fragment>
+            ))}
+          </BreadcrumbList>
+        </Breadcrumb>
+      </div>
+
+      <div className="mx-auto hidden w-full max-w-xl items-center gap-2 md:flex">
+        <Search className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+        <Input placeholder="Search tasks, projects, and people" className="border-0 shadow-none focus-visible:ring-0" />
+      </div>
+
+      <div className="ml-auto flex items-center gap-2">
+        {canCreate && (
+          <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+            <DialogTrigger asChild>
+              <Button className="gap-2">
+                <Plus className="h-4 w-4" />
+                Create
+              </Button>
+            </DialogTrigger>
+            <DialogContent aria-describedby={undefined}>
+              <DialogHeader>
+                <DialogTitle>Quick create</DialogTitle>
+              </DialogHeader>
+              <div className="grid gap-2">
+                {actions.map((action) => (
+                  <Button key={action.path} variant="outline" className="justify-start" onClick={() => handleAction(action.path)}>
+                    {action.label}
+                  </Button>
+                ))}
+              </div>
+            </DialogContent>
+          </Dialog>
+        )}
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" className="gap-2">
+              <Avatar className="h-8 w-8">
+                <AvatarFallback>{user?.email?.charAt(0).toUpperCase() ?? "U"}</AvatarFallback>
+              </Avatar>
+              <span className="hidden text-sm font-medium sm:inline">{user?.email ?? "Guest"}</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuLabel>Account</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => navigate("/profile")}>Profile</DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => navigate("/settings")}>Settings</DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => navigate("/logout")}>Sign out</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </header>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,18 @@
+export type Role = "admin" | "manager" | "member" | "viewer";
+
+export type User = {
+  id: string;
+  email: string;
+  role: Role;
+};
+
+const MOCK_USER: User = {
+  id: "user-1",
+  email: "casey.manager@example.com",
+  role: "manager",
+};
+
+export function getCurrentUser(): User | null {
+  // TODO: Replace with Supabase session lookup
+  return MOCK_USER;
+}

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,7 +1,16 @@
-/**
- * Centralized feature flags for OutPaged migration work.
- * All flags default to false so new functionality can ship safely.
- */
+export const FEATURE_FLAGS = {
+  dashboards: true,
+  automations: true,
+  integrations: true,
+  forms: true,
+  goals: true,
+  timeTracking: true,
+  apiExplorer: true,
+} as const;
+
+export type FeatureFlagKey = keyof typeof FEATURE_FLAGS;
+
+// Legacy flags kept for backward compatibility with existing modules.
 export const enableOutpagedBrand = true;
 export const enableGoogleSSO = true;
 export const enableDomainAllowlist = false;

--- a/src/lib/navConfig.test.ts
+++ b/src/lib/navConfig.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "@jest/globals";
+import { NAV, getNavForRole } from "./navConfig";
+
+const TOP_LEVEL_IDS = [
+  "home",
+  "my-work",
+  "inbox",
+  "projects",
+  "boards",
+  "calendar",
+  "timeline",
+  "workload",
+  "dashboards",
+  "reports",
+  "docs",
+  "files",
+  "automations",
+  "integrations",
+  "forms",
+  "goals",
+  "templates",
+  "people",
+  "time",
+  "admin",
+  "help",
+];
+
+describe("navConfig", () => {
+  it("contains the expected top-level item order", () => {
+    const ids = NAV.map((item) => item.id);
+    expect(ids).toEqual(TOP_LEVEL_IDS);
+  });
+
+  it("hides admin entries for managers", () => {
+    const managerNav = getNavForRole("manager");
+    const topLevelIds = managerNav.map((item) => item.id);
+
+    expect(topLevelIds).not.toContain("admin");
+    expect(topLevelIds).toContain("projects");
+  });
+
+  it("excludes member-only areas for viewers", () => {
+    const viewerNav = getNavForRole("viewer");
+    const topLevelIds = viewerNav.map((item) => item.id);
+
+    expect(topLevelIds).toContain("home");
+    expect(topLevelIds).not.toContain("my-work");
+  });
+});

--- a/src/lib/navConfig.tsx
+++ b/src/lib/navConfig.tsx
@@ -1,0 +1,293 @@
+import { ReactNode } from "react";
+import {
+  Archive,
+  BadgeCheck,
+  BarChart3,
+  BookText,
+  Briefcase,
+  Building2,
+  CalendarDays,
+  ClipboardList,
+  Clock3,
+  CreditCard,
+  Files,
+  FolderGit2,
+  GaugeCircle,
+  HelpCircle,
+  Inbox,
+  Layers3,
+  LayoutDashboard,
+  LineChart,
+  ListChecks,
+  ListTodo,
+  Network,
+  PieChart,
+  Settings,
+  Share2,
+  SquareStack,
+  Target,
+  Users,
+  Workflow,
+  ShieldCheck,
+} from "lucide-react";
+
+import { FEATURE_FLAGS } from "./featureFlags";
+import { Role } from "./auth";
+
+export type BadgeKey = "inboxCount" | "myWorkCount";
+
+export type NavItem = {
+  id: string;
+  label: string;
+  path: string;
+  icon?: ReactNode;
+  roles?: Role[];
+  featureFlag?: keyof typeof FEATURE_FLAGS;
+  badgeKey?: BadgeKey;
+  children?: NavItem[];
+};
+
+const ALL_ROLES: Role[] = ["admin", "manager", "member", "viewer"];
+const COLLAB_ROLES: Role[] = ["admin", "manager", "member"];
+const LEADERSHIP_ROLES: Role[] = ["admin", "manager"];
+
+export const NAV: NavItem[] = [
+  {
+    id: "home",
+    label: "Home",
+    path: "/",
+    icon: <LayoutDashboard className="h-5 w-5" aria-hidden="true" />,
+    roles: ALL_ROLES,
+  },
+  {
+    id: "my-work",
+    label: "My Work",
+    path: "/my-work",
+    icon: <ListTodo className="h-5 w-5" aria-hidden="true" />,
+    roles: COLLAB_ROLES,
+    badgeKey: "myWorkCount",
+  },
+  {
+    id: "inbox",
+    label: "Inbox",
+    path: "/inbox",
+    icon: <Inbox className="h-5 w-5" aria-hidden="true" />,
+    roles: ALL_ROLES,
+    badgeKey: "inboxCount",
+  },
+  {
+    id: "projects",
+    label: "Projects",
+    path: "/projects",
+    icon: <Briefcase className="h-5 w-5" aria-hidden="true" />,
+    roles: ALL_ROLES,
+  },
+  {
+    id: "boards",
+    label: "Boards",
+    path: "/boards",
+    icon: <Layers3 className="h-5 w-5" aria-hidden="true" />,
+    roles: ALL_ROLES,
+  },
+  {
+    id: "calendar",
+    label: "Calendar",
+    path: "/calendar",
+    icon: <CalendarDays className="h-5 w-5" aria-hidden="true" />,
+    roles: ALL_ROLES,
+  },
+  {
+    id: "timeline",
+    label: "Timeline",
+    path: "/timeline",
+    icon: <LineChart className="h-5 w-5" aria-hidden="true" />,
+    roles: ALL_ROLES,
+  },
+  {
+    id: "workload",
+    label: "Workload",
+    path: "/workload",
+    icon: <GaugeCircle className="h-5 w-5" aria-hidden="true" />,
+    roles: LEADERSHIP_ROLES,
+  },
+  {
+    id: "dashboards",
+    label: "Dashboards",
+    path: "/dashboards",
+    icon: <PieChart className="h-5 w-5" aria-hidden="true" />,
+    roles: LEADERSHIP_ROLES,
+    featureFlag: "dashboards",
+  },
+  {
+    id: "reports",
+    label: "Reports",
+    path: "/reports",
+    icon: <BarChart3 className="h-5 w-5" aria-hidden="true" />,
+    roles: ALL_ROLES,
+  },
+  {
+    id: "docs",
+    label: "Docs & Wiki",
+    path: "/docs",
+    icon: <BookText className="h-5 w-5" aria-hidden="true" />,
+    roles: ALL_ROLES,
+  },
+  {
+    id: "files",
+    label: "Files",
+    path: "/files",
+    icon: <Files className="h-5 w-5" aria-hidden="true" />,
+    roles: ALL_ROLES,
+  },
+  {
+    id: "automations",
+    label: "Automations",
+    path: "/automations",
+    icon: <Workflow className="h-5 w-5" aria-hidden="true" />,
+    roles: LEADERSHIP_ROLES,
+    featureFlag: "automations",
+  },
+  {
+    id: "integrations",
+    label: "Integrations",
+    path: "/integrations",
+    icon: <Share2 className="h-5 w-5" aria-hidden="true" />,
+    roles: LEADERSHIP_ROLES,
+    featureFlag: "integrations",
+  },
+  {
+    id: "forms",
+    label: "Forms",
+    path: "/forms",
+    icon: <ClipboardList className="h-5 w-5" aria-hidden="true" />,
+    roles: LEADERSHIP_ROLES,
+    featureFlag: "forms",
+  },
+  {
+    id: "goals",
+    label: "Goals & OKRs",
+    path: "/goals",
+    icon: <Target className="h-5 w-5" aria-hidden="true" />,
+    roles: ALL_ROLES,
+    featureFlag: "goals",
+  },
+  {
+    id: "templates",
+    label: "Templates",
+    path: "/templates",
+    icon: <SquareStack className="h-5 w-5" aria-hidden="true" />,
+    roles: ALL_ROLES,
+  },
+  {
+    id: "people",
+    label: "People & Teams",
+    path: "/people",
+    icon: <Users className="h-5 w-5" aria-hidden="true" />,
+    roles: LEADERSHIP_ROLES,
+  },
+  {
+    id: "time",
+    label: "Time Tracking",
+    path: "/time",
+    icon: <Clock3 className="h-5 w-5" aria-hidden="true" />,
+    roles: ALL_ROLES,
+    featureFlag: "timeTracking",
+  },
+  {
+    id: "admin",
+    label: "Admin",
+    path: "/admin",
+    icon: <Settings className="h-5 w-5" aria-hidden="true" />,
+    roles: ["admin"],
+    children: [
+      {
+        id: "admin-workspace",
+        label: "Workspace",
+        path: "/admin/workspace",
+        icon: <Building2 className="h-4 w-4" aria-hidden="true" />,
+        roles: ["admin"],
+      },
+      {
+        id: "admin-permissions",
+        label: "Permissions & Roles",
+        path: "/admin/permissions",
+        icon: <BadgeCheck className="h-4 w-4" aria-hidden="true" />,
+        roles: ["admin"],
+      },
+      {
+        id: "admin-security",
+        label: "Security",
+        path: "/admin/security",
+        icon: <ShieldCheck className="h-4 w-4" aria-hidden="true" />,
+        roles: ["admin"],
+      },
+      {
+        id: "admin-audit",
+        label: "Audit Logs",
+        path: "/admin/audit",
+        icon: <ListChecks className="h-4 w-4" aria-hidden="true" />,
+        roles: ["admin"],
+      },
+      {
+        id: "admin-data",
+        label: "Data & Backups",
+        path: "/admin/data",
+        icon: <Archive className="h-4 w-4" aria-hidden="true" />,
+        roles: ["admin"],
+      },
+      {
+        id: "admin-webhooks",
+        label: "Webhooks",
+        path: "/admin/webhooks",
+        icon: <Network className="h-4 w-4" aria-hidden="true" />,
+        roles: ["admin"],
+      },
+      {
+        id: "admin-api",
+        label: "API Explorer",
+        path: "/admin/api",
+        icon: <FolderGit2 className="h-4 w-4" aria-hidden="true" />,
+        roles: ["admin"],
+        featureFlag: "apiExplorer",
+      },
+      {
+        id: "admin-billing",
+        label: "Billing & Plans",
+        path: "/admin/billing",
+        icon: <CreditCard className="h-4 w-4" aria-hidden="true" />,
+        roles: ["admin"],
+      },
+    ],
+  },
+  {
+    id: "help",
+    label: "Help",
+    path: "/help",
+    icon: <HelpCircle className="h-5 w-5" aria-hidden="true" />,
+    roles: ALL_ROLES,
+  },
+];
+
+// TODO: Add favorites and pinning support once requirements are defined.
+
+function filterItems(items: NavItem[], role: Role): NavItem[] {
+  return items
+    .map((item) => {
+      if (item.roles && !item.roles.includes(role)) {
+        return null;
+      }
+      if (item.featureFlag && !FEATURE_FLAGS[item.featureFlag]) {
+        return null;
+      }
+      const children = item.children ? filterItems(item.children, role) : undefined;
+      if (children && children.length === 0 && item.children) {
+        return null;
+      }
+      return { ...item, children };
+    })
+    .filter((item): item is NavItem => Boolean(item));
+}
+
+export function getNavForRole(role: Role) {
+  return filterItems(NAV, role);
+}

--- a/src/pages/ia/AutomationsPage.tsx
+++ b/src/pages/ia/AutomationsPage.tsx
@@ -1,0 +1,11 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function AutomationsPage() {
+  return (
+    <PageTemplate
+      title="Automations"
+      description="Design rules, triggers, and actions to orchestrate team workflows."
+      featureFlag="automations"
+    />
+  );
+}

--- a/src/pages/ia/BoardsPage.tsx
+++ b/src/pages/ia/BoardsPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function BoardsPage() {
+  return (
+    <PageTemplate
+      title="Boards"
+      description="Track work across all projects in a unified Kanban view."
+    />
+  );
+}

--- a/src/pages/ia/CalendarPage.tsx
+++ b/src/pages/ia/CalendarPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function CalendarPage() {
+  return (
+    <PageTemplate
+      title="Calendar"
+      description="View every deadline, event, and handoff in a single calendar."
+    />
+  );
+}

--- a/src/pages/ia/DashboardsPage.tsx
+++ b/src/pages/ia/DashboardsPage.tsx
@@ -1,0 +1,11 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function DashboardsPage() {
+  return (
+    <PageTemplate
+      title="Dashboards"
+      description="Build curated dashboards with real-time metrics for leadership."
+      featureFlag="dashboards"
+    />
+  );
+}

--- a/src/pages/ia/DocsPage.tsx
+++ b/src/pages/ia/DocsPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function DocsPage() {
+  return (
+    <PageTemplate
+      title="Docs & Wiki"
+      description="Publish internal documentation, project briefs, and knowledge articles."
+    />
+  );
+}

--- a/src/pages/ia/FilesPage.tsx
+++ b/src/pages/ia/FilesPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function FilesPage() {
+  return (
+    <PageTemplate
+      title="Files"
+      description="Browse workspace files with filters, permissions, and version history."
+    />
+  );
+}

--- a/src/pages/ia/FormsPage.tsx
+++ b/src/pages/ia/FormsPage.tsx
@@ -1,0 +1,11 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function FormsPage() {
+  return (
+    <PageTemplate
+      title="Forms"
+      description="Collect requests, support tickets, and intake information with shareable forms."
+      featureFlag="forms"
+    />
+  );
+}

--- a/src/pages/ia/GoalsPage.tsx
+++ b/src/pages/ia/GoalsPage.tsx
@@ -1,0 +1,11 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function GoalsPage() {
+  return (
+    <PageTemplate
+      title="Goals & OKRs"
+      description="Align teams around shared objectives and measure progress in real time."
+      featureFlag="goals"
+    />
+  );
+}

--- a/src/pages/ia/HelpPage.tsx
+++ b/src/pages/ia/HelpPage.tsx
@@ -1,0 +1,21 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function HelpPage() {
+  return (
+    <PageTemplate
+      title="Help"
+      description="Access documentation, keyboard shortcuts, and support resources."
+    >
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="rounded-lg border bg-background p-4">
+          <h2 className="text-base font-semibold">Documentation</h2>
+          <p className="mt-2 text-sm text-muted-foreground">Deep dives, onboarding guides, and best practices.</p>
+        </div>
+        <div className="rounded-lg border bg-background p-4">
+          <h2 className="text-base font-semibold">Shortcuts</h2>
+          <p className="mt-2 text-sm text-muted-foreground">Learn power moves to navigate faster.</p>
+        </div>
+      </div>
+    </PageTemplate>
+  );
+}

--- a/src/pages/ia/HomePage.tsx
+++ b/src/pages/ia/HomePage.tsx
@@ -1,0 +1,31 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function HomePage() {
+  return (
+    <PageTemplate
+      title="Home"
+      description="Your personalized snapshot of projects, updates, and priorities across the workspace."
+    >
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <div className="rounded-lg border bg-background p-4 shadow-sm">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Today</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Review critical work and plan your day at a glance.
+          </p>
+        </div>
+        <div className="rounded-lg border bg-background p-4 shadow-sm">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Recent activity</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Track updates from boards, tasks, and teammates.
+          </p>
+        </div>
+        <div className="rounded-lg border bg-background p-4 shadow-sm">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Upcoming milestones</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Monitor the next deliverables across your projects.
+          </p>
+        </div>
+      </div>
+    </PageTemplate>
+  );
+}

--- a/src/pages/ia/InboxPage.tsx
+++ b/src/pages/ia/InboxPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function InboxPage() {
+  return (
+    <PageTemplate
+      title="Inbox"
+      description="Stay on top of mentions, approvals, and notifications as they happen."
+    />
+  );
+}

--- a/src/pages/ia/IntegrationsPage.tsx
+++ b/src/pages/ia/IntegrationsPage.tsx
@@ -1,0 +1,11 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function IntegrationsPage() {
+  return (
+    <PageTemplate
+      title="Integrations"
+      description="Connect Jira, GitHub, Slack, Google, and more to automate handoffs."
+      featureFlag="integrations"
+    />
+  );
+}

--- a/src/pages/ia/MyWorkPage.tsx
+++ b/src/pages/ia/MyWorkPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function MyWorkPage() {
+  return (
+    <PageTemplate
+      title="My Work"
+      description="See everything assigned to you, grouped by priority and due date."
+    />
+  );
+}

--- a/src/pages/ia/NewBoardPage.tsx
+++ b/src/pages/ia/NewBoardPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function NewBoardPage() {
+  return (
+    <PageTemplate
+      title="New Board"
+      description="Design a board layout, swimlanes, and automation recipes."
+    />
+  );
+}

--- a/src/pages/ia/NewDashboardPage.tsx
+++ b/src/pages/ia/NewDashboardPage.tsx
@@ -1,0 +1,11 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function NewDashboardPage() {
+  return (
+    <PageTemplate
+      title="New Dashboard"
+      description="Assemble widgets and data sources to monitor performance."
+      featureFlag="dashboards"
+    />
+  );
+}

--- a/src/pages/ia/NewProjectPage.tsx
+++ b/src/pages/ia/NewProjectPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function NewProjectPage() {
+  return (
+    <PageTemplate
+      title="New Project"
+      description="Spin up a new project space with templates, automations, and permissions."
+    />
+  );
+}

--- a/src/pages/ia/NewTaskPage.tsx
+++ b/src/pages/ia/NewTaskPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function NewTaskPage() {
+  return (
+    <PageTemplate
+      title="New Task"
+      description="Capture task details, ownership, and priority in seconds."
+    />
+  );
+}

--- a/src/pages/ia/PageTemplate.tsx
+++ b/src/pages/ia/PageTemplate.tsx
@@ -1,0 +1,39 @@
+import { ReactNode } from "react";
+import { FEATURE_FLAGS } from "@/lib/featureFlags";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+interface PageTemplateProps {
+  title: string;
+  description: string;
+  featureFlag?: keyof typeof FEATURE_FLAGS;
+  children?: ReactNode;
+}
+
+export function PageTemplate({ title, description, featureFlag, children }: PageTemplateProps) {
+  const isDisabled = featureFlag ? !FEATURE_FLAGS[featureFlag] : false;
+
+  return (
+    <section className="flex flex-col gap-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
+        <p className="text-muted-foreground">{description}</p>
+      </header>
+      {isDisabled ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <h2 className="text-xl font-semibold">Feature disabled</h2>
+          <p className="mt-2 text-muted-foreground">
+            This area is not available right now. Contact your admin if you need access.
+          </p>
+          <Button className="mt-4" variant="outline">
+            Contact admin
+          </Button>
+        </div>
+      ) : (
+        <div className={cn("rounded-lg border bg-background p-6", children ? "space-y-4" : "text-muted-foreground")}>
+          {children ?? "We are putting the finishing touches on this experience."}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/pages/ia/PeoplePage.tsx
+++ b/src/pages/ia/PeoplePage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function PeoplePage() {
+  return (
+    <PageTemplate
+      title="People & Teams"
+      description="Manage members, teams, roles, and capacity in one directory."
+    />
+  );
+}

--- a/src/pages/ia/ProjectsPage.tsx
+++ b/src/pages/ia/ProjectsPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function ProjectsPage() {
+  return (
+    <PageTemplate
+      title="Projects"
+      description="Browse every project in the workspace with flexible grouping and filters."
+    />
+  );
+}

--- a/src/pages/ia/ReportsPage.tsx
+++ b/src/pages/ia/ReportsPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function ReportsPage() {
+  return (
+    <PageTemplate
+      title="Reports"
+      description="Run ad-hoc reports and track key performance indicators."
+    />
+  );
+}

--- a/src/pages/ia/TemplatesPage.tsx
+++ b/src/pages/ia/TemplatesPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function TemplatesPage() {
+  return (
+    <PageTemplate
+      title="Templates"
+      description="Jumpstart work with reusable board, report, and automation templates."
+    />
+  );
+}

--- a/src/pages/ia/TimeTrackingPage.tsx
+++ b/src/pages/ia/TimeTrackingPage.tsx
@@ -1,0 +1,11 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function TimeTrackingPage() {
+  return (
+    <PageTemplate
+      title="Time Tracking"
+      description="Capture billable and non-billable time with timers and timesheets."
+      featureFlag="timeTracking"
+    />
+  );
+}

--- a/src/pages/ia/TimelinePage.tsx
+++ b/src/pages/ia/TimelinePage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function TimelinePage() {
+  return (
+    <PageTemplate
+      title="Timeline"
+      description="Understand cross-project delivery and highlight key phases and risks."
+    />
+  );
+}

--- a/src/pages/ia/WorkloadPage.tsx
+++ b/src/pages/ia/WorkloadPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "./PageTemplate";
+
+export default function WorkloadPage() {
+  return (
+    <PageTemplate
+      title="Workload"
+      description="Balance assignments across people and teams to prevent burnout."
+    />
+  );
+}

--- a/src/pages/ia/admin/AdminApiPage.tsx
+++ b/src/pages/ia/admin/AdminApiPage.tsx
@@ -1,0 +1,11 @@
+import { PageTemplate } from "../PageTemplate";
+
+export default function AdminApiPage() {
+  return (
+    <PageTemplate
+      title="API Explorer"
+      description="Test API calls, generate tokens, and monitor rate limits."
+      featureFlag="apiExplorer"
+    />
+  );
+}

--- a/src/pages/ia/admin/AdminAuditPage.tsx
+++ b/src/pages/ia/admin/AdminAuditPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "../PageTemplate";
+
+export default function AdminAuditPage() {
+  return (
+    <PageTemplate
+      title="Audit Logs"
+      description="Review changes across projects, users, and integrations for compliance."
+    />
+  );
+}

--- a/src/pages/ia/admin/AdminBillingPage.tsx
+++ b/src/pages/ia/admin/AdminBillingPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "../PageTemplate";
+
+export default function AdminBillingPage() {
+  return (
+    <PageTemplate
+      title="Billing & Plans"
+      description="View invoices, adjust seat counts, and manage payment methods."
+    />
+  );
+}

--- a/src/pages/ia/admin/AdminDataPage.tsx
+++ b/src/pages/ia/admin/AdminDataPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "../PageTemplate";
+
+export default function AdminDataPage() {
+  return (
+    <PageTemplate
+      title="Data & Backups"
+      description="Control exports, retention, and recovery for workspace data."
+    />
+  );
+}

--- a/src/pages/ia/admin/AdminHomePage.tsx
+++ b/src/pages/ia/admin/AdminHomePage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "../PageTemplate";
+
+export default function AdminHomePage() {
+  return (
+    <PageTemplate
+      title="Admin"
+      description="Configure workspace-level policies, security, and billing."
+    />
+  );
+}

--- a/src/pages/ia/admin/AdminPermissionsPage.tsx
+++ b/src/pages/ia/admin/AdminPermissionsPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "../PageTemplate";
+
+export default function AdminPermissionsPage() {
+  return (
+    <PageTemplate
+      title="Permissions & Roles"
+      description="Define custom roles, approval chains, and access policies."
+    />
+  );
+}

--- a/src/pages/ia/admin/AdminSecurityPage.tsx
+++ b/src/pages/ia/admin/AdminSecurityPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "../PageTemplate";
+
+export default function AdminSecurityPage() {
+  return (
+    <PageTemplate
+      title="Security"
+      description="Enforce SSO, SCIM, and security guardrails for your workspace."
+    />
+  );
+}

--- a/src/pages/ia/admin/AdminWebhooksPage.tsx
+++ b/src/pages/ia/admin/AdminWebhooksPage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "../PageTemplate";
+
+export default function AdminWebhooksPage() {
+  return (
+    <PageTemplate
+      title="Webhooks"
+      description="Configure outbound webhooks for updates, automation, and observability."
+    />
+  );
+}

--- a/src/pages/ia/admin/AdminWorkspacePage.tsx
+++ b/src/pages/ia/admin/AdminWorkspacePage.tsx
@@ -1,0 +1,10 @@
+import { PageTemplate } from "../PageTemplate";
+
+export default function AdminWorkspacePage() {
+  return (
+    <PageTemplate
+      title="Workspace"
+      description="Manage workspace details, regions, and collaboration defaults."
+    />
+  );
+}

--- a/src/pages/ia/projects/ProjectAutomationsPage.tsx
+++ b/src/pages/ia/projects/ProjectAutomationsPage.tsx
@@ -1,0 +1,31 @@
+import { FEATURE_FLAGS } from "@/lib/featureFlags";
+import { Button } from "@/components/ui/button";
+import { ProjectPageTemplate } from "./ProjectPageTemplate";
+
+export default function ProjectAutomationsPage() {
+  if (!FEATURE_FLAGS.automations) {
+    return (
+      <ProjectPageTemplate
+        title="Automations"
+        description="Create rules to automate repetitive work and keep teams aligned."
+      >
+        <div className="text-center">
+          <h2 className="text-xl font-semibold">Feature disabled</h2>
+          <p className="mt-2 text-muted-foreground">
+            Automations are turned off for this workspace. Ask your admin to enable them.
+          </p>
+          <Button className="mt-4" variant="outline">
+            Contact admin
+          </Button>
+        </div>
+      </ProjectPageTemplate>
+    );
+  }
+
+  return (
+    <ProjectPageTemplate
+      title="Automations"
+      description="Create rules to automate repetitive work and keep teams aligned."
+    />
+  );
+}

--- a/src/pages/ia/projects/ProjectBacklogPage.tsx
+++ b/src/pages/ia/projects/ProjectBacklogPage.tsx
@@ -1,0 +1,10 @@
+import { ProjectPageTemplate } from "./ProjectPageTemplate";
+
+export default function ProjectBacklogPage() {
+  return (
+    <ProjectPageTemplate
+      title="Backlog"
+      description="Groom upcoming work, capture ideas, and prepare for the next sprint."
+    />
+  );
+}

--- a/src/pages/ia/projects/ProjectBoardPage.tsx
+++ b/src/pages/ia/projects/ProjectBoardPage.tsx
@@ -1,0 +1,10 @@
+import { ProjectPageTemplate } from "./ProjectPageTemplate";
+
+export default function ProjectBoardPage() {
+  return (
+    <ProjectPageTemplate
+      title="Board"
+      description="Visualize work across columns and swimlanes to keep flow moving."
+    />
+  );
+}

--- a/src/pages/ia/projects/ProjectCalendarPage.tsx
+++ b/src/pages/ia/projects/ProjectCalendarPage.tsx
@@ -1,0 +1,10 @@
+import { ProjectPageTemplate } from "./ProjectPageTemplate";
+
+export default function ProjectCalendarPage() {
+  return (
+    <ProjectPageTemplate
+      title="Calendar"
+      description="Map tasks, milestones, and dependencies on a shared schedule."
+    />
+  );
+}

--- a/src/pages/ia/projects/ProjectDependenciesPage.tsx
+++ b/src/pages/ia/projects/ProjectDependenciesPage.tsx
@@ -1,0 +1,10 @@
+import { ProjectPageTemplate } from "./ProjectPageTemplate";
+
+export default function ProjectDependenciesPage() {
+  return (
+    <ProjectPageTemplate
+      title="Dependencies"
+      description="Model relationships across tasks, teams, and external blockers."
+    />
+  );
+}

--- a/src/pages/ia/projects/ProjectDocsPage.tsx
+++ b/src/pages/ia/projects/ProjectDocsPage.tsx
@@ -1,0 +1,10 @@
+import { ProjectPageTemplate } from "./ProjectPageTemplate";
+
+export default function ProjectDocsPage() {
+  return (
+    <ProjectPageTemplate
+      title="Docs"
+      description="Capture project knowledge, briefs, and decisions in one place."
+    />
+  );
+}

--- a/src/pages/ia/projects/ProjectFilesPage.tsx
+++ b/src/pages/ia/projects/ProjectFilesPage.tsx
@@ -1,0 +1,10 @@
+import { ProjectPageTemplate } from "./ProjectPageTemplate";
+
+export default function ProjectFilesPage() {
+  return (
+    <ProjectPageTemplate
+      title="Files"
+      description="Browse and manage project assets with approvals and version history."
+    />
+  );
+}

--- a/src/pages/ia/projects/ProjectListPage.tsx
+++ b/src/pages/ia/projects/ProjectListPage.tsx
@@ -1,0 +1,10 @@
+import { ProjectPageTemplate } from "./ProjectPageTemplate";
+
+export default function ProjectListPage() {
+  return (
+    <ProjectPageTemplate
+      title="List"
+      description="Structured list of tasks with inline editing and filters."
+    />
+  );
+}

--- a/src/pages/ia/projects/ProjectOverviewPage.tsx
+++ b/src/pages/ia/projects/ProjectOverviewPage.tsx
@@ -1,0 +1,10 @@
+import { ProjectPageTemplate } from "./ProjectPageTemplate";
+
+export default function ProjectOverviewPage() {
+  return (
+    <ProjectPageTemplate
+      title="Overview"
+      description="High-level status, health, and upcoming work for this project."
+    />
+  );
+}

--- a/src/pages/ia/projects/ProjectPageTemplate.tsx
+++ b/src/pages/ia/projects/ProjectPageTemplate.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from "react";
+import { useParams } from "react-router-dom";
+import { TabBar } from "@/components/common/TabBar";
+
+interface ProjectPageTemplateProps {
+  title: string;
+  description: string;
+  children?: ReactNode;
+}
+
+export function ProjectPageTemplate({ title, description, children }: ProjectPageTemplateProps) {
+  const { id } = useParams();
+
+  return (
+    <section className="flex flex-col gap-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
+        <p className="text-muted-foreground">{description}</p>
+        <p className="text-sm text-muted-foreground">Project reference: {id ?? "Unknown"}</p>
+        {/* TODO: Replace reference with actual project name */}
+      </header>
+      <TabBar />
+      <div className="rounded-lg border bg-background p-6 text-muted-foreground">
+        {children ?? "Content for this view is coming soon."}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/ia/projects/ProjectReportsPage.tsx
+++ b/src/pages/ia/projects/ProjectReportsPage.tsx
@@ -1,0 +1,10 @@
+import { ProjectPageTemplate } from "./ProjectPageTemplate";
+
+export default function ProjectReportsPage() {
+  return (
+    <ProjectPageTemplate
+      title="Reports"
+      description="Generate insights on project performance, risks, and outcomes."
+    />
+  );
+}

--- a/src/pages/ia/projects/ProjectSettingsPage.tsx
+++ b/src/pages/ia/projects/ProjectSettingsPage.tsx
@@ -1,0 +1,10 @@
+import { ProjectPageTemplate } from "./ProjectPageTemplate";
+
+export default function ProjectSettingsPage() {
+  return (
+    <ProjectPageTemplate
+      title="Settings"
+      description="Manage permissions, integrations, and metadata for this project."
+    />
+  );
+}

--- a/src/pages/ia/projects/ProjectSprintsPage.tsx
+++ b/src/pages/ia/projects/ProjectSprintsPage.tsx
@@ -1,0 +1,10 @@
+import { ProjectPageTemplate } from "./ProjectPageTemplate";
+
+export default function ProjectSprintsPage() {
+  return (
+    <ProjectPageTemplate
+      title="Sprints"
+      description="Plan iterations, assign capacity, and close out completed work."
+    />
+  );
+}

--- a/src/pages/ia/projects/ProjectTimelinePage.tsx
+++ b/src/pages/ia/projects/ProjectTimelinePage.tsx
@@ -1,0 +1,10 @@
+import { ProjectPageTemplate } from "./ProjectPageTemplate";
+
+export default function ProjectTimelinePage() {
+  return (
+    <ProjectPageTemplate
+      title="Timeline"
+      description="Track sequences of work and surface risks before they impact delivery."
+    />
+  );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,0 +1,126 @@
+import { Suspense } from "react";
+import { Navigate, useRoutes } from "react-router-dom";
+import { AppLayout } from "@/components/layout/AppLayout";
+import { ErrorBoundary } from "@/components/common/ErrorBoundary";
+import HomePage from "@/pages/ia/HomePage";
+import MyWorkPage from "@/pages/ia/MyWorkPage";
+import InboxPage from "@/pages/ia/InboxPage";
+import ProjectsPage from "@/pages/ia/ProjectsPage";
+import BoardsPage from "@/pages/ia/BoardsPage";
+import CalendarPage from "@/pages/ia/CalendarPage";
+import TimelinePage from "@/pages/ia/TimelinePage";
+import WorkloadPage from "@/pages/ia/WorkloadPage";
+import DashboardsPage from "@/pages/ia/DashboardsPage";
+import ReportsPage from "@/pages/ia/ReportsPage";
+import DocsPage from "@/pages/ia/DocsPage";
+import FilesPage from "@/pages/ia/FilesPage";
+import AutomationsPage from "@/pages/ia/AutomationsPage";
+import IntegrationsPage from "@/pages/ia/IntegrationsPage";
+import FormsPage from "@/pages/ia/FormsPage";
+import GoalsPage from "@/pages/ia/GoalsPage";
+import TemplatesPage from "@/pages/ia/TemplatesPage";
+import PeoplePage from "@/pages/ia/PeoplePage";
+import TimeTrackingPage from "@/pages/ia/TimeTrackingPage";
+import HelpPage from "@/pages/ia/HelpPage";
+import AdminHomePage from "@/pages/ia/admin/AdminHomePage";
+import AdminWorkspacePage from "@/pages/ia/admin/AdminWorkspacePage";
+import AdminPermissionsPage from "@/pages/ia/admin/AdminPermissionsPage";
+import AdminSecurityPage from "@/pages/ia/admin/AdminSecurityPage";
+import AdminAuditPage from "@/pages/ia/admin/AdminAuditPage";
+import AdminDataPage from "@/pages/ia/admin/AdminDataPage";
+import AdminWebhooksPage from "@/pages/ia/admin/AdminWebhooksPage";
+import AdminApiPage from "@/pages/ia/admin/AdminApiPage";
+import AdminBillingPage from "@/pages/ia/admin/AdminBillingPage";
+import ProjectOverviewPage from "@/pages/ia/projects/ProjectOverviewPage";
+import ProjectListPage from "@/pages/ia/projects/ProjectListPage";
+import ProjectBoardPage from "@/pages/ia/projects/ProjectBoardPage";
+import ProjectBacklogPage from "@/pages/ia/projects/ProjectBacklogPage";
+import ProjectSprintsPage from "@/pages/ia/projects/ProjectSprintsPage";
+import ProjectCalendarPage from "@/pages/ia/projects/ProjectCalendarPage";
+import ProjectTimelinePage from "@/pages/ia/projects/ProjectTimelinePage";
+import ProjectDependenciesPage from "@/pages/ia/projects/ProjectDependenciesPage";
+import ProjectReportsPage from "@/pages/ia/projects/ProjectReportsPage";
+import ProjectDocsPage from "@/pages/ia/projects/ProjectDocsPage";
+import ProjectFilesPage from "@/pages/ia/projects/ProjectFilesPage";
+import ProjectAutomationsPage from "@/pages/ia/projects/ProjectAutomationsPage";
+import ProjectSettingsPage from "@/pages/ia/projects/ProjectSettingsPage";
+import NewProjectPage from "@/pages/ia/NewProjectPage";
+import NewBoardPage from "@/pages/ia/NewBoardPage";
+import NewTaskPage from "@/pages/ia/NewTaskPage";
+import NewDashboardPage from "@/pages/ia/NewDashboardPage";
+import Login from "@/pages/Login";
+import AuthCallback from "@/pages/AuthCallback";
+import NotFound from "@/pages/NotFound";
+
+const Suspended = ({ children }: { children: React.ReactNode }) => (
+  <Suspense fallback={<div className="p-6">Loading...</div>}>
+    <ErrorBoundary>{children}</ErrorBoundary>
+  </Suspense>
+);
+
+export function AppRoutes() {
+  return useRoutes([
+    {
+      path: "/",
+      element: (
+        <Suspended>
+          <AppLayout />
+        </Suspended>
+      ),
+      children: [
+        { index: true, element: <HomePage /> },
+        { path: "my-work", element: <MyWorkPage /> },
+        { path: "inbox", element: <InboxPage /> },
+        { path: "projects", element: <ProjectsPage /> },
+        { path: "projects/new", element: <NewProjectPage /> },
+        { path: "projects/:id", element: <ProjectOverviewPage /> },
+        { path: "projects/:id/overview", element: <ProjectOverviewPage /> },
+        { path: "projects/:id/list", element: <ProjectListPage /> },
+        { path: "projects/:id/board", element: <ProjectBoardPage /> },
+        { path: "projects/:id/backlog", element: <ProjectBacklogPage /> },
+        { path: "projects/:id/sprints", element: <ProjectSprintsPage /> },
+        { path: "projects/:id/calendar", element: <ProjectCalendarPage /> },
+        { path: "projects/:id/timeline", element: <ProjectTimelinePage /> },
+        { path: "projects/:id/dependencies", element: <ProjectDependenciesPage /> },
+        { path: "projects/:id/reports", element: <ProjectReportsPage /> },
+        { path: "projects/:id/docs", element: <ProjectDocsPage /> },
+        { path: "projects/:id/files", element: <ProjectFilesPage /> },
+        { path: "projects/:id/automations", element: <ProjectAutomationsPage /> },
+        { path: "projects/:id/settings", element: <ProjectSettingsPage /> },
+        { path: "boards", element: <BoardsPage /> },
+        { path: "boards/new", element: <NewBoardPage /> },
+        { path: "calendar", element: <CalendarPage /> },
+        { path: "timeline", element: <TimelinePage /> },
+        { path: "workload", element: <WorkloadPage /> },
+        { path: "dashboards", element: <DashboardsPage /> },
+        { path: "dashboards/new", element: <NewDashboardPage /> },
+        { path: "reports", element: <ReportsPage /> },
+        { path: "docs", element: <DocsPage /> },
+        { path: "files", element: <FilesPage /> },
+        { path: "automations", element: <AutomationsPage /> },
+        { path: "integrations", element: <IntegrationsPage /> },
+        { path: "forms", element: <FormsPage /> },
+        { path: "goals", element: <GoalsPage /> },
+        { path: "templates", element: <TemplatesPage /> },
+        { path: "people", element: <PeoplePage /> },
+        { path: "time", element: <TimeTrackingPage /> },
+        { path: "tasks/new", element: <NewTaskPage /> },
+        { path: "admin", element: <AdminHomePage /> },
+        { path: "admin/workspace", element: <AdminWorkspacePage /> },
+        { path: "admin/permissions", element: <AdminPermissionsPage /> },
+        { path: "admin/security", element: <AdminSecurityPage /> },
+        { path: "admin/audit", element: <AdminAuditPage /> },
+        { path: "admin/data", element: <AdminDataPage /> },
+        { path: "admin/webhooks", element: <AdminWebhooksPage /> },
+        { path: "admin/api", element: <AdminApiPage /> },
+        { path: "admin/billing", element: <AdminBillingPage /> },
+        { path: "help", element: <HelpPage /> },
+      ],
+    },
+    { path: "/login", element: <Login /> },
+    { path: "/auth/callback", element: <AuthCallback /> },
+    { path: "/auth", element: <Navigate to="/login" replace /> },
+    { path: "/logout", element: <Navigate to="/login" replace /> },
+    { path: "*", element: <NotFound /> },
+  ]);
+}

--- a/src/state/badges.tsx
+++ b/src/state/badges.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
+
+export type BadgeCounts = {
+  inboxCount: number;
+  myWorkCount: number;
+  setInboxCount: (count: number) => void;
+  setMyWorkCount: (count: number) => void;
+};
+
+const BadgesContext = createContext<BadgeCounts | undefined>(undefined);
+
+export function BadgesProvider({ children }: { children: ReactNode }) {
+  const [inboxCount, setInboxCount] = useState(5);
+  const [myWorkCount, setMyWorkCount] = useState(3);
+
+  const value = useMemo(
+    () => ({
+      inboxCount,
+      myWorkCount,
+      setInboxCount,
+      setMyWorkCount,
+    }),
+    [inboxCount, myWorkCount]
+  );
+
+  return <BadgesContext.Provider value={value}>{children}</BadgesContext.Provider>;
+}
+
+export function useBadges() {
+  const context = useContext(BadgesContext);
+  if (!context) {
+    throw new Error("useBadges must be used within a BadgesProvider");
+  }
+
+  return context;
+}
+
+// TODO: Replace mock values with live data once notification APIs are wired up.


### PR DESCRIPTION
## Summary
- replace the shell with a role-aware AppLayout that renders the new sidebar and topbar from a central navigation config
- add IA route stubs, project tab navigation, and a badges store so every destination has a populated placeholder and badge counts
- introduce feature-flag utilities, mocked auth, and automated tests to validate navigation structure and layout rendering

## Testing
- npm run type-check
- npm run lint
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e263448100832794a7132f5bff0e45