### PR TITLE
feat: add calendar interface and route inventory

### DIFF
--- a/src/components/common/DateRangeControls.tsx
+++ b/src/components/common/DateRangeControls.tsx
@@ -1,0 +1,64 @@
+import { addDays, addMonths, addWeeks, endOfDay, endOfMonth, endOfWeek, startOfDay, startOfMonth, startOfWeek } from "date-fns";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type CalendarUnit = "day" | "week" | "month";
+
+export interface DateRange {
+  from: Date;
+  to: Date;
+}
+
+interface DateRangeControlsProps {
+  unit: CalendarUnit;
+  range: DateRange;
+  onChange: (range: DateRange) => void;
+  className?: string;
+}
+
+function getUnitHelpers(unit: CalendarUnit) {
+  switch (unit) {
+    case "day":
+      return {
+        prev: (date: Date) => addDays(date, -1),
+        next: (date: Date) => addDays(date, 1),
+        normalize: (date: Date) => ({ from: startOfDay(date), to: endOfDay(date) }),
+      };
+    case "week":
+      return {
+        prev: (date: Date) => addWeeks(date, -1),
+        next: (date: Date) => addWeeks(date, 1),
+        normalize: (date: Date) => ({ from: startOfWeek(date, { weekStartsOn: 1 }), to: endOfWeek(date, { weekStartsOn: 1 }) }),
+      };
+    case "month":
+    default:
+      return {
+        prev: (date: Date) => addMonths(date, -1),
+        next: (date: Date) => addMonths(date, 1),
+        normalize: (date: Date) => ({ from: startOfMonth(date), to: endOfMonth(date) }),
+      };
+  }
+}
+
+export function DateRangeControls({ unit, range, onChange, className }: DateRangeControlsProps) {
+  const helpers = getUnitHelpers(unit);
+
+  const goTo = (date: Date) => {
+    const normalized = helpers.normalize(date);
+    onChange(normalized);
+  };
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <Button variant="outline" size="sm" onClick={() => goTo(helpers.prev(range.from))} aria-label="Previous">
+        Prev
+      </Button>
+      <Button variant="outline" size="sm" onClick={() => goTo(new Date())} aria-label="Today">
+        Today
+      </Button>
+      <Button variant="outline" size="sm" onClick={() => goTo(helpers.next(range.from))} aria-label="Next">
+        Next
+      </Button>
+    </div>
+  );
+}

--- a/src/components/common/TabBar.tsx
+++ b/src/components/common/TabBar.tsx
@@ -19,7 +19,7 @@ export const PROJECT_TABS = [
 ] as const;
 
 export function TabBar() {
-  const { id } = useParams();
+  const { projectId } = useParams();
   const location = useLocation();
   const tabRefs = useRef<(HTMLAnchorElement | null)[]>([]);
 
@@ -42,11 +42,11 @@ export function TabBar() {
     <nav className="overflow-x-auto" role="tablist" aria-label="Project navigation">
       <div className="flex min-w-max gap-1 rounded-md border bg-background p-1">
         {tabItems.map((tab, index) => {
-          const projectId = id ?? "";
-          const tabPath = `/projects/${projectId}/${tab.path}`;
+          const currentProjectId = projectId ?? "";
+          const tabPath = `/projects/${currentProjectId}/${tab.path}`;
           const isActive =
             location.pathname === tabPath ||
-            (tab.path === "overview" && location.pathname === `/projects/${projectId}`);
+            (tab.path === "overview" && location.pathname === `/projects/${currentProjectId}`);
 
           return (
             <NavLink

--- a/src/components/common/ViewSwitch.tsx
+++ b/src/components/common/ViewSwitch.tsx
@@ -1,0 +1,38 @@
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { cn } from "@/lib/utils";
+
+export type CalendarView = "month" | "week" | "day";
+
+interface ViewSwitchProps {
+  value: CalendarView;
+  onChange: (value: CalendarView) => void;
+  className?: string;
+}
+
+const OPTIONS: Array<{ value: CalendarView; label: string }> = [
+  { value: "month", label: "Month" },
+  { value: "week", label: "Week" },
+  { value: "day", label: "Day" },
+];
+
+export function ViewSwitch({ value, onChange, className }: ViewSwitchProps) {
+  return (
+    <ToggleGroup
+      type="single"
+      value={value}
+      onValueChange={(next) => {
+        if (next) {
+          onChange(next as CalendarView);
+        }
+      }}
+      className={cn("rounded-md border p-1", className)}
+      aria-label="Select calendar view"
+    >
+      {OPTIONS.map((option) => (
+        <ToggleGroupItem key={option.value} value={option.value} className="px-3 py-2 text-sm">
+          {option.label}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  );
+}

--- a/src/components/tasks/TaskPreviewDrawer.tsx
+++ b/src/components/tasks/TaskPreviewDrawer.tsx
@@ -1,0 +1,86 @@
+import { Link } from "react-router-dom";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { CalendarTask } from "@/hooks/useCalendar";
+import { format, parseISO } from "date-fns";
+import { cn } from "@/lib/utils";
+
+function formatDate(value?: string | null) {
+  if (!value) return "Unscheduled";
+  try {
+    return format(parseISO(value), "MMM d, yyyy");
+  } catch (error) {
+    return value;
+  }
+}
+
+interface TaskPreviewDrawerProps {
+  task: CalendarTask | null;
+  open: boolean;
+  onClose: () => void;
+  projectName?: string;
+}
+
+export function TaskPreviewDrawer({ task, open, onClose, projectName }: TaskPreviewDrawerProps) {
+  return (
+    <Sheet open={open} onOpenChange={(next) => (!next ? onClose() : undefined)}>
+      <SheetContent side="right" className="flex w-full flex-col gap-4 sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle>{task?.title ?? "Task"}</SheetTitle>
+          <SheetDescription>
+            <span className="block text-sm text-muted-foreground">
+              {projectName ?? task?.project_id ?? "Unknown project"}
+            </span>
+          </SheetDescription>
+        </SheetHeader>
+        <ScrollArea className="flex-1 pr-2">
+          <div className="space-y-4">
+            <div className="space-y-1">
+              <h3 className="text-sm font-medium text-muted-foreground">Status</h3>
+              <Badge variant="secondary" className="capitalize">
+                {task?.status ?? "Unknown"}
+              </Badge>
+            </div>
+            <div className="space-y-1">
+              <h3 className="text-sm font-medium text-muted-foreground">Assignee</h3>
+              <p className="text-sm">
+                {task?.assignee ?? "Unassigned"}
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              <div>
+                <p className="text-muted-foreground">Start</p>
+                <p className="font-medium">{formatDate(task?.start_date)}</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Due</p>
+                <p className={cn("font-medium", !task?.due_date && "text-muted-foreground")}>{formatDate(task?.due_date)}</p>
+              </div>
+            </div>
+            <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+              TODO: Quick date edits
+            </div>
+          </div>
+        </ScrollArea>
+        <div className="flex items-center justify-between gap-2">
+          <Button asChild className="flex-1" variant="default">
+            <Link to={task ? `/projects/${task.project_id}/tasks/${task.id}` : "#"}>
+              Open task
+            </Link>
+          </Button>
+          <Button variant="outline" onClick={onClose} className="flex-1">
+            Close
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -1,0 +1,46 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+type CalendarRange = {
+  from: Date;
+  to: Date;
+  projectId?: string;
+};
+
+export type CalendarTask = {
+  id: string;
+  project_id: string;
+  title: string;
+  status?: string | null;
+  assignee?: string | null;
+  start_date?: string | null;
+  due_date?: string | null;
+  updated_at: string;
+};
+
+function toIsoDate(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+export function useCalendarRange(range: CalendarRange) {
+  const { from, to, projectId } = range;
+  const key = useMemo(
+    () => ["calendar", projectId ?? "all", toIsoDate(from), toIsoDate(to)],
+    [from, to, projectId]
+  );
+
+  const query = useQuery({
+    queryKey: key,
+    queryFn: async () => {
+      // Placeholder implementation until services are wired.
+      return [] as CalendarTask[];
+    },
+  });
+
+  return {
+    tasks: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}

--- a/src/pages/calendar/CalendarPage.tsx
+++ b/src/pages/calendar/CalendarPage.tsx
@@ -1,0 +1,561 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { KeyboardEvent } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  addDays,
+  eachDayOfInterval,
+  endOfDay,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isSameDay,
+  isSameMonth,
+  isToday,
+  parseISO,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns";
+import { supabase } from "@/integrations/supabase/client";
+import { useCalendarRange, CalendarTask } from "@/hooks/useCalendar";
+import { DateRangeControls, DateRange, CalendarUnit } from "@/components/common/DateRangeControls";
+import { ViewSwitch, CalendarView } from "@/components/common/ViewSwitch";
+import { TaskPreviewDrawer } from "@/components/tasks/TaskPreviewDrawer";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const WEEK_OPTIONS = { weekStartsOn: 1 as const };
+const MAX_VISIBLE_TASKS = 3;
+
+interface ProjectOption {
+  id: string;
+  name: string | null;
+}
+
+function getRangeForView(view: CalendarView, pivot: Date): DateRange {
+  switch (view) {
+    case "day":
+      return { from: startOfDay(pivot), to: endOfDay(pivot) };
+    case "week":
+      return {
+        from: startOfWeek(pivot, WEEK_OPTIONS),
+        to: endOfWeek(pivot, WEEK_OPTIONS),
+      };
+    case "month":
+    default:
+      return {
+        from: startOfMonth(pivot),
+        to: endOfMonth(pivot),
+      };
+  }
+}
+
+function formatHeaderLabel(view: CalendarView, range: DateRange) {
+  switch (view) {
+    case "day":
+      return format(range.from, "EEEE, MMM d");
+    case "week":
+      return `${format(range.from, "MMM d")} - ${format(range.to, "MMM d")}`;
+    case "month":
+    default:
+      return format(range.from, "MMMM yyyy");
+  }
+}
+
+function normalizeTaskInterval(task: CalendarTask) {
+  const start = task.start_date ? startOfDay(parseISO(task.start_date)) : null;
+  const due = task.due_date ? endOfDay(parseISO(task.due_date)) : null;
+
+  if (!start && !due) return null;
+
+  if (start && due) {
+    if (start <= due) {
+      return { start, end: due };
+    }
+    return { start: due, end: endOfDay(start) };
+  }
+
+  if (start && !due) {
+    return { start, end: endOfDay(start) };
+  }
+
+  if (!start && due) {
+    const normalized = startOfDay(due);
+    return { start: normalized, end: endOfDay(due) };
+  }
+
+  return null;
+}
+
+function getDayKey(date: Date) {
+  return format(date, "yyyy-MM-dd");
+}
+
+function buildTasksByDay(tasks: CalendarTask[]) {
+  const map = new Map<string, CalendarTask[]>();
+  tasks.forEach((task) => {
+    const interval = normalizeTaskInterval(task);
+    if (!interval) return;
+    const days = eachDayOfInterval({ start: interval.start, end: interval.end });
+    days.forEach((day) => {
+      const key = getDayKey(day);
+      const existing = map.get(key);
+      if (existing) {
+        existing.push(task);
+      } else {
+        map.set(key, [task]);
+      }
+    });
+  });
+  return map;
+}
+
+function useProjectsList() {
+  return useQuery({
+    queryKey: ["calendar", "projects"],
+    queryFn: async () => {
+      const { data, error } = await supabase.from("projects").select("id, name");
+      if (error) {
+        throw error;
+      }
+      return (data ?? []) as ProjectOption[];
+    },
+  });
+}
+
+interface DayTasksDrawerProps {
+  date: Date | null;
+  tasks: CalendarTask[];
+  open: boolean;
+  onClose: () => void;
+  onSelectTask: (task: CalendarTask) => void;
+  getProjectName: (projectId: string) => string;
+}
+
+function DayTasksDrawer({ date, tasks, open, onClose, onSelectTask, getProjectName }: DayTasksDrawerProps) {
+  return (
+    <Sheet open={open} onOpenChange={(next) => (!next ? onClose() : undefined)}>
+      <SheetContent side="right" className="flex w-full flex-col gap-4 sm:max-w-sm">
+        <SheetHeader>
+          <SheetTitle>{date ? format(date, "EEEE, MMM d") : "Tasks"}</SheetTitle>
+        </SheetHeader>
+        <ScrollArea className="h-full pr-2">
+          <div className="space-y-2 pb-6">
+            {tasks.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No tasks scheduled.</p>
+            ) : (
+              tasks.map((task) => (
+                <button
+                  key={task.id}
+                  type="button"
+                  onClick={() => onSelectTask(task)}
+                  className="w-full rounded-md border bg-background p-3 text-left transition hover:border-primary"
+                >
+                  <p className="font-medium">{task.title}</p>
+                  <p className="text-xs text-muted-foreground">{getProjectName(task.project_id)}</p>
+                </button>
+              ))
+            )}
+          </div>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function CalendarSkeleton() {
+  return (
+    <div className="grid gap-px rounded-lg border bg-border">
+      {Array.from({ length: 6 }).map((_, weekIndex) => (
+        <div key={weekIndex} className="grid grid-cols-7 gap-px">
+          {Array.from({ length: 7 }).map((__, dayIndex) => (
+            <Skeleton key={`${weekIndex}-${dayIndex}`} className="h-24 w-full" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CalendarEmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex h-48 flex-col items-center justify-center rounded-md border border-dashed text-center">
+      <p className="text-sm text-muted-foreground">{message}</p>
+    </div>
+  );
+}
+
+export default function CalendarPage() {
+  const [view, setView] = useState<CalendarView>("month");
+  const [range, setRange] = useState<DateRange>(() => getRangeForView("month", new Date()));
+  const [focusedDate, setFocusedDate] = useState<Date>(range.from);
+  const [selectedProject, setSelectedProject] = useState<string | undefined>(undefined);
+  const [selectedTask, setSelectedTask] = useState<CalendarTask | null>(null);
+  const [isTaskDrawerOpen, setIsTaskDrawerOpen] = useState(false);
+  const [expandedDay, setExpandedDay] = useState<Date | null>(null);
+  const [isDayDrawerOpen, setIsDayDrawerOpen] = useState(false);
+
+  const { data: projects = [] } = useProjectsList();
+  const projectLookup = useMemo(() => {
+    const map = new Map<string, string>();
+    projects.forEach((project) => {
+      map.set(project.id, project.name ?? "Untitled project");
+    });
+    return map;
+  }, [projects]);
+
+  const { tasks, isLoading, error, refetch } = useCalendarRange({
+    from: range.from,
+    to: range.to,
+    projectId: selectedProject,
+  });
+
+  const tasksByDay = useMemo(() => buildTasksByDay(tasks), [tasks]);
+
+  const getTasksForDate = useCallback(
+    (date: Date) => tasksByDay.get(getDayKey(date)) ?? [],
+    [tasksByDay]
+  );
+
+  const expandedDayTasks = expandedDay ? getTasksForDate(expandedDay) : [];
+
+  useEffect(() => {
+    document.title = "Calendar";
+  }, []);
+
+  const unitMap: Record<CalendarView, CalendarUnit> = {
+    month: "month",
+    week: "week",
+    day: "day",
+  };
+
+  const headerLabel = useMemo(() => formatHeaderLabel(view, range), [view, range]);
+
+  const handleRangeChange = (nextRange: DateRange) => {
+    setRange(nextRange);
+    setFocusedDate(nextRange.from);
+  };
+
+  const updateFocusedDate = (next: Date) => {
+    setFocusedDate(next);
+    if (next < range.from || next > range.to) {
+      const nextRange = getRangeForView(view, next);
+      setRange(nextRange);
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      updateFocusedDate(addDays(focusedDate, -1));
+    }
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      updateFocusedDate(addDays(focusedDate, 1));
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      updateFocusedDate(addDays(focusedDate, view === "month" ? -7 : -1));
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      updateFocusedDate(addDays(focusedDate, view === "month" ? 7 : 1));
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      setExpandedDay(focusedDate);
+      setIsDayDrawerOpen(true);
+    }
+    if (event.key === "Escape") {
+      if (isTaskDrawerOpen) {
+        setIsTaskDrawerOpen(false);
+      }
+      if (isDayDrawerOpen) {
+        setIsDayDrawerOpen(false);
+        setExpandedDay(null);
+      }
+    }
+  };
+
+  const openTask = (task: CalendarTask) => {
+    setSelectedTask(task);
+    setIsTaskDrawerOpen(true);
+    setIsDayDrawerOpen(false);
+  };
+
+  const renderMonth = () => {
+    const start = startOfWeek(startOfMonth(range.from), WEEK_OPTIONS);
+    const end = endOfWeek(endOfMonth(range.from), WEEK_OPTIONS);
+    const days = eachDayOfInterval({ start, end });
+    const weeks: Date[][] = [];
+    for (let i = 0; i < days.length; i += 7) {
+      weeks.push(days.slice(i, i + 7));
+    }
+
+    return (
+      <div
+        role="grid"
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        className="grid gap-px rounded-lg border bg-border outline-none"
+      >
+        {weeks.map((week, index) => (
+          <div key={index} role="row" className="grid grid-cols-7 gap-px">
+            {week.map((day) => {
+              const dayTasks = getTasksForDate(day);
+              const visible = dayTasks.slice(0, MAX_VISIBLE_TASKS);
+              const remaining = dayTasks.length - visible.length;
+              const isFocused = isSameDay(day, focusedDate);
+              return (
+                <div
+                  key={day.toISOString()}
+                  role="gridcell"
+                  className={cn(
+                    "flex min-h-[120px] flex-col bg-background p-2 text-xs",
+                    !isSameMonth(day, range.from) && "bg-muted/40 text-muted-foreground",
+                    isFocused && "ring-2 ring-primary"
+                  )}
+                  onClick={() => updateFocusedDate(day)}
+                >
+                  <div className="flex items-center justify-between">
+                    <span className={cn("text-sm font-medium", isToday(day) && "text-primary")}>{format(day, "d")}</span>
+                    {isToday(day) && <Badge variant="outline">Today</Badge>}
+                  </div>
+                  <div className="mt-2 space-y-1">
+                    {visible.map((task) => (
+                      <button
+                        key={task.id}
+                        type="button"
+                        onClick={() => openTask(task)}
+                        className="flex w-full items-center justify-between rounded-md bg-primary/10 px-2 py-1 text-left text-xs hover:bg-primary/20"
+                      >
+                        <span className="truncate">{task.title}</span>
+                      </button>
+                    ))}
+                    {remaining > 0 && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setExpandedDay(day);
+                          setIsDayDrawerOpen(true);
+                        }}
+                        className="w-full rounded-md border border-dashed px-2 py-1 text-left text-xs text-muted-foreground hover:border-primary"
+                      >
+                        +{remaining} more
+                      </button>
+                    )}
+                    {dayTasks.length === 0 && (
+                      <p className="text-xs text-muted-foreground">No tasks</p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  const renderWeek = () => {
+    const days = eachDayOfInterval({ start: range.from, end: range.to });
+    return (
+      <div
+        role="grid"
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        className="grid grid-cols-7 gap-2"
+      >
+        {days.map((day) => {
+          const dayTasks = getTasksForDate(day);
+          const isFocused = isSameDay(day, focusedDate);
+          return (
+            <div
+              key={day.toISOString()}
+              role="gridcell"
+              className={cn(
+                "flex min-h-[160px] flex-col rounded-lg border bg-background p-3",
+                isFocused && "ring-2 ring-primary"
+              )}
+              onClick={() => updateFocusedDate(day)}
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-medium">{format(day, "EEE d")}</span>
+                {isToday(day) && <Badge variant="outline">Today</Badge>}
+              </div>
+              <div className="mt-3 space-y-2">
+                {dayTasks.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">No tasks</p>
+                ) : (
+                  dayTasks.map((task) => (
+                    <button
+                      key={task.id}
+                      type="button"
+                      onClick={() => openTask(task)}
+                      className="w-full rounded-md bg-primary/10 px-2 py-1 text-left text-sm hover:bg-primary/20"
+                    >
+                      <p className="truncate font-medium">{task.title}</p>
+                      <p className="text-xs text-muted-foreground">{projectLookup.get(task.project_id) ?? "Project"}</p>
+                    </button>
+                  ))
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderDay = () => {
+    const dayTasks = getTasksForDate(focusedDate);
+    return (
+      <div
+        role="grid"
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        className="flex flex-col gap-4"
+      >
+        <div className="rounded-lg border bg-background p-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">{format(focusedDate, "EEEE, MMM d")}</h2>
+            {isToday(focusedDate) && <Badge variant="outline">Today</Badge>}
+          </div>
+          <div className="mt-4 space-y-3">
+            {dayTasks.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No tasks in this day.</p>
+            ) : (
+              dayTasks.map((task) => (
+                <button
+                  key={task.id}
+                  type="button"
+                  onClick={() => openTask(task)}
+                  className="w-full rounded-md border bg-muted/40 px-3 py-2 text-left transition hover:border-primary"
+                >
+                  <p className="font-medium">{task.title}</p>
+                  <p className="text-xs text-muted-foreground">{projectLookup.get(task.project_id) ?? "Project"}</p>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const renderContent = () => {
+    if (isLoading) {
+      return <CalendarSkeleton />;
+    }
+
+    if (error) {
+      return (
+        <div className="flex flex-col gap-3 rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+          <div className="flex items-center gap-2">
+            <AlertCircle className="h-4 w-4" />
+            <span>We could not load the calendar right now.</span>
+          </div>
+          <Button variant="outline" size="sm" onClick={() => refetch()}>Retry</Button>
+        </div>
+      );
+    }
+
+    if (tasks.length === 0) {
+      return <CalendarEmptyState message="No tasks in this range." />;
+    }
+
+    if (view === "month") return renderMonth();
+    if (view === "week") return renderWeek();
+    return renderDay();
+  };
+
+  return (
+    <section className="flex flex-col gap-6">
+      <header className="space-y-4">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="/">Home</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>Calendar</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight">Calendar</h1>
+            <p className="text-muted-foreground">Plan work across every project.</p>
+          </div>
+          <ViewSwitch value={view} onChange={(next) => {
+            setView(next);
+            setRange(getRangeForView(next, focusedDate));
+          }} />
+        </div>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <DateRangeControls unit={unitMap[view]} range={range} onChange={handleRangeChange} />
+            <span className="text-sm font-medium">{headerLabel}</span>
+          </div>
+          <Select
+            value={selectedProject ?? "all"}
+            onValueChange={(value) => {
+              setSelectedProject(value === "all" ? undefined : value);
+            }}
+          >
+            <SelectTrigger className="w-[220px]">
+              <SelectValue placeholder="All projects" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All projects</SelectItem>
+              {projects.map((project) => (
+                <SelectItem key={project.id} value={project.id}>
+                  {project.name ?? "Untitled project"}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </header>
+      {renderContent()}
+      <TaskPreviewDrawer
+        task={selectedTask}
+        open={isTaskDrawerOpen}
+        onClose={() => setIsTaskDrawerOpen(false)}
+        projectName={selectedTask ? projectLookup.get(selectedTask.project_id) ?? undefined : undefined}
+      />
+      <DayTasksDrawer
+        date={expandedDay}
+        tasks={expandedDayTasks}
+        open={isDayDrawerOpen}
+        onClose={() => {
+          setIsDayDrawerOpen(false);
+          setExpandedDay(null);
+        }}
+        onSelectTask={openTask}
+        getProjectName={(projectId) => projectLookup.get(projectId) ?? "Project"}
+      />
+    </section>
+  );
+}

--- a/src/pages/ia/projects/ProjectPageTemplate.tsx
+++ b/src/pages/ia/projects/ProjectPageTemplate.tsx
@@ -9,14 +9,14 @@ interface ProjectPageTemplateProps {
 }
 
 export function ProjectPageTemplate({ title, description, children }: ProjectPageTemplateProps) {
-  const { id } = useParams();
+  const { projectId } = useParams();
 
   return (
     <section className="flex flex-col gap-6">
       <header className="space-y-2">
         <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
         <p className="text-muted-foreground">{description}</p>
-        <p className="text-sm text-muted-foreground">Project reference: {id ?? "Unknown"}</p>
+        <p className="text-sm text-muted-foreground">Project reference: {projectId ?? "Unknown"}</p>
         {/* TODO: Replace reference with actual project name */}
       </header>
       <TabBar />

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -7,7 +7,7 @@ import MyWorkPage from "@/pages/ia/MyWorkPage";
 import InboxPage from "@/pages/ia/InboxPage";
 import ProjectsPage from "@/pages/ia/ProjectsPage";
 import BoardsPage from "@/pages/ia/BoardsPage";
-import CalendarPage from "@/pages/ia/CalendarPage";
+import CalendarPage from "@/pages/calendar/CalendarPage";
 import TimelinePage from "@/pages/ia/TimelinePage";
 import WorkloadPage from "@/pages/ia/WorkloadPage";
 import DashboardsPage from "@/pages/ia/DashboardsPage";
@@ -76,20 +76,20 @@ export function AppRoutes() {
         { path: "inbox", element: <InboxPage /> },
         { path: "projects", element: <ProjectsPage /> },
         { path: "projects/new", element: <NewProjectPage /> },
-        { path: "projects/:id", element: <ProjectOverviewPage /> },
-        { path: "projects/:id/overview", element: <ProjectOverviewPage /> },
-        { path: "projects/:id/list", element: <ProjectListPage /> },
-        { path: "projects/:id/board", element: <ProjectBoardPage /> },
-        { path: "projects/:id/backlog", element: <ProjectBacklogPage /> },
-        { path: "projects/:id/sprints", element: <ProjectSprintsPage /> },
-        { path: "projects/:id/calendar", element: <ProjectCalendarPage /> },
-        { path: "projects/:id/timeline", element: <ProjectTimelinePage /> },
-        { path: "projects/:id/dependencies", element: <ProjectDependenciesPage /> },
-        { path: "projects/:id/reports", element: <ProjectReportsPage /> },
-        { path: "projects/:id/docs", element: <ProjectDocsPage /> },
-        { path: "projects/:id/files", element: <ProjectFilesPage /> },
-        { path: "projects/:id/automations", element: <ProjectAutomationsPage /> },
-        { path: "projects/:id/settings", element: <ProjectSettingsPage /> },
+        { path: "projects/:projectId", element: <ProjectOverviewPage /> },
+        { path: "projects/:projectId/overview", element: <ProjectOverviewPage /> },
+        { path: "projects/:projectId/list", element: <ProjectListPage /> },
+        { path: "projects/:projectId/board", element: <ProjectBoardPage /> },
+        { path: "projects/:projectId/backlog", element: <ProjectBacklogPage /> },
+        { path: "projects/:projectId/sprints", element: <ProjectSprintsPage /> },
+        { path: "projects/:projectId/calendar", element: <ProjectCalendarPage /> },
+        { path: "projects/:projectId/timeline", element: <ProjectTimelinePage /> },
+        { path: "projects/:projectId/dependencies", element: <ProjectDependenciesPage /> },
+        { path: "projects/:projectId/reports", element: <ProjectReportsPage /> },
+        { path: "projects/:projectId/docs", element: <ProjectDocsPage /> },
+        { path: "projects/:projectId/files", element: <ProjectFilesPage /> },
+        { path: "projects/:projectId/automations", element: <ProjectAutomationsPage /> },
+        { path: "projects/:projectId/settings", element: <ProjectSettingsPage /> },
         { path: "boards", element: <BoardsPage /> },
         { path: "boards/new", element: <NewBoardPage /> },
         { path: "calendar", element: <CalendarPage /> },


### PR DESCRIPTION
## Summary
- align project routes to use :projectId and capture the calendar/timeline inventory details
- replace the placeholder calendar page with an interactive month, week, and day UI plus shared range controls and task preview drawer scaffolding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e334ae2fdc83278c0811a755e114a5