### PR TITLE
chore: scaffold People & Time routes behind feature flags

### DIFF
--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -32,6 +32,12 @@ function findNavLabel(path: string) {
       if (item.path === path) {
         return item.label;
       }
+      if (item.matchPaths) {
+        const match = item.matchPaths.find((candidate) => matchesPattern(candidate, path));
+        if (match) {
+          return item.label;
+        }
+      }
       if (item.children) {
         const found = walk(item.children);
         if (found) {
@@ -50,6 +56,32 @@ function formatSegment(segment: string) {
     .split("-")
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(" ");
+}
+
+const CUSTOM_CRUMBS = [
+  { pattern: "/people", label: "People" },
+  { pattern: "/people/:userId", label: "Member" },
+  { pattern: "/teams", label: "Teams" },
+  { pattern: "/teams/:teamId", label: "Team" },
+  { pattern: "/time", label: "Time" },
+  { pattern: "/time/my", label: "My" },
+  { pattern: "/time/approvals", label: "Approvals" },
+  { pattern: "/projects/:projectId/people", label: "People" },
+  { pattern: "/projects/:projectId/teams", label: "Teams" },
+  { pattern: "/projects/:projectId/time", label: "Time" },
+] as const;
+
+function matchesPattern(pattern: string, path: string) {
+  if (pattern === path) return true;
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regexPattern = escaped.replace(/:\w+/g, "[^/]+");
+  const regex = new RegExp(`^${regexPattern}$`);
+  return regex.test(path);
+}
+
+function findCustomLabel(path: string) {
+  const match = CUSTOM_CRUMBS.find((crumb) => matchesPattern(crumb.pattern, path));
+  return match?.label;
 }
 
 type TopbarProps = {
@@ -84,7 +116,7 @@ export function Topbar({ onToggleSidebar }: TopbarProps) {
 
     segments.forEach((segment, index) => {
       href += `/${segment}`;
-      let label = findNavLabel(href);
+      let label = findCustomLabel(href) ?? findNavLabel(href);
 
       if (!label && segments[0] === "projects") {
         if (index === 1) {

--- a/src/hooks/useDocumentTitle.ts
+++ b/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+const APP_NAME = "Outpaged";
+
+export function useDocumentTitle(title: string) {
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const previous = document.title;
+    document.title = title ? `${title} | ${APP_NAME}` : APP_NAME;
+
+    return () => {
+      document.title = previous;
+    };
+  }, [title]);
+}

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,12 +1,32 @@
+const truthy = new Set(["true", "1", "on", "yes"]);
+const falsy = new Set(["false", "0", "off", "no"]);
+
+function getBooleanFlag(key: string, fallback: boolean) {
+  const envKey = `VITE_${key}` as keyof ImportMetaEnv;
+  const raw = typeof import.meta !== "undefined" ? import.meta.env?.[envKey] : undefined;
+
+  if (typeof raw === "string") {
+    const value = raw.toLowerCase();
+    if (truthy.has(value)) return true;
+    if (falsy.has(value)) return false;
+  }
+
+  return fallback;
+}
+
+export const FEATURE_PEOPLE_TEAMS = getBooleanFlag("FEATURE_PEOPLE_TEAMS", true);
+export const FEATURE_TIME_TRACKING = getBooleanFlag("FEATURE_TIME_TRACKING", true);
+
 export const FEATURE_FLAGS = {
   dashboards: true,
   automations: true,
   integrations: true,
   forms: true,
   goals: true,
-  timeTracking: true,
+  timeTracking: FEATURE_TIME_TRACKING,
   apiExplorer: true,
-} as const;
+  peopleTeams: FEATURE_PEOPLE_TEAMS,
+} satisfies Record<string, boolean>;
 
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS;
 

--- a/src/lib/navConfig.tsx
+++ b/src/lib/navConfig.tsx
@@ -44,6 +44,7 @@ export type NavItem = {
   roles?: Role[];
   featureFlag?: keyof typeof FEATURE_FLAGS;
   badgeKey?: BadgeKey;
+  matchPaths?: string[];
   children?: NavItem[];
 };
 
@@ -184,6 +185,14 @@ export const NAV: NavItem[] = [
     path: "/people",
     icon: <Users className="h-5 w-5" aria-hidden="true" />,
     roles: LEADERSHIP_ROLES,
+    featureFlag: "peopleTeams",
+    matchPaths: [
+      "/people/:userId",
+      "/teams",
+      "/teams/:teamId",
+      "/projects/:projectId/people",
+      "/projects/:projectId/teams",
+    ],
   },
   {
     id: "time",
@@ -192,6 +201,11 @@ export const NAV: NavItem[] = [
     icon: <Clock3 className="h-5 w-5" aria-hidden="true" />,
     roles: ALL_ROLES,
     featureFlag: "timeTracking",
+    matchPaths: [
+      "/time/my",
+      "/time/approvals",
+      "/projects/:projectId/time",
+    ],
   },
   {
     id: "admin",

--- a/src/pages/people/PeoplePage.tsx
+++ b/src/pages/people/PeoplePage.tsx
@@ -1,0 +1,28 @@
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+export default function PeoplePage() {
+  useDocumentTitle("People");
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">People</h1>
+        <p className="text-sm text-muted-foreground">Directory coming soon.</p>
+      </header>
+      <div className="space-y-3 rounded-lg border bg-background p-6 shadow-sm">
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div
+              key={index}
+              className="h-10 w-full animate-pulse rounded-md bg-muted/60"
+              aria-hidden="true"
+            />
+          ))}
+        </div>
+        <p className="text-sm text-muted-foreground">
+          We are preparing the unified directory for people and teams.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/people/ProfilePage.tsx
+++ b/src/pages/people/ProfilePage.tsx
@@ -1,0 +1,33 @@
+import { useParams } from "react-router-dom";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+export default function ProfilePage() {
+  const { userId = "" } = useParams();
+  useDocumentTitle(`People / ${userId || "Member"}`);
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Member</h1>
+        <p className="text-sm text-muted-foreground">Profile setup is in progress.</p>
+      </header>
+      <div className="rounded-lg border bg-background p-6 shadow-sm">
+        <div className="flex items-center gap-4">
+          <div className="h-16 w-16 animate-pulse rounded-full bg-muted/60" aria-hidden="true" />
+          <div className="space-y-2">
+            <div className="h-4 w-40 animate-pulse rounded bg-muted/60" aria-hidden="true" />
+            <div className="h-3 w-32 animate-pulse rounded bg-muted/60" aria-hidden="true" />
+          </div>
+        </div>
+        <div className="mt-6 space-y-3 text-sm text-muted-foreground">
+          <p>We will load profile details for user {userId || "soon"}.</p>
+          <div className="space-y-2">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div key={index} className="h-4 w-full animate-pulse rounded bg-muted/40" aria-hidden="true" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/projects/ProjectPeoplePage.tsx
+++ b/src/pages/projects/ProjectPeoplePage.tsx
@@ -1,0 +1,26 @@
+import { useParams } from "react-router-dom";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+export default function ProjectPeoplePage() {
+  const { projectId = "" } = useParams();
+  useDocumentTitle(`Projects / ${projectId || "Project"} / People`);
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Project People</h1>
+        <p className="text-sm text-muted-foreground">Member assignments will display for project {projectId || "soon"}.</p>
+      </header>
+      <div className="rounded-lg border bg-background p-6 shadow-sm">
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="h-10 w-full animate-pulse rounded-md bg-muted/50" aria-hidden="true" />
+          ))}
+        </div>
+        <p className="mt-4 text-sm text-muted-foreground">
+          Use this area to review project members once the service is connected.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/projects/ProjectTeamsPage.tsx
+++ b/src/pages/projects/ProjectTeamsPage.tsx
@@ -1,0 +1,26 @@
+import { useParams } from "react-router-dom";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+export default function ProjectTeamsPage() {
+  const { projectId = "" } = useParams();
+  useDocumentTitle(`Projects / ${projectId || "Project"} / Teams`);
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Project Teams</h1>
+        <p className="text-sm text-muted-foreground">Linked teams will appear for project {projectId || "soon"}.</p>
+      </header>
+      <div className="rounded-lg border bg-background p-6 shadow-sm">
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="h-12 w-full animate-pulse rounded-md bg-muted/50" aria-hidden="true" />
+          ))}
+        </div>
+        <p className="mt-4 text-sm text-muted-foreground">
+          We will show shared ownership and staffing once the backend is ready.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/projects/ProjectTimePage.tsx
+++ b/src/pages/projects/ProjectTimePage.tsx
@@ -1,0 +1,26 @@
+import { useParams } from "react-router-dom";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+export default function ProjectTimePage() {
+  const { projectId = "" } = useParams();
+  useDocumentTitle(`Projects / ${projectId || "Project"} / Time`);
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Project Time</h1>
+        <p className="text-sm text-muted-foreground">Time summaries will load for project {projectId || "soon"}.</p>
+      </header>
+      <div className="rounded-lg border bg-background p-6 shadow-sm">
+        <div className="space-y-2">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <div key={index} className="h-24 w-full animate-pulse rounded-md bg-muted/40" aria-hidden="true" />
+          ))}
+        </div>
+        <p className="mt-4 text-sm text-muted-foreground">
+          Detailed hours by person and day will appear once tracking is wired.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/teams/TeamDetailPage.tsx
+++ b/src/pages/teams/TeamDetailPage.tsx
@@ -1,0 +1,30 @@
+import { useParams } from "react-router-dom";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+export default function TeamDetailPage() {
+  const { teamId = "" } = useParams();
+  useDocumentTitle(`Teams / ${teamId || "Team"}`);
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Team</h1>
+        <p className="text-sm text-muted-foreground">Member and project details are coming soon.</p>
+      </header>
+      <div className="space-y-4 rounded-lg border bg-background p-6 shadow-sm">
+        <div className="space-y-2">
+          <div className="h-5 w-32 animate-pulse rounded bg-muted/60" aria-hidden="true" />
+          <div className="h-4 w-48 animate-pulse rounded bg-muted/50" aria-hidden="true" />
+        </div>
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="h-10 w-full animate-pulse rounded-md bg-muted/50" aria-hidden="true" />
+          ))}
+        </div>
+        <p className="text-sm text-muted-foreground">
+          We will surface team {teamId || "details"} with members and linked projects here.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/teams/TeamsPage.tsx
+++ b/src/pages/teams/TeamsPage.tsx
@@ -1,0 +1,24 @@
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+export default function TeamsPage() {
+  useDocumentTitle("Teams");
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Teams</h1>
+        <p className="text-sm text-muted-foreground">Team lists will be ready shortly.</p>
+      </header>
+      <div className="rounded-lg border bg-background p-6 shadow-sm">
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="h-12 w-full animate-pulse rounded-md bg-muted/60" aria-hidden="true" />
+          ))}
+        </div>
+        <p className="mt-4 text-sm text-muted-foreground">
+          We are setting up team management and member workflows.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/time/ApprovalsPage.tsx
+++ b/src/pages/time/ApprovalsPage.tsx
@@ -1,0 +1,20 @@
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+export default function ApprovalsPage() {
+  useDocumentTitle("Time / Approvals");
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <p className="text-sm font-medium">Pending submissions</p>
+        <p className="text-sm text-muted-foreground">Managers will review and approve time periods here.</p>
+      </div>
+      <div className="space-y-2">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="h-16 w-full animate-pulse rounded-md bg-muted/50" aria-hidden="true" />
+        ))}
+      </div>
+      <p className="text-sm text-muted-foreground">No submissions yet. This view updates once time periods are sent for approval.</p>
+    </div>
+  );
+}

--- a/src/pages/time/MyTimePage.tsx
+++ b/src/pages/time/MyTimePage.tsx
@@ -1,0 +1,23 @@
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+export default function MyTimePage() {
+  useDocumentTitle("Time / My");
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="space-y-1">
+          <p className="text-sm font-medium">This week</p>
+          <p className="text-sm text-muted-foreground">We will load your tracked time and timers here.</p>
+        </div>
+        <div className="h-10 w-32 animate-pulse rounded-md bg-muted/60" aria-hidden="true" />
+      </div>
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <div key={index} className="h-12 w-full animate-pulse rounded-md bg-muted/50" aria-hidden="true" />
+        ))}
+      </div>
+      <p className="text-sm text-muted-foreground">Timesheet entry and submission actions are coming soon.</p>
+    </div>
+  );
+}

--- a/src/pages/time/TimeHomePage.tsx
+++ b/src/pages/time/TimeHomePage.tsx
@@ -1,0 +1,37 @@
+import { Link, Outlet, useLocation } from "react-router-dom";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Card, CardContent } from "@/components/ui/card";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+export default function TimeHomePage() {
+  const location = useLocation();
+  useDocumentTitle("Time");
+
+  const tabValue = location.pathname.endsWith("/approvals") ? "approvals" : "my";
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Time</h1>
+        <p className="text-sm text-muted-foreground">Track and approve work in one place.</p>
+      </header>
+      <Card>
+        <CardContent className="p-6">
+          <Tabs value={tabValue} onValueChange={() => {}} className="w-full">
+            <TabsList className="grid w-full grid-cols-2 md:w-auto">
+              <TabsTrigger value="my" asChild>
+                <Link to="/time/my">My</Link>
+              </TabsTrigger>
+              <TabsTrigger value="approvals" asChild>
+                <Link to="/time/approvals">Approvals</Link>
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+          <div className="mt-6">
+            <Outlet />
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -19,8 +19,16 @@ import IntegrationsPage from "@/pages/ia/IntegrationsPage";
 import FormsPage from "@/pages/ia/FormsPage";
 import GoalsPage from "@/pages/ia/GoalsPage";
 import TemplatesPage from "@/pages/ia/TemplatesPage";
-import PeoplePage from "@/pages/ia/PeoplePage";
-import TimeTrackingPage from "@/pages/ia/TimeTrackingPage";
+import PeoplePage from "@/pages/people/PeoplePage";
+import ProfilePage from "@/pages/people/ProfilePage";
+import TeamsPage from "@/pages/teams/TeamsPage";
+import TeamDetailPage from "@/pages/teams/TeamDetailPage";
+import TimeHomePage from "@/pages/time/TimeHomePage";
+import MyTimePage from "@/pages/time/MyTimePage";
+import ApprovalsPage from "@/pages/time/ApprovalsPage";
+import ProjectPeoplePage from "@/pages/projects/ProjectPeoplePage";
+import ProjectTeamsPage from "@/pages/projects/ProjectTeamsPage";
+import ProjectTimePage from "@/pages/projects/ProjectTimePage";
 import HelpPage from "@/pages/ia/HelpPage";
 import AdminHomePage from "@/pages/ia/admin/AdminHomePage";
 import AdminWorkspacePage from "@/pages/ia/admin/AdminWorkspacePage";
@@ -54,6 +62,7 @@ import NotFound from "@/pages/NotFound";
 import Profile from "@/pages/Profile";
 import Settings from "@/pages/Settings";
 import SearchPage from "@/pages/Search";
+import { FEATURE_PEOPLE_TEAMS, FEATURE_TIME_TRACKING } from "@/lib/featureFlags";
 
 const Suspended = ({ children }: { children: React.ReactNode }) => (
   <Suspense fallback={<div className="p-6">Loading...</div>}>
@@ -62,6 +71,83 @@ const Suspended = ({ children }: { children: React.ReactNode }) => (
 );
 
 export function AppRoutes() {
+  const children = [
+    { index: true, element: <HomePage /> },
+    { path: "my-work", element: <MyWorkPage /> },
+    { path: "inbox", element: <InboxPage /> },
+    { path: "projects", element: <ProjectsPage /> },
+    { path: "projects/new", element: <NewProjectPage /> },
+    { path: "projects/:projectId", element: <ProjectOverviewPage /> },
+    { path: "projects/:projectId/overview", element: <ProjectOverviewPage /> },
+    { path: "projects/:projectId/list", element: <ProjectListPage /> },
+    { path: "projects/:projectId/board", element: <ProjectBoardPage /> },
+    { path: "projects/:projectId/backlog", element: <ProjectBacklogPage /> },
+    { path: "projects/:projectId/sprints", element: <ProjectSprintsPage /> },
+    { path: "projects/:projectId/calendar", element: <ProjectCalendarPage /> },
+    { path: "projects/:projectId/timeline", element: <ProjectTimelinePage /> },
+    { path: "projects/:projectId/dependencies", element: <ProjectDependenciesPage /> },
+    { path: "projects/:projectId/reports", element: <ProjectReportsPage /> },
+    { path: "projects/:projectId/docs", element: <ProjectDocsPage /> },
+    { path: "projects/:projectId/files", element: <ProjectFilesPage /> },
+    { path: "projects/:projectId/automations", element: <ProjectAutomationsPage /> },
+    { path: "projects/:projectId/settings", element: <ProjectSettingsPage /> },
+    { path: "boards", element: <BoardsPage /> },
+    { path: "boards/new", element: <NewBoardPage /> },
+    { path: "calendar", element: <CalendarPage /> },
+    { path: "timeline", element: <TimelinePage /> },
+    { path: "workload", element: <WorkloadPage /> },
+    { path: "dashboards", element: <DashboardsPage /> },
+    { path: "dashboards/new", element: <NewDashboardPage /> },
+    { path: "reports", element: <ReportsPage /> },
+    { path: "docs", element: <DocsPage /> },
+    { path: "files", element: <FilesPage /> },
+    { path: "automations", element: <AutomationsPage /> },
+    { path: "integrations", element: <IntegrationsPage /> },
+    { path: "forms", element: <FormsPage /> },
+    { path: "goals", element: <GoalsPage /> },
+    { path: "templates", element: <TemplatesPage /> },
+    { path: "tasks/new", element: <NewTaskPage /> },
+    { path: "profile", element: <Profile /> },
+    { path: "settings", element: <Settings /> },
+    { path: "search", element: <SearchPage /> },
+    { path: "admin", element: <AdminHomePage /> },
+    { path: "admin/workspace", element: <AdminWorkspacePage /> },
+    { path: "admin/permissions", element: <AdminPermissionsPage /> },
+    { path: "admin/security", element: <AdminSecurityPage /> },
+    { path: "admin/audit", element: <AdminAuditPage /> },
+    { path: "admin/data", element: <AdminDataPage /> },
+    { path: "admin/webhooks", element: <AdminWebhooksPage /> },
+    { path: "admin/api", element: <AdminApiPage /> },
+    { path: "admin/billing", element: <AdminBillingPage /> },
+    { path: "help", element: <HelpPage /> },
+  ];
+
+  if (FEATURE_PEOPLE_TEAMS) {
+    children.push(
+      { path: "people", element: <PeoplePage /> },
+      { path: "people/:userId", element: <ProfilePage /> },
+      { path: "teams", element: <TeamsPage /> },
+      { path: "teams/:teamId", element: <TeamDetailPage /> },
+      { path: "projects/:projectId/people", element: <ProjectPeoplePage /> },
+      { path: "projects/:projectId/teams", element: <ProjectTeamsPage /> }
+    );
+  }
+
+  if (FEATURE_TIME_TRACKING) {
+    children.push(
+      {
+        path: "time",
+        element: <TimeHomePage />,
+        children: [
+          { index: true, element: <MyTimePage /> },
+          { path: "my", element: <MyTimePage /> },
+          { path: "approvals", element: <ApprovalsPage /> },
+        ],
+      },
+      { path: "projects/:projectId/time", element: <ProjectTimePage /> }
+    );
+  }
+
   return useRoutes([
     {
       path: "/",
@@ -70,58 +156,7 @@ export function AppRoutes() {
           <AppLayout />
         </Suspended>
       ),
-      children: [
-        { index: true, element: <HomePage /> },
-        { path: "my-work", element: <MyWorkPage /> },
-        { path: "inbox", element: <InboxPage /> },
-        { path: "projects", element: <ProjectsPage /> },
-        { path: "projects/new", element: <NewProjectPage /> },
-        { path: "projects/:projectId", element: <ProjectOverviewPage /> },
-        { path: "projects/:projectId/overview", element: <ProjectOverviewPage /> },
-        { path: "projects/:projectId/list", element: <ProjectListPage /> },
-        { path: "projects/:projectId/board", element: <ProjectBoardPage /> },
-        { path: "projects/:projectId/backlog", element: <ProjectBacklogPage /> },
-        { path: "projects/:projectId/sprints", element: <ProjectSprintsPage /> },
-        { path: "projects/:projectId/calendar", element: <ProjectCalendarPage /> },
-        { path: "projects/:projectId/timeline", element: <ProjectTimelinePage /> },
-        { path: "projects/:projectId/dependencies", element: <ProjectDependenciesPage /> },
-        { path: "projects/:projectId/reports", element: <ProjectReportsPage /> },
-        { path: "projects/:projectId/docs", element: <ProjectDocsPage /> },
-        { path: "projects/:projectId/files", element: <ProjectFilesPage /> },
-        { path: "projects/:projectId/automations", element: <ProjectAutomationsPage /> },
-        { path: "projects/:projectId/settings", element: <ProjectSettingsPage /> },
-        { path: "boards", element: <BoardsPage /> },
-        { path: "boards/new", element: <NewBoardPage /> },
-        { path: "calendar", element: <CalendarPage /> },
-        { path: "timeline", element: <TimelinePage /> },
-        { path: "workload", element: <WorkloadPage /> },
-        { path: "dashboards", element: <DashboardsPage /> },
-        { path: "dashboards/new", element: <NewDashboardPage /> },
-        { path: "reports", element: <ReportsPage /> },
-        { path: "docs", element: <DocsPage /> },
-        { path: "files", element: <FilesPage /> },
-        { path: "automations", element: <AutomationsPage /> },
-        { path: "integrations", element: <IntegrationsPage /> },
-        { path: "forms", element: <FormsPage /> },
-        { path: "goals", element: <GoalsPage /> },
-        { path: "templates", element: <TemplatesPage /> },
-        { path: "people", element: <PeoplePage /> },
-        { path: "time", element: <TimeTrackingPage /> },
-        { path: "tasks/new", element: <NewTaskPage /> },
-        { path: "profile", element: <Profile /> },
-        { path: "settings", element: <Settings /> },
-        { path: "search", element: <SearchPage /> },
-        { path: "admin", element: <AdminHomePage /> },
-        { path: "admin/workspace", element: <AdminWorkspacePage /> },
-        { path: "admin/permissions", element: <AdminPermissionsPage /> },
-        { path: "admin/security", element: <AdminSecurityPage /> },
-        { path: "admin/audit", element: <AdminAuditPage /> },
-        { path: "admin/data", element: <AdminDataPage /> },
-        { path: "admin/webhooks", element: <AdminWebhooksPage /> },
-        { path: "admin/api", element: <AdminApiPage /> },
-        { path: "admin/billing", element: <AdminBillingPage /> },
-        { path: "help", element: <HelpPage /> },
-      ],
+      children,
     },
     { path: "/login", element: <Login /> },
     { path: "/auth/callback", element: <AuthCallback /> },


### PR DESCRIPTION
## Summary
- add environment-controlled feature flags for People/Teams and Time Tracking and update navigation highlighting for scoped routes
- scaffold placeholder pages with document titles for global and project People, Teams, and Time destinations
- gate router configuration and breadcrumbs with the new flags while keeping existing sections untouched

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e337a526908327ab85057f26a18bb9