### PR TITLE
feat: expand docs workspace and reports navigation

### DIFF
--- a/__mocks__/@/integrations/supabase/client.ts
+++ b/__mocks__/@/integrations/supabase/client.ts
@@ -1,0 +1,35 @@
+const createQueryBuilder = () => {
+  const result = { data: [], error: null };
+  const builder: any = {
+    select: jest.fn(() => builder),
+    order: jest.fn(() => Promise.resolve(result)),
+    eq: jest.fn(() => builder),
+    is: jest.fn(() => builder),
+    or: jest.fn(() => builder),
+    limit: jest.fn(() => builder),
+    maybeSingle: jest.fn(() => Promise.resolve({ data: null, error: null })),
+    single: jest.fn(() => Promise.resolve({ data: null, error: null })),
+    insert: jest.fn(() => ({
+      select: () => ({
+        single: () => Promise.resolve({ data: { id: "mock-id" }, error: null }),
+      }),
+    })),
+    update: jest.fn(() => ({
+      select: () => ({
+        single: () => Promise.resolve({ data: { id: "mock-id" }, error: null }),
+      }),
+    })),
+    delete: jest.fn(() => Promise.resolve({ error: null })),
+    then: (resolve: (value: any) => void) => Promise.resolve(result).then(resolve),
+    catch: (reject: (reason: any) => void) => Promise.resolve(result).catch(reject),
+    finally: (callback: () => void) => Promise.resolve(result).finally(callback),
+  };
+  return builder;
+};
+
+export const supabase = {
+  from: jest.fn(() => createQueryBuilder()),
+  auth: {
+    getUser: jest.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+  },
+};

--- a/docs/reports-docs-inventory.md
+++ b/docs/reports-docs-inventory.md
@@ -1,0 +1,29 @@
+# Reports & Docs Inventory
+
+## Existing Files
+
+### Reports
+- `src/pages/Reports.tsx`
+- `src/pages/ia/ReportsPage.tsx`
+- `src/components/analytics/ReportsGenerator.tsx`
+- `src/components/analytics/ReportScheduler.tsx`
+
+### Docs & Wiki
+- `src/pages/Documents.tsx`
+- `src/pages/ia/DocsPage.tsx`
+- `src/components/docs/DocumentTemplates.tsx`
+- `src/components/operations/DocsWorkspacePanel.tsx`
+- `src/components/documents/DocumentManager.tsx`
+- `src/components/documents/DocumentTemplateSelector.tsx`
+- `src/components/knowledge/WikiKnowledgeBase.tsx`
+
+## Routes
+- `/reports` → `src/pages/ia/ReportsPage.tsx`
+- `/docs` → `src/pages/ia/DocsPage.tsx`
+- `/projects/:id/reports` → `src/pages/ia/projects/ProjectReportsPage.tsx`
+- `/projects/:id/docs` → `src/pages/ia/projects/ProjectDocsPage.tsx`
+
+## Observations
+- `ReportsPage`, `DocsPage`, `ProjectReportsPage`, and `ProjectDocsPage` are placeholders using shared templates.
+- Legacy `src/pages/Reports.tsx` and `src/pages/Documents.tsx` are not wired into the router.
+- No dedicated services, hooks, or Supabase tables for reports or docs exist yet.

--- a/docs/reports-docs-inventory.md
+++ b/docs/reports-docs-inventory.md
@@ -1,14 +1,41 @@
 # Reports & Docs Inventory
 
-## Existing Files
+## Reports
+- `src/pages/reports/ReportsHome.tsx`
+- `src/pages/reports/ReportCreate.tsx`
+- `src/pages/reports/ReportDetail.tsx`
+- `src/pages/reports/ReportEdit.tsx`
+- `src/hooks/useReports.ts`
+- `src/services/reports.ts`
+- `supabase/migrations/20251005060000_add_reports.sql`
 
-### Reports
+### Related legacy or auxiliary files
 - `src/pages/Reports.tsx`
 - `src/pages/ia/ReportsPage.tsx`
 - `src/components/analytics/ReportsGenerator.tsx`
 - `src/components/analytics/ReportScheduler.tsx`
+- `src/pages/ia/projects/ProjectReportsPage.tsx`
 
-### Docs & Wiki
+## Docs & Wiki
+- `src/pages/docs/DocsHome.tsx`
+- `src/pages/docs/DocCreate.tsx`
+- `src/pages/docs/DocDetail.tsx`
+- `src/pages/docs/DocEdit.tsx`
+- `src/pages/projects/ProjectDocsHome.tsx`
+- `src/pages/projects/ProjectDocCreate.tsx`
+- `src/pages/projects/ProjectDocDetail.tsx`
+- `src/pages/projects/ProjectDocEdit.tsx`
+- `src/components/docs/DocTree.tsx`
+- `src/components/docs/DocToolbar.tsx`
+- `src/components/docs/MarkdownEditor.tsx`
+- `src/components/docs/VersionHistory.tsx`
+- `src/hooks/useDocs.ts`
+- `src/services/docs.ts`
+- `src/services/storage.ts`
+- `supabase/migrations/20251005060010_add_docs.sql`
+- `supabase/migrations/20251005060020_add_docs_bucket.sql`
+
+### Related legacy or auxiliary files
 - `src/pages/Documents.tsx`
 - `src/pages/ia/DocsPage.tsx`
 - `src/components/docs/DocumentTemplates.tsx`
@@ -16,14 +43,14 @@
 - `src/components/documents/DocumentManager.tsx`
 - `src/components/documents/DocumentTemplateSelector.tsx`
 - `src/components/knowledge/WikiKnowledgeBase.tsx`
+- `src/pages/ia/projects/ProjectDocsPage.tsx`
 
 ## Routes
-- `/reports` → `src/pages/ia/ReportsPage.tsx`
-- `/docs` → `src/pages/ia/DocsPage.tsx`
-- `/projects/:id/reports` → `src/pages/ia/projects/ProjectReportsPage.tsx`
-- `/projects/:id/docs` → `src/pages/ia/projects/ProjectDocsPage.tsx`
+- `/reports`, `/reports/new`, `/reports/:reportId`, `/reports/:reportId/edit`
+- `/docs`, `/docs/new`, `/docs/:docId`, `/docs/:docId/edit`
+- `/projects/:projectId/docs`, `/projects/:projectId/docs/new`, `/projects/:projectId/docs/:docId`, `/projects/:projectId/docs/:docId/edit`
 
-## Observations
-- `ReportsPage`, `DocsPage`, `ProjectReportsPage`, and `ProjectDocsPage` are placeholders using shared templates.
-- Legacy `src/pages/Reports.tsx` and `src/pages/Documents.tsx` are not wired into the router.
-- No dedicated services, hooks, or Supabase tables for reports or docs exist yet.
+## Notes
+- Sidebar highlights `/reports` and `/docs` and stays active inside project-scoped docs routes.
+- Breadcrumbs resolve report names, doc titles, and project names where available.
+- Supabase services power CRUD operations plus report execution and doc version history.

--- a/src/components/docs/DocToolbar.tsx
+++ b/src/components/docs/DocToolbar.tsx
@@ -1,0 +1,76 @@
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { DocPage } from "@/types";
+import { Edit, History, Link, Plus, Trash, FolderSymlink } from "lucide-react";
+
+interface DocToolbarProps {
+  doc?: DocPage | null;
+  onCreate?: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+  onMove?: () => void;
+  onShowVersions?: () => void;
+  onCopyLink?: () => void;
+  onTogglePublish?: (value: boolean) => void;
+}
+
+export function DocToolbar({
+  doc,
+  onCreate,
+  onEdit,
+  onDelete,
+  onMove,
+  onShowVersions,
+  onCopyLink,
+  onTogglePublish,
+}: DocToolbarProps) {
+  const isPublished = doc?.is_published ?? true;
+
+  return (
+    <TooltipProvider>
+      <div className="flex flex-wrap items-center gap-2">
+        {onCreate && (
+          <Button size="sm" onClick={onCreate}>
+            <Plus className="mr-1 h-4 w-4" /> New doc
+          </Button>
+        )}
+        {onEdit && (
+          <Button size="sm" variant="outline" onClick={onEdit}>
+            <Edit className="mr-1 h-4 w-4" /> Edit
+          </Button>
+        )}
+        {onMove && (
+          <Button size="sm" variant="outline" onClick={onMove}>
+            <FolderSymlink className="mr-1 h-4 w-4" /> Move
+          </Button>
+        )}
+        {onShowVersions && (
+          <Button size="sm" variant="outline" onClick={onShowVersions}>
+            <History className="mr-1 h-4 w-4" /> Versions
+          </Button>
+        )}
+        {onCopyLink && (
+          <Button size="sm" variant="outline" onClick={onCopyLink}>
+            <Link className="mr-1 h-4 w-4" /> Copy link
+          </Button>
+        )}
+        {onDelete && (
+          <Button size="sm" variant="destructive" onClick={onDelete}>
+            <Trash className="mr-1 h-4 w-4" /> Delete
+          </Button>
+        )}
+        {onTogglePublish && (
+          <div className="ml-auto flex items-center gap-2 rounded border px-3 py-1 text-xs">
+            <span className="font-medium">Published</span>
+            <Switch
+              checked={isPublished}
+              onCheckedChange={onTogglePublish}
+              aria-label="Toggle publish"
+            />
+          </div>
+        )}
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/src/components/docs/DocTree.tsx
+++ b/src/components/docs/DocTree.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useMemo, useState } from "react";
+import { ChevronDown, ChevronRight, FileText, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { DocPage } from "@/types";
+
+interface DocTreeProps {
+  docs: DocPage[];
+  activeId?: string;
+  onSelect?: (doc: DocPage) => void;
+  onCreate?: (parentId?: string | null) => void;
+}
+
+type DocNode = DocPage & { children: DocNode[] };
+
+function buildTree(docs: DocPage[]): DocNode[] {
+  const map = new Map<string, DocNode>();
+  const roots: DocNode[] = [];
+
+  docs.forEach((doc) => {
+    map.set(doc.id, { ...doc, children: [] });
+  });
+
+  map.forEach((node) => {
+    if (node.parent_id && map.has(node.parent_id)) {
+      map.get(node.parent_id)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  });
+
+  const sortNodes = (items: DocNode[]) => {
+    items.sort((a, b) => a.title.localeCompare(b.title));
+    items.forEach((child) => sortNodes(child.children));
+  };
+
+  sortNodes(roots);
+  return roots;
+}
+
+export function DocTree({ docs, activeId, onSelect, onCreate }: DocTreeProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set<string>());
+
+  const tree = useMemo(() => buildTree(docs), [docs]);
+
+  useEffect(() => {
+    if (!activeId) {
+      return;
+    }
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      let current = docs.find((doc) => doc.id === activeId);
+      while (current?.parent_id) {
+        next.add(current.parent_id);
+        current = docs.find((doc) => doc.id === current?.parent_id);
+      }
+      return next;
+    });
+  }, [activeId, docs]);
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const renderNode = (node: DocNode, depth: number) => {
+    const isExpanded = expanded.has(node.id);
+    const hasChildren = node.children.length > 0;
+    const isActive = node.id === activeId;
+
+    return (
+      <div key={node.id}>
+        <div
+          className={`flex items-center gap-1 rounded px-2 py-1 text-sm ${
+            isActive ? "bg-primary/10 text-primary" : "hover:bg-muted"
+          }`}
+        >
+          <button
+            type="button"
+            onClick={() => (hasChildren ? toggle(node.id) : onSelect?.(node))}
+            className="flex flex-1 items-center gap-2 text-left"
+          >
+            {hasChildren ? (
+              isExpanded ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )
+            ) : (
+              <span className="w-4" />
+            )}
+            <FileText className="h-4 w-4 text-muted-foreground" />
+            <span onClick={() => onSelect?.(node)} className="truncate">
+              {node.title || "Untitled"}
+            </span>
+          </button>
+          {onCreate && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={() => onCreate(node.id)}
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+        {hasChildren && isExpanded && (
+          <div className="ml-4 border-l border-muted-foreground/20 pl-3">
+            {node.children.map((child) => renderNode(child, depth + 1))}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-medium text-muted-foreground">Pages</h2>
+        {onCreate && (
+          <Button size="sm" variant="outline" onClick={() => onCreate(null)}>
+            <Plus className="mr-1 h-4 w-4" />
+            New
+          </Button>
+        )}
+      </div>
+      <div className="space-y-1">
+        {tree.length === 0 ? (
+          <div className="rounded border border-dashed p-4 text-center text-xs text-muted-foreground">
+            No docs yet.
+          </div>
+        ) : (
+          tree.map((node) => renderNode(node, 0))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/docs/MarkdownEditor.tsx
+++ b/src/components/docs/MarkdownEditor.tsx
@@ -1,0 +1,154 @@
+import { ChangeEvent, useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { uploadDocImage } from "@/services/storage";
+import { useAuth } from "@/hooks/useAuth";
+import { useToast } from "@/hooks/use-toast";
+import { Image, Eye, Pencil } from "lucide-react";
+
+interface MarkdownEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function renderMarkdown(markdown: string) {
+  const escapeHtml = (value: string) =>
+    value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+  const escaped = escapeHtml(markdown);
+
+  const headingProcessed = escaped
+    .replace(/^######\s+(.*)$/gm, "<h6>$1</h6>")
+    .replace(/^#####\s+(.*)$/gm, "<h5>$1</h5>")
+    .replace(/^####\s+(.*)$/gm, "<h4>$1</h4>")
+    .replace(/^###\s+(.*)$/gm, "<h3>$1</h3>")
+    .replace(/^##\s+(.*)$/gm, "<h2>$1</h2>")
+    .replace(/^#\s+(.*)$/gm, "<h1>$1</h1>");
+
+  const emphasisProcessed = headingProcessed
+    .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.*?)\*/g, "<em>$1</em>")
+    .replace(/`([^`]+)`/g, "<code>$1</code>");
+
+  const lines = emphasisProcessed.split(/\n{2,}/).map((paragraph) => {
+    if (/^<h[1-6]>/.test(paragraph)) {
+      return paragraph;
+    }
+    if (/^\s*[-*]\s+/.test(paragraph)) {
+      const items = paragraph
+        .split(/\n/)
+        .filter(Boolean)
+        .map((item) => item.replace(/^\s*[-*]\s+/, ""));
+      return `<ul>${items.map((item) => `<li>${item}</li>`).join("")}</ul>`;
+    }
+    const content = paragraph.replace(/\n/g, "<br />");
+    return `<p>${content}</p>`;
+  });
+
+  return lines.join("");
+}
+
+export function MarkdownEditor({ value, onChange }: MarkdownEditorProps) {
+  const [tab, setTab] = useState("edit");
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const { user } = useAuth();
+  const { toast } = useToast();
+
+  const previewHtml = useMemo(() => renderMarkdown(value), [value]);
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    onChange(event.target.value);
+  };
+
+  const handleUploadClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const insertAtCursor = (snippet: string) => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      onChange(`${value}${snippet}`);
+      return;
+    }
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const nextValue = `${value.slice(0, start)}${snippet}${value.slice(end)}`;
+    onChange(nextValue);
+    requestAnimationFrame(() => {
+      textarea.focus();
+      const cursor = start + snippet.length;
+      textarea.setSelectionRange(cursor, cursor);
+    });
+  };
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+    if (!user) {
+      toast({ title: "Sign in required", description: "You must be signed in to upload images." });
+      return;
+    }
+    try {
+      const { publicUrl } = await uploadDocImage(file, user.id);
+      insertAtCursor(`![${file.name}](${publicUrl})`);
+      toast({ title: "Image uploaded", description: "We added a link to your doc." });
+    } catch (error: any) {
+      console.error(error);
+      toast({
+        title: "Upload failed",
+        description: error?.message ?? "We could not upload that image.",
+        variant: "destructive",
+      });
+    } finally {
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <Tabs value={tab} onValueChange={setTab} className="w-full">
+          <TabsList className="w-full justify-start">
+            <TabsTrigger value="edit" className="flex items-center gap-1">
+              <Pencil className="h-4 w-4" /> Edit
+            </TabsTrigger>
+            <TabsTrigger value="preview" className="flex items-center gap-1">
+              <Eye className="h-4 w-4" /> Preview
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="edit" className="mt-3">
+            <div className="flex items-center justify-between pb-2 text-xs text-muted-foreground">
+              <span>Markdown supported</span>
+              <Button type="button" size="sm" variant="outline" onClick={handleUploadClick}>
+                <Image className="mr-1 h-4 w-4" /> Upload image
+              </Button>
+              <input
+                type="file"
+                accept="image/*"
+                className="hidden"
+                ref={fileInputRef}
+                onChange={handleFileChange}
+              />
+            </div>
+            <Textarea
+              ref={textareaRef}
+              value={value}
+              onChange={handleChange}
+              rows={20}
+              className="font-mono text-sm"
+            />
+          </TabsContent>
+          <TabsContent value="preview" className="mt-3">
+            <div className="prose max-w-none whitespace-pre-wrap text-sm" dangerouslySetInnerHTML={{ __html: previewHtml }} />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+}

--- a/src/components/docs/VersionHistory.tsx
+++ b/src/components/docs/VersionHistory.tsx
@@ -1,0 +1,41 @@
+import { formatDistanceToNow } from "date-fns";
+import { Button } from "@/components/ui/button";
+interface VersionHistoryProps {
+  versions: Array<{ version: number; created_at: string; created_by: string | null }>;
+  onRestore?: (version: number) => void;
+  className?: string;
+}
+
+export function VersionHistory({ versions, onRestore, className }: VersionHistoryProps) {
+  if (!versions.length) {
+    return (
+      <div className={`rounded border border-dashed p-4 text-center text-sm text-muted-foreground ${className ?? ""}`}>
+        No versions yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className={`space-y-2 ${className ?? ""}`}>
+      {versions.map((version) => (
+        <div
+          key={version.version}
+          className="flex items-center justify-between rounded border px-3 py-2 text-sm"
+        >
+          <div>
+            <div className="font-medium">Version {version.version}</div>
+            <div className="text-xs text-muted-foreground">
+              Saved {formatDistanceToNow(new Date(version.created_at), { addSuffix: true })}
+              {version.created_by ? ` · ${version.created_by}` : ""}
+            </div>
+          </div>
+          {onRestore && (
+            <Button size="sm" variant="outline" onClick={() => onRestore(version.version)}>
+              Restore
+            </Button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/docs/__tests__/MarkdownEditor.test.tsx
+++ b/src/components/docs/__tests__/MarkdownEditor.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { MarkdownEditor } from "../MarkdownEditor";
+
+jest.mock("@/services/storage", () => ({
+  uploadDocImage: jest.fn(),
+}));
+
+jest.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "user-1" } }),
+}));
+
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+const { uploadDocImage } = jest.requireMock("@/services/storage");
+
+describe("MarkdownEditor", () => {
+  it("uploads an image and inserts markdown", async () => {
+    const handleChange = jest.fn();
+    (uploadDocImage as jest.Mock).mockResolvedValue({ publicUrl: "https://cdn/docs/img.png" });
+
+    const { container } = render(<MarkdownEditor value="" onChange={handleChange} />);
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["image"], "diagram.png", { type: "image/png" });
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(uploadDocImage).toHaveBeenCalledWith(file, "user-1");
+      expect(handleChange).toHaveBeenCalledWith("![diagram.png](https://cdn/docs/img.png)");
+    });
+  });
+});

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -5,6 +5,33 @@ import HomePage from "@/pages/ia/HomePage";
 import ProjectsPage from "@/pages/ia/ProjectsPage";
 import HelpPage from "@/pages/ia/HelpPage";
 
+jest.mock("@/state/profile", () => ({
+  useProfile: () => ({ profile: null, error: null }),
+}));
+
+jest.mock("@/hooks/useReports", () => ({
+  useReport: () => ({ data: null, isLoading: false, isError: false, refetch: jest.fn() }),
+  useReports: () => ({ data: [], isLoading: false, isError: false }),
+  useCreateReport: () => ({ mutateAsync: jest.fn(), isPending: false }),
+  useUpdateReport: () => ({ mutateAsync: jest.fn(), isPending: false }),
+  useDeleteReport: () => ({ mutateAsync: jest.fn(), isPending: false }),
+  useRunReport: () => ({ mutateAsync: jest.fn(), isPending: false }),
+}));
+
+jest.mock("@/hooks/useDocs", () => ({
+  useDoc: () => ({ data: null, isLoading: false, isError: false, refetch: jest.fn() }),
+  useDocs: () => ({ data: [], isLoading: false, isError: false }),
+  useCreateDoc: () => ({ mutateAsync: jest.fn(), isPending: false }),
+  useUpdateDoc: () => ({ mutateAsync: jest.fn(), isPending: false }),
+  useDeleteDoc: () => ({ mutateAsync: jest.fn(), isPending: false }),
+  useDocVersions: () => ({ data: [], isLoading: false, isError: false }),
+}));
+
+jest.mock("@/hooks/useProjectMeta", () => ({
+  useProjectMeta: () => ({ data: null, isLoading: false, isError: false }),
+  projectKeys: { detail: (id: string) => ["projects", "meta", id] },
+}));
+
 describe("AppLayout", () => {
   beforeAll(() => {
     Object.defineProperty(window, "matchMedia", {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -23,6 +23,16 @@ export function Sidebar({ isCollapsed, onCollapseToggle, onNavigate, className }
   const badgeCounts = { inboxCount, myWorkCount } as const;
   const location = useLocation();
   const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+  const additionalActiveMatchers = useMemo(
+    () => ({
+      "/docs": (path: string) =>
+        path === "/docs" ||
+        path.startsWith("/docs/") ||
+        /^\/projects\/[^/]+\/docs(\/.*)?$/.test(path),
+      "/reports": (path: string) => path === "/reports" || path.startsWith("/reports/"),
+    }),
+    []
+  );
 
   const flattened = useMemo(() => {
     const acc: Array<{ item: NavItem; depth: number }> = [];
@@ -55,7 +65,10 @@ export function Sidebar({ isCollapsed, onCollapseToggle, onNavigate, className }
   };
 
   const renderNavItem = (item: NavItem, index: number, depth = 0) => {
-    const isActive = location.pathname === item.path || location.pathname.startsWith(`${item.path}/`);
+    const baseActive =
+      location.pathname === item.path || location.pathname.startsWith(`${item.path}/`);
+    const extraActive = additionalActiveMatchers[item.path]?.(location.pathname) ?? false;
+    const isActive = baseActive || extraActive;
     const badgeValue = item.badgeKey ? badgeCounts[item.badgeKey] : 0;
     const showBadge = item.badgeKey ? badgeValue > 0 : false;
 
@@ -88,7 +101,7 @@ export function Sidebar({ isCollapsed, onCollapseToggle, onNavigate, className }
             {badgeValue}
           </span>
         )}
-        {isActive && (
+        {(isActive) && (
           <span
             aria-hidden="true"
             className="absolute left-0 top-1/2 h-8 w-0.5 -translate-y-1/2 rounded-full bg-primary"

--- a/src/hooks/useDocs.ts
+++ b/src/hooks/useDocs.ts
@@ -1,0 +1,124 @@
+import { useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { DocPage } from "@/types";
+import {
+  createDoc,
+  createDocVersionFromCurrent,
+  deleteDoc,
+  getDoc,
+  listDocVersions,
+  listDocs,
+  updateDoc,
+} from "@/services/docs";
+
+type DocsListParams = {
+  projectId?: string;
+  parentId?: string | null;
+  q?: string;
+};
+
+const docsKeys = {
+  all: ["docs"] as const,
+  list: (params: DocsListParams = {}) =>
+    [
+      "docs",
+      "list",
+      params.projectId ?? "all",
+      params.parentId ?? "any",
+      params.q ?? "",
+    ] as const,
+  detail: (id: string) => ["docs", "detail", id] as const,
+  versions: (id: string) => ["docs", "versions", id] as const,
+};
+
+export function useDocs(params: DocsListParams = {}) {
+  return useQuery({
+    queryKey: docsKeys.list(params),
+    queryFn: () => listDocs(params),
+    staleTime: 1000 * 30,
+  });
+}
+
+export function useDoc(id?: string) {
+  return useQuery({
+    queryKey: id ? docsKeys.detail(id) : ["docs", "detail", "missing"] as const,
+    queryFn: () => getDoc(id as string),
+    enabled: Boolean(id),
+    staleTime: 1000 * 60,
+  });
+}
+
+export function useCreateDoc() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createDoc,
+    onSuccess: async (doc) => {
+      await queryClient.invalidateQueries({ predicate: (query) => query.queryKey[0] === "docs" });
+      queryClient.setQueryData(docsKeys.detail(doc.id), doc);
+    },
+  });
+}
+
+export function useUpdateDoc() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: Parameters<typeof updateDoc>[1] }) =>
+      updateDoc(id, patch),
+    onSuccess: async (doc) => {
+      queryClient.setQueryData(docsKeys.detail(doc.id), doc);
+      await queryClient.invalidateQueries({ predicate: (query) => query.queryKey[0] === "docs" });
+    },
+  });
+}
+
+export function useDeleteDoc() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => deleteDoc(id),
+    onSuccess: async (_data, id) => {
+      queryClient.removeQueries({ queryKey: docsKeys.detail(id) });
+      await queryClient.invalidateQueries({ predicate: (query) => query.queryKey[0] === "docs" });
+    },
+  });
+}
+
+export function useDocVersions(docId?: string) {
+  return useQuery({
+    queryKey: docId ? docsKeys.versions(docId) : ["docs", "versions", "missing"] as const,
+    queryFn: () => listDocVersions(docId as string),
+    enabled: Boolean(docId),
+    staleTime: 1000 * 10,
+  });
+}
+
+export function useCreateDocVersion() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (docId: string) => createDocVersionFromCurrent(docId),
+    onSuccess: async (_data, docId) => {
+      await queryClient.invalidateQueries({ queryKey: docsKeys.versions(docId) });
+    },
+  });
+}
+
+export function useDocSearch(docs: DocPage[] | undefined, term: string) {
+  return useMemo(() => {
+    if (!docs) {
+      return [] as DocPage[];
+    }
+    const value = term.trim().toLowerCase();
+    if (!value) {
+      return docs;
+    }
+    return docs.filter((doc) => {
+      return (
+        doc.title.toLowerCase().includes(value) ||
+        (doc.body_markdown ?? "").toLowerCase().includes(value)
+      );
+    });
+  }, [docs, term]);
+}

--- a/src/hooks/useProjectMeta.ts
+++ b/src/hooks/useProjectMeta.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { getProjectMeta } from "@/services/projects";
+import type { ProjectMeta } from "@/types";
+
+export const projectKeys = {
+  detail: (projectId: string) => ["projects", "meta", projectId] as const,
+};
+
+export function useProjectMeta(projectId?: string, enabled = true) {
+  return useQuery<ProjectMeta | null>({
+    queryKey: projectId ? projectKeys.detail(projectId) : ["projects", "meta", "missing"],
+    queryFn: () => getProjectMeta(projectId as string),
+    enabled: Boolean(projectId) && enabled,
+    staleTime: 1000 * 60 * 5,
+  });
+}

--- a/src/hooks/useReports.ts
+++ b/src/hooks/useReports.ts
@@ -1,0 +1,137 @@
+import { useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { Report } from "@/types";
+import {
+  createReport,
+  deleteReport,
+  getReport,
+  listReports,
+  runReport,
+  updateReport,
+} from "@/services/reports";
+
+type ReportsQueryOptions = {
+  projectId?: string;
+  enabled?: boolean;
+};
+
+type RunReportVariables = {
+  config: any;
+};
+
+const reportsKeys = {
+  all: ["reports"] as const,
+  list: (projectId?: string) =>
+    ["reports", "list", projectId ?? "all"] as const,
+  detail: (id: string) => ["reports", "detail", id] as const,
+  run: (id?: string) => ["reports", "run", id ?? "config"] as const,
+};
+
+export function useReports({ projectId, enabled = true }: ReportsQueryOptions = {}) {
+  return useQuery({
+    queryKey: reportsKeys.list(projectId),
+    queryFn: () => listReports(projectId),
+    staleTime: 1000 * 30,
+    enabled,
+  });
+}
+
+export function useReport(id?: string) {
+  return useQuery({
+    queryKey: id ? reportsKeys.detail(id) : ["reports", "detail", "missing"] as const,
+    queryFn: () => getReport(id as string),
+    staleTime: 1000 * 60,
+    enabled: Boolean(id),
+  });
+}
+
+export function useCreateReport(projectId?: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createReport,
+    onSuccess: async (data) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: reportsKeys.all }),
+        projectId
+          ? queryClient.invalidateQueries({ queryKey: reportsKeys.list(projectId) })
+          : Promise.resolve(),
+      ]);
+      queryClient.setQueryData(reportsKeys.detail(data.id), data);
+    },
+  });
+}
+
+export function useUpdateReport() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: Parameters<typeof updateReport>[1] }) =>
+      updateReport(id, patch),
+    onSuccess: async (data) => {
+      queryClient.setQueryData(reportsKeys.detail(data.id), data);
+      await queryClient.invalidateQueries({ queryKey: reportsKeys.all });
+    },
+  });
+}
+
+export function useDeleteReport(projectId?: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => deleteReport(id),
+    onSuccess: async (_data, id) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: reportsKeys.all }),
+        projectId
+          ? queryClient.invalidateQueries({ queryKey: reportsKeys.list(projectId) })
+          : Promise.resolve(),
+      ]);
+      queryClient.removeQueries({ queryKey: reportsKeys.detail(id) });
+    },
+  });
+}
+
+export function useRunReport(id?: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: reportsKeys.run(id),
+    mutationFn: ({ config }: RunReportVariables) => runReport(config),
+    onSuccess: (_data, variables) => {
+      if (!id) {
+        return;
+      }
+      const cached = queryClient.getQueryData<Report | null>(reportsKeys.detail(id));
+      if (cached) {
+        const updated = {
+          ...cached,
+          config: variables.config,
+          updated_at: new Date().toISOString(),
+        };
+        queryClient.setQueryData(reportsKeys.detail(id), updated);
+      }
+    },
+  });
+}
+
+export function useReportSearch(
+  reports: Report[] | undefined,
+  searchTerm: string
+) {
+  return useMemo(() => {
+    if (!reports) {
+      return [];
+    }
+    const term = searchTerm.trim().toLowerCase();
+    if (!term) {
+      return reports;
+    }
+    return reports.filter((report) => {
+      return (
+        report.name.toLowerCase().includes(term) ||
+        (report.description ?? "").toLowerCase().includes(term)
+      );
+    });
+  }, [reports, searchTerm]);
+}

--- a/src/hooks/useUnsavedChangesPrompt.ts
+++ b/src/hooks/useUnsavedChangesPrompt.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import { useBlocker } from "react-router-dom";
+
+export function useUnsavedChangesPrompt(when: boolean, message = "You have unsaved changes. Leave without saving?") {
+  const blocker = useBlocker(when);
+
+  useEffect(() => {
+    if (blocker.state === "blocked") {
+      const confirmLeave = window.confirm(message);
+      if (confirmLeave) {
+        blocker.proceed();
+      } else {
+        blocker.reset();
+      }
+    }
+  }, [blocker, message]);
+
+  useEffect(() => {
+    const handler = (event: BeforeUnloadEvent) => {
+      if (when) {
+        event.preventDefault();
+        event.returnValue = "";
+      }
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [when]);
+}

--- a/src/pages/docs/DocCreate.tsx
+++ b/src/pages/docs/DocCreate.tsx
@@ -1,0 +1,174 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useDocs, useCreateDoc } from "@/hooks/useDocs";
+import { MarkdownEditor } from "@/components/docs/MarkdownEditor";
+import { supabase } from "@/integrations/supabase/client";
+import { useToast } from "@/hooks/use-toast";
+
+interface ProjectOption {
+  id: string;
+  name: string;
+}
+
+export default function DocCreate() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { toast } = useToast();
+  const [title, setTitle] = useState("");
+  const [projectId, setProjectId] = useState<string | "all">("all");
+  const [parentId, setParentId] = useState<string | "none">("none");
+  const [body, setBody] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    document.title = "Docs / New";
+  }, []);
+
+  useEffect(() => {
+    const parent = searchParams.get("parent");
+    if (parent) {
+      setParentId(parent);
+    }
+  }, [searchParams]);
+
+  const [projects, setProjects] = useState<ProjectOption[]>([]);
+  useEffect(() => {
+    let isMounted = true;
+    (async () => {
+      const { data, error } = await supabase
+        .from("projects")
+        .select("id, name")
+        .order("name", { ascending: true });
+      if (error) {
+        console.error(error);
+        return;
+      }
+      if (isMounted) {
+        setProjects(data ?? []);
+      }
+    })();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const docsQuery = useDocs({ projectId: projectId === "all" ? undefined : projectId });
+  const createDoc = useCreateDoc();
+
+  const availableParents = useMemo(() => docsQuery.data ?? [], [docsQuery.data]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    if (!title.trim()) {
+      setError("Title is required.");
+      return;
+    }
+
+    try {
+      const doc = await createDoc.mutateAsync({
+        title: title.trim(),
+        body_markdown: body,
+        project_id: projectId === "all" ? null : projectId,
+        parent_id: parentId === "none" ? null : parentId,
+      });
+      toast({ title: "Doc created" });
+      navigate(`/docs/${doc.id}`);
+    } catch (mutationError: any) {
+      console.error(mutationError);
+      setError(mutationError?.message ?? "Could not create doc.");
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-4xl p-6">
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Create doc</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {error && (
+              <Alert variant="destructive">
+                <AlertTitle>Something went wrong</AlertTitle>
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="title">Title</Label>
+              <Input
+                id="title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="Project brief"
+                required
+              />
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Project</Label>
+                <Select value={projectId} onValueChange={setProjectId}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="All projects" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All projects</SelectItem>
+                    {projects.map((project) => (
+                      <SelectItem key={project.id} value={project.id}>
+                        {project.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>Parent</Label>
+                <Select value={parentId} onValueChange={setParentId}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Top level" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">Top level</SelectItem>
+                    {availableParents.map((doc) => (
+                      <SelectItem key={doc.id} value={doc.id}>
+                        {doc.title}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Content</Label>
+              <MarkdownEditor value={body} onChange={setBody} />
+            </div>
+          </CardContent>
+          <CardFooter className="flex items-center justify-between">
+            <Button type="button" variant="ghost" onClick={() => navigate(-1)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={createDoc.isPending}>
+              {createDoc.isPending ? "Saving..." : "Create"}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/docs/DocDetail.tsx
+++ b/src/pages/docs/DocDetail.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { DocToolbar } from "@/components/docs/DocToolbar";
+import { VersionHistory } from "@/components/docs/VersionHistory";
+import { renderMarkdown } from "@/components/docs/MarkdownEditor";
+import { useDoc, useDocs, useDeleteDoc, useUpdateDoc, useDocVersions } from "@/hooks/useDocs";
+import { useToast } from "@/hooks/use-toast";
+import { supabase } from "@/integrations/supabase/client";
+import { createDocVersionFromCurrent } from "@/services/docs";
+
+export default function DocDetail() {
+  const { docId } = useParams<{ docId: string }>();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [isVersionsOpen, setVersionsOpen] = useState(false);
+  const [isMoveOpen, setMoveOpen] = useState(false);
+  const [moveTarget, setMoveTarget] = useState<string>("none");
+
+  const docQuery = useDoc(docId);
+  const docsQuery = useDocs();
+  const deleteDoc = useDeleteDoc();
+  const updateDoc = useUpdateDoc();
+  const versionsQuery = useDocVersions(isVersionsOpen ? docId : undefined);
+
+  useEffect(() => {
+    if (docQuery.data?.title) {
+      document.title = `Docs / ${docQuery.data.title}`;
+    }
+  }, [docQuery.data?.title]);
+
+  const hasChildren = useMemo(() => {
+    if (!docQuery.data || !docsQuery.data) {
+      return false;
+    }
+    return docsQuery.data.some((doc) => doc.parent_id === docQuery.data!.id);
+  }, [docQuery.data, docsQuery.data]);
+
+  const descendantIds = useMemo(() => {
+    if (!docQuery.data || !docsQuery.data) {
+      return new Set<string>();
+    }
+    const ids = new Set<string>();
+    const walk = (id: string) => {
+      docsQuery.data
+        ?.filter((doc) => doc.parent_id === id)
+        .forEach((child) => {
+          if (!ids.has(child.id)) {
+            ids.add(child.id);
+            walk(child.id);
+          }
+        });
+    };
+    walk(docQuery.data.id);
+    return ids;
+  }, [docQuery.data, docsQuery.data]);
+
+  const parentOptions = useMemo(() => {
+    if (!docsQuery.data || !docQuery.data) {
+      return [];
+    }
+    return docsQuery.data.filter(
+      (doc) => doc.id !== docQuery.data!.id && !descendantIds.has(doc.id)
+    );
+  }, [docsQuery.data, docQuery.data, descendantIds]);
+
+  const handleDelete = async () => {
+    if (!docQuery.data || !docId) {
+      return;
+    }
+    if (hasChildren) {
+      toast({
+        title: "Cannot delete",
+        description: "Move or delete child pages before removing this doc.",
+        variant: "destructive",
+      });
+      return;
+    }
+    const confirmed = window.confirm("Delete this doc?");
+    if (!confirmed) {
+      return;
+    }
+    try {
+      await deleteDoc.mutateAsync(docId);
+      toast({ title: "Doc deleted" });
+      navigate("/docs");
+    } catch (error: any) {
+      console.error(error);
+      toast({ title: "Delete failed", description: error?.message ?? "Could not delete doc", variant: "destructive" });
+    }
+  };
+
+  const handleTogglePublish = async (value: boolean) => {
+    if (!docId) {
+      return;
+    }
+    try {
+      await updateDoc.mutateAsync({ id: docId, patch: { is_published: value } });
+      toast({ title: value ? "Doc published" : "Doc hidden" });
+    } catch (error: any) {
+      console.error(error);
+      toast({ title: "Update failed", description: error?.message ?? "Could not update doc", variant: "destructive" });
+    }
+  };
+
+  const handleCopyLink = async () => {
+    if (!docId) {
+      return;
+    }
+    const url = `${window.location.origin}/docs/${docId}`;
+    await navigator.clipboard.writeText(url);
+    toast({ title: "Link copied" });
+  };
+
+  const handleMove = async () => {
+    if (!docId) {
+      return;
+    }
+    const parent_id = moveTarget === "none" ? null : moveTarget;
+    if (parent_id && descendantIds.has(parent_id)) {
+      toast({
+        title: "Invalid move",
+        description: "Choose a parent outside of this doc's subtree.",
+        variant: "destructive",
+      });
+      return;
+    }
+    try {
+      await updateDoc.mutateAsync({ id: docId, patch: { parent_id } });
+      toast({ title: "Doc moved" });
+      setMoveOpen(false);
+    } catch (error: any) {
+      console.error(error);
+      toast({ title: "Move failed", description: error?.message ?? "Could not move doc", variant: "destructive" });
+    }
+  };
+
+  const handleRestore = async (version: number) => {
+    if (!docId || !docQuery.data) {
+      return;
+    }
+    try {
+      const { data, error } = await supabase
+        .from("doc_versions")
+        .select("title, body_markdown")
+        .eq("doc_id", docId)
+        .eq("version", version)
+        .maybeSingle();
+      if (error || !data) {
+        throw error ?? new Error("Version not found");
+      }
+      await createDocVersionFromCurrent(docId);
+      await updateDoc.mutateAsync({
+        id: docId,
+        patch: {
+          title: data.title,
+          body_markdown: data.body_markdown ?? "",
+          version: docQuery.data.version + 1,
+        },
+      });
+      toast({ title: "Version restored" });
+      setVersionsOpen(false);
+    } catch (error: any) {
+      console.error(error);
+      toast({ title: "Restore failed", description: error?.message ?? "Could not restore version", variant: "destructive" });
+    }
+  };
+
+  if (docQuery.isLoading) {
+    return <div className="p-6 text-sm text-muted-foreground">Loading doc...</div>;
+  }
+
+  if (docQuery.isError) {
+    return (
+      <div className="p-6">
+        <Alert variant="destructive">
+          <AlertTitle>We could not load this doc</AlertTitle>
+          <AlertDescription>
+            {docQuery.error instanceof Error && docQuery.error.message.includes("permission")
+              ? "You do not have access."
+              : "Try reloading the page."}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  if (!docQuery.data) {
+    return <div className="p-6 text-sm text-muted-foreground">Doc not found.</div>;
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-4xl space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">{docQuery.data.title}</h1>
+          <p className="text-sm text-muted-foreground">Version {docQuery.data.version}</p>
+        </div>
+        <Button onClick={() => navigate(`/docs/${docId}/edit`)}>Edit</Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <DocToolbar
+              doc={docQuery.data}
+              onCreate={() => navigate(`/docs/new?parent=${docQuery.data.id}`)}
+              onEdit={() => navigate(`/docs/${docId}/edit`)}
+              onDelete={handleDelete}
+              onMove={() => {
+                setMoveTarget(docQuery.data?.parent_id ?? "none");
+                setMoveOpen(true);
+              }}
+              onShowVersions={() => setVersionsOpen(true)}
+              onCopyLink={handleCopyLink}
+              onTogglePublish={handleTogglePublish}
+            />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div
+            className="prose max-w-none text-sm"
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(docQuery.data.body_markdown ?? "") }}
+          />
+        </CardContent>
+      </Card>
+
+      <Dialog open={isVersionsOpen} onOpenChange={setVersionsOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Version history</DialogTitle>
+          </DialogHeader>
+          {versionsQuery.isLoading ? (
+            <div className="py-6 text-center text-sm text-muted-foreground">Loading versions...</div>
+          ) : versionsQuery.isError ? (
+            <div className="py-6 text-center text-sm text-destructive">Could not load versions.</div>
+          ) : (
+            <VersionHistory versions={versionsQuery.data ?? []} onRestore={handleRestore} />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isMoveOpen} onOpenChange={setMoveOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Move doc</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Select value={moveTarget} onValueChange={setMoveTarget}>
+              <SelectTrigger>
+                <SelectValue placeholder="Top level" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">Top level</SelectItem>
+                {parentOptions.map((doc) => (
+                  <SelectItem key={doc.id} value={doc.id}>
+                    {doc.title}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setMoveOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleMove} disabled={updateDoc.isPending}>
+              {updateDoc.isPending ? "Moving..." : "Move"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/docs/DocEdit.tsx
+++ b/src/pages/docs/DocEdit.tsx
@@ -1,0 +1,206 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { MarkdownEditor } from "@/components/docs/MarkdownEditor";
+import { useDoc, useDocs, useUpdateDoc } from "@/hooks/useDocs";
+import { createDocVersionFromCurrent } from "@/services/docs";
+import { useToast } from "@/hooks/use-toast";
+import { useUnsavedChangesPrompt } from "@/hooks/useUnsavedChangesPrompt";
+
+export default function DocEdit() {
+  const { docId } = useParams<{ docId: string }>();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const docQuery = useDoc(docId);
+  const docsQuery = useDocs();
+  const updateDoc = useUpdateDoc();
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [parentId, setParentId] = useState<string | "none">("none");
+  const [isPublished, setIsPublished] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isDirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    if (docQuery.data) {
+      setTitle(docQuery.data.title);
+      setBody(docQuery.data.body_markdown ?? "");
+      setParentId(docQuery.data.parent_id ?? "none");
+      setIsPublished(docQuery.data.is_published);
+      document.title = `Docs / ${docQuery.data.title} / Edit`;
+    }
+  }, [docQuery.data]);
+
+  useUnsavedChangesPrompt(isDirty);
+
+  const descendantIds = useMemo(() => {
+    if (!docQuery.data || !docsQuery.data) {
+      return new Set<string>();
+    }
+    const ids = new Set<string>();
+    const walk = (id: string) => {
+      docsQuery.data
+        ?.filter((doc) => doc.parent_id === id)
+        .forEach((child) => {
+          if (!ids.has(child.id)) {
+            ids.add(child.id);
+            walk(child.id);
+          }
+        });
+    };
+    walk(docQuery.data.id);
+    return ids;
+  }, [docQuery.data, docsQuery.data]);
+
+  const parentOptions = useMemo(() => {
+    if (!docsQuery.data || !docQuery.data) {
+      return [];
+    }
+    return docsQuery.data.filter(
+      (doc) => doc.id !== docQuery.data!.id && !descendantIds.has(doc.id)
+    );
+  }, [docsQuery.data, docQuery.data, descendantIds]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!docId || !docQuery.data) {
+      return;
+    }
+    setError(null);
+
+    if (!title.trim()) {
+      setError("Title is required.");
+      return;
+    }
+
+    try {
+      if (title.trim() !== docQuery.data.title || body !== (docQuery.data.body_markdown ?? "")) {
+        await createDocVersionFromCurrent(docId);
+      }
+      if (parentId !== "none" && descendantIds.has(parentId)) {
+        setError("Select a parent outside of this doc's subtree.");
+        return;
+      }
+
+      await updateDoc.mutateAsync({
+        id: docId,
+        patch: {
+          title: title.trim(),
+          body_markdown: body,
+          parent_id: parentId === "none" ? null : parentId,
+          is_published: isPublished,
+          version: docQuery.data.version + 1,
+        },
+      });
+      setDirty(false);
+      toast({ title: "Doc updated" });
+      navigate(`/docs/${docId}`);
+    } catch (mutationError: any) {
+      console.error(mutationError);
+      setError(mutationError?.message ?? "Could not update doc.");
+    }
+  };
+
+  if (docQuery.isLoading) {
+    return <div className="p-6 text-sm text-muted-foreground">Loading doc...</div>;
+  }
+
+  if (docQuery.isError || !docQuery.data) {
+    return (
+      <div className="p-6">
+        <Alert variant="destructive">
+          <AlertTitle>We could not load this doc</AlertTitle>
+          <AlertDescription>
+            {docQuery.error instanceof Error && docQuery.error.message.includes("permission")
+              ? "You do not have access."
+              : "Try reloading the page."}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-4xl p-6">
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-6"
+        onChange={() => setDirty(true)}
+      >
+        <Card>
+          <CardHeader>
+            <CardTitle>Edit doc</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {error && (
+              <Alert variant="destructive">
+                <AlertTitle>Something went wrong</AlertTitle>
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="title">Title</Label>
+              <Input
+                id="title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                required
+              />
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Parent</Label>
+                <Select value={parentId} onValueChange={setParentId}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Top level" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">Top level</SelectItem>
+                    {parentOptions.map((doc) => (
+                      <SelectItem key={doc.id} value={doc.id}>
+                        {doc.title}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label className="flex items-center gap-2">
+                  Published
+                  <Switch checked={isPublished} onCheckedChange={setIsPublished} />
+                </Label>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Content</Label>
+              <MarkdownEditor value={body} onChange={setBody} />
+            </div>
+          </CardContent>
+          <CardFooter className="flex items-center justify-between">
+            <Button type="button" variant="ghost" onClick={() => navigate(-1)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={updateDoc.isPending}>
+              {updateDoc.isPending ? "Saving..." : "Save changes"}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/docs/DocsHome.tsx
+++ b/src/pages/docs/DocsHome.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useDocs, useDocSearch, useDeleteDoc, useUpdateDoc, useDocVersions } from "@/hooks/useDocs";
+import { DocTree } from "@/components/docs/DocTree";
+import { DocToolbar } from "@/components/docs/DocToolbar";
+import { VersionHistory } from "@/components/docs/VersionHistory";
+import { renderMarkdown } from "@/components/docs/MarkdownEditor";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useToast } from "@/hooks/use-toast";
+
+export default function DocsHome() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [search, setSearch] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [isVersionsOpen, setVersionsOpen] = useState(false);
+
+  useEffect(() => {
+    document.title = "Docs";
+  }, []);
+
+  const docsQuery = useDocs();
+  const deleteDoc = useDeleteDoc();
+  const updateDoc = useUpdateDoc();
+  const versionsQuery = useDocVersions(isVersionsOpen ? selectedId ?? undefined : undefined);
+
+  useEffect(() => {
+    if (!selectedId && docsQuery.data?.length) {
+      setSelectedId(docsQuery.data[0].id);
+    }
+  }, [docsQuery.data, selectedId]);
+
+  const filteredDocs = useDocSearch(docsQuery.data, search);
+
+  const selectedDoc = useMemo(() => {
+    if (!selectedId || !docsQuery.data) {
+      return null;
+    }
+    return docsQuery.data.find((doc) => doc.id === selectedId) ?? null;
+  }, [selectedId, docsQuery.data]);
+
+  const handleCreate = (parentId?: string | null) => {
+    const params = new URLSearchParams();
+    if (parentId) {
+      params.set("parent", parentId);
+    }
+    navigate(`/docs/new${params.toString() ? `?${params.toString()}` : ""}`);
+  };
+
+  const handleEdit = () => {
+    if (!selectedDoc) {
+      return;
+    }
+    navigate(`/docs/${selectedDoc.id}/edit`);
+  };
+
+  const handleOpenVersions = () => {
+    if (!selectedDoc) {
+      return;
+    }
+    setVersionsOpen(true);
+  };
+
+  const handleTogglePublish = async (value: boolean) => {
+    if (!selectedDoc) {
+      return;
+    }
+    try {
+      await updateDoc.mutateAsync({ id: selectedDoc.id, patch: { is_published: value } });
+      toast({ title: value ? "Doc published" : "Doc hidden" });
+    } catch (error: any) {
+      console.error(error);
+      toast({ title: "Update failed", description: error?.message ?? "Could not update doc", variant: "destructive" });
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!selectedDoc) {
+      return;
+    }
+    const hasChildren = docsQuery.data?.some((doc) => doc.parent_id === selectedDoc.id);
+    if (hasChildren) {
+      toast({
+        title: "Cannot delete",
+        description: "Move or delete child pages before removing this doc.",
+        variant: "destructive",
+      });
+      return;
+    }
+    const confirmed = window.confirm("Delete this doc?");
+    if (!confirmed) {
+      return;
+    }
+    try {
+      await deleteDoc.mutateAsync(selectedDoc.id);
+      toast({ title: "Doc deleted" });
+      setSelectedId(null);
+    } catch (error: any) {
+      console.error(error);
+      toast({ title: "Delete failed", description: error?.message ?? "Could not delete doc", variant: "destructive" });
+    }
+  };
+
+  const handleCopyLink = async () => {
+    if (!selectedDoc) {
+      return;
+    }
+    const url = `${window.location.origin}/docs/${selectedDoc.id}`;
+    await navigator.clipboard.writeText(url);
+    toast({ title: "Link copied" });
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl gap-6 p-6">
+      <aside className="hidden w-full max-w-xs flex-shrink-0 flex-col gap-4 rounded border bg-background p-4 md:flex">
+        <Input
+          placeholder="Search docs"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+        />
+        {docsQuery.isLoading ? (
+          <div className="py-10 text-center text-sm text-muted-foreground">Loading docs...</div>
+        ) : docsQuery.isError ? (
+          <div className="py-10 text-center text-sm text-destructive">
+            {docsQuery.error instanceof Error && docsQuery.error.message.includes("permission")
+              ? "You do not have access."
+              : "We could not load docs."}
+          </div>
+        ) : (
+          <DocTree
+            docs={filteredDocs}
+            activeId={selectedId ?? undefined}
+            onSelect={(doc) => setSelectedId(doc.id)}
+            onCreate={handleCreate}
+          />
+        )}
+      </aside>
+      <main className="flex-1 space-y-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">Docs</h1>
+            <p className="text-sm text-muted-foreground">Centralize documentation for every team.</p>
+          </div>
+          <Button onClick={() => handleCreate(null)}>New doc</Button>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex flex-col gap-2">
+              <span>{selectedDoc?.title ?? "Select a doc"}</span>
+              {selectedDoc && (
+                <DocToolbar
+                  doc={selectedDoc}
+                  onCreate={() => handleCreate(selectedDoc.id)}
+                  onEdit={handleEdit}
+                  onDelete={handleDelete}
+                  onShowVersions={handleOpenVersions}
+                  onCopyLink={handleCopyLink}
+                  onTogglePublish={handleTogglePublish}
+                />
+              )}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {docsQuery.isLoading ? (
+              <div className="py-10 text-center text-sm text-muted-foreground">Loading doc...</div>
+            ) : !selectedDoc ? (
+              <div className="py-10 text-center text-sm text-muted-foreground">
+                Select a doc from the list to preview its contents.
+              </div>
+            ) : (
+              <div
+                className="prose max-w-none text-sm"
+                dangerouslySetInnerHTML={{ __html: renderMarkdown(selectedDoc.body_markdown ?? "") }}
+              />
+            )}
+          </CardContent>
+        </Card>
+      </main>
+
+      <Dialog open={isVersionsOpen} onOpenChange={setVersionsOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Version history</DialogTitle>
+          </DialogHeader>
+          {versionsQuery.isLoading ? (
+            <div className="py-6 text-center text-sm text-muted-foreground">Loading versions...</div>
+          ) : versionsQuery.isError ? (
+            <div className="py-6 text-center text-sm text-destructive">Could not load versions.</div>
+          ) : (
+            <VersionHistory versions={versionsQuery.data ?? []} />
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/docs/__tests__/DocPages.test.tsx
+++ b/src/pages/docs/__tests__/DocPages.test.tsx
@@ -1,0 +1,256 @@
+import { fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useParams } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import DocsHome from "../DocsHome";
+import DocEdit from "../DocEdit";
+import type { DocPage } from "@/types";
+import { useDocSearch } from "@/hooks/useDocs";
+
+jest.mock("@/components/docs/DocToolbar", () => ({
+  DocToolbar: () => <div data-testid="doc-toolbar" />,
+}));
+
+jest.mock("@/components/docs/VersionHistory", () => ({
+  VersionHistory: () => <div data-testid="version-history" />,
+}));
+
+jest.mock("@/hooks/useUnsavedChangesPrompt", () => ({
+  useUnsavedChangesPrompt: () => undefined,
+}));
+
+jest.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "user-1" } }),
+}));
+
+jest.mock("@/hooks/useDocs", () => {
+  const actual = jest.requireActual("@/hooks/useDocs");
+  return {
+    ...actual,
+    useDocs: jest.fn(),
+    useDoc: jest.fn(),
+    useCreateDoc: jest.fn(),
+    useUpdateDoc: jest.fn(),
+    useDeleteDoc: jest.fn(),
+    useDocVersions: jest.fn(),
+  };
+});
+
+jest.mock("@/services/docs", () => {
+  const actual = jest.requireActual("@/services/docs");
+  return {
+    ...actual,
+    createDocVersionFromCurrent: jest.fn(),
+  };
+});
+
+jest.mock("@/integrations/supabase/client", () => {
+  const createBuilder = () => {
+    const result = { data: [], error: null };
+    const builder: any = {
+      select: jest.fn(() => builder),
+      order: jest.fn(() => Promise.resolve(result)),
+      eq: jest.fn(() => builder),
+      is: jest.fn(() => builder),
+      limit: jest.fn(() => builder),
+      maybeSingle: jest.fn(() => Promise.resolve({ data: null, error: null })),
+      single: jest.fn(() => Promise.resolve({ data: null, error: null })),
+      insert: jest.fn(() => ({
+        select: () => ({
+          single: () => Promise.resolve({ data: { id: "doc-1" }, error: null }),
+        }),
+      })),
+      update: jest.fn(() => ({
+        select: () => ({
+          single: () => Promise.resolve({ data: { id: "doc-1" }, error: null }),
+        }),
+      })),
+      delete: jest.fn(() => Promise.resolve({ error: null })),
+      then: (resolve: (value: any) => void) => Promise.resolve(result).then(resolve),
+      catch: (reject: (reason: any) => void) => Promise.resolve(result).catch(reject),
+      finally: (callback: () => void) => Promise.resolve(result).finally(callback),
+    };
+    return builder;
+  };
+
+  return {
+    supabase: {
+      from: jest.fn(() => createBuilder()),
+      auth: {
+        getUser: jest.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+      },
+    },
+  };
+});
+
+const { useDocs, useDoc, useUpdateDoc, useDeleteDoc, useDocVersions } =
+  jest.requireMock("@/hooks/useDocs");
+const { createDocVersionFromCurrent } = jest.requireMock("@/services/docs");
+
+const createClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+const DocDetailStub = () => {
+  const params = useParams();
+  return <div>Doc detail {params.docId}</div>;
+};
+
+describe("Docs flows", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders docs in the tree", () => {
+    const docs: DocPage[] = [
+      {
+        id: "doc-1",
+        owner: "user-1",
+        title: "Project Plan",
+        body_markdown: "Hello",
+        is_published: true,
+        version: 1,
+        project_id: null,
+        parent_id: null,
+        slug: "project-plan",
+        created_at: "",
+        updated_at: "",
+        created_by: null,
+        updated_by: null,
+        body_html: null,
+      },
+    ];
+
+    (useDocs as jest.Mock).mockReturnValue({
+      data: docs,
+      isLoading: false,
+      isError: false,
+    });
+    (useDeleteDoc as jest.Mock).mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    (useUpdateDoc as jest.Mock).mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    (useDocVersions as jest.Mock).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    const client = createClient();
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={["/docs"]}>
+          <Routes>
+            <Route path="/docs" element={<DocsHome />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expect(screen.getAllByText("Project Plan").length).toBeGreaterThan(0);
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("saves doc edits and bumps version", async () => {
+    const doc: DocPage = {
+      id: "doc-1",
+      owner: "user-1",
+      title: "Plan",
+      body_markdown: "Initial",
+      is_published: true,
+      version: 2,
+      project_id: null,
+      parent_id: null,
+      slug: "plan",
+      created_at: "",
+      updated_at: "",
+      created_by: null,
+      updated_by: null,
+      body_html: null,
+    };
+
+    (useDoc as jest.Mock).mockReturnValue({
+      data: doc,
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+    (useDocs as jest.Mock).mockReturnValue({ data: [doc], isLoading: false, isError: false });
+    const mutateAsync = jest.fn().mockResolvedValue({ id: "doc-1" });
+    (useUpdateDoc as jest.Mock).mockReturnValue({ mutateAsync, isPending: false });
+    (createDocVersionFromCurrent as jest.Mock).mockResolvedValue(undefined);
+
+    const client = createClient();
+
+    const { container } = render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={["/docs/doc-1/edit"]}>
+          <Routes>
+            <Route path="/docs/:docId/edit" element={<DocEdit />} />
+            <Route path="/docs/:docId" element={<DocDetailStub />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Plan Updated" } });
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "Revised" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(createDocVersionFromCurrent).toHaveBeenCalledWith("doc-1"));
+    expect(mutateAsync).toHaveBeenCalled();
+    const payload = mutateAsync.mock.calls[0][0];
+    expect(payload.patch.version).toBe(3);
+    expect(await screen.findByText("Doc detail doc-1")).toBeInTheDocument();
+  });
+});
+
+describe("useDocSearch", () => {
+  it("filters docs by title or body", () => {
+    const docs: DocPage[] = [
+      {
+        id: "1",
+        owner: "user-1",
+        title: "Project Brief",
+        body_markdown: "Overview",
+        is_published: true,
+        version: 1,
+        project_id: null,
+        parent_id: null,
+        slug: "brief",
+        created_at: "",
+        updated_at: "",
+        created_by: null,
+        updated_by: null,
+        body_html: null,
+      },
+      {
+        id: "2",
+        owner: "user-1",
+        title: "Release Notes",
+        body_markdown: "Updates",
+        is_published: true,
+        version: 1,
+        project_id: null,
+        parent_id: null,
+        slug: "release",
+        created_at: "",
+        updated_at: "",
+        created_by: null,
+        updated_by: null,
+        body_html: null,
+      },
+    ];
+
+    const { result, rerender } = renderHook(({ term }) => useDocSearch(docs, term), {
+      initialProps: { term: "" },
+    });
+
+    expect(result.current).toHaveLength(2);
+    rerender({ term: "release" });
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].title).toBe("Release Notes");
+  });
+});

--- a/src/pages/projects/ProjectDocCreate.tsx
+++ b/src/pages/projects/ProjectDocCreate.tsx
@@ -1,0 +1,137 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { MarkdownEditor } from "@/components/docs/MarkdownEditor";
+import { useDocs, useCreateDoc } from "@/hooks/useDocs";
+import { useToast } from "@/hooks/use-toast";
+import { useProjectMeta } from "@/hooks/useProjectMeta";
+
+export default function ProjectDocCreate() {
+  const { projectId } = useParams<{ projectId: string }>();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [title, setTitle] = useState("");
+  const [parentId, setParentId] = useState<string | "none">("none");
+  const [body, setBody] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const projectMeta = useProjectMeta(projectId);
+
+  useEffect(() => {
+    const projectLabel = projectMeta.data?.name ?? projectId ?? "Project";
+    document.title = `Projects / ${projectLabel} / Docs / New`;
+  }, [projectMeta.data?.name, projectId]);
+
+  useEffect(() => {
+    const parent = searchParams.get("parent");
+    if (parent) {
+      setParentId(parent);
+    }
+  }, [searchParams]);
+
+  const docsQuery = useDocs({ projectId });
+  const createDoc = useCreateDoc();
+
+  const availableParents = useMemo(() => docsQuery.data ?? [], [docsQuery.data]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    if (!projectId) {
+      setError("Missing project.");
+      return;
+    }
+
+    if (!title.trim()) {
+      setError("Title is required.");
+      return;
+    }
+
+    try {
+      const doc = await createDoc.mutateAsync({
+        title: title.trim(),
+        body_markdown: body,
+        project_id: projectId,
+        parent_id: parentId === "none" ? null : parentId,
+      });
+      toast({ title: "Doc created" });
+      navigate(`/projects/${projectId}/docs/${doc.id}`);
+    } catch (mutationError: any) {
+      console.error(mutationError);
+      setError(mutationError?.message ?? "Could not create doc.");
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-4xl p-6">
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Create doc</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {error && (
+              <Alert variant="destructive">
+                <AlertTitle>Something went wrong</AlertTitle>
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="title">Title</Label>
+              <Input
+                id="title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Parent</Label>
+              <Select value={parentId} onValueChange={setParentId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Top level" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">Top level</SelectItem>
+                  {availableParents.map((doc) => (
+                    <SelectItem key={doc.id} value={doc.id}>
+                      {doc.title}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Content</Label>
+              <MarkdownEditor value={body} onChange={setBody} />
+            </div>
+          </CardContent>
+          <CardFooter className="flex items-center justify-between">
+            <Button type="button" variant="ghost" onClick={() => navigate(-1)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={createDoc.isPending}>
+              {createDoc.isPending ? "Saving..." : "Create"}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/projects/ProjectDocDetail.tsx
+++ b/src/pages/projects/ProjectDocDetail.tsx
@@ -1,0 +1,293 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { DocToolbar } from "@/components/docs/DocToolbar";
+import { VersionHistory } from "@/components/docs/VersionHistory";
+import { renderMarkdown } from "@/components/docs/MarkdownEditor";
+import { useDoc, useDocs, useDeleteDoc, useUpdateDoc, useDocVersions } from "@/hooks/useDocs";
+import { useToast } from "@/hooks/use-toast";
+import { supabase } from "@/integrations/supabase/client";
+import { createDocVersionFromCurrent } from "@/services/docs";
+import { useProjectMeta } from "@/hooks/useProjectMeta";
+
+export default function ProjectDocDetail() {
+  const { projectId, docId } = useParams<{ projectId: string; docId: string }>();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [isVersionsOpen, setVersionsOpen] = useState(false);
+  const [isMoveOpen, setMoveOpen] = useState(false);
+  const [moveTarget, setMoveTarget] = useState<string>("none");
+
+  const docQuery = useDoc(docId);
+  const docsQuery = useDocs({ projectId });
+  const deleteDoc = useDeleteDoc();
+  const updateDoc = useUpdateDoc();
+  const versionsQuery = useDocVersions(isVersionsOpen ? docId : undefined);
+
+  const projectMeta = useProjectMeta(projectId);
+
+  useEffect(() => {
+    const projectLabel = projectMeta.data?.name ?? projectId ?? "Project";
+    if (docQuery.data?.title) {
+      document.title = `Projects / ${projectLabel} / Docs / ${docQuery.data.title}`;
+    } else {
+      document.title = `Projects / ${projectLabel} / Docs`;
+    }
+  }, [docQuery.data?.title, projectMeta.data?.name, projectId]);
+
+  const docMatchesProject = docQuery.data?.project_id === projectId;
+
+  const hasChildren = useMemo(() => {
+    if (!docQuery.data || !docsQuery.data) {
+      return false;
+    }
+    return docsQuery.data.some((doc) => doc.parent_id === docQuery.data!.id);
+  }, [docQuery.data, docsQuery.data]);
+
+  const descendantIds = useMemo(() => {
+    if (!docQuery.data || !docsQuery.data) {
+      return new Set<string>();
+    }
+    const ids = new Set<string>();
+    const walk = (id: string) => {
+      docsQuery.data
+        ?.filter((doc) => doc.parent_id === id)
+        .forEach((child) => {
+          if (!ids.has(child.id)) {
+            ids.add(child.id);
+            walk(child.id);
+          }
+        });
+    };
+    walk(docQuery.data.id);
+    return ids;
+  }, [docQuery.data, docsQuery.data]);
+
+  const parentOptions = useMemo(() => {
+    if (!docsQuery.data || !docQuery.data) {
+      return [];
+    }
+    return docsQuery.data.filter(
+      (doc) => doc.id !== docQuery.data!.id && !descendantIds.has(doc.id)
+    );
+  }, [docsQuery.data, docQuery.data, descendantIds]);
+
+  const handleDelete = async () => {
+    if (!docQuery.data || !docId) {
+      return;
+    }
+    if (hasChildren) {
+      toast({
+        title: "Cannot delete",
+        description: "Move or delete child pages before removing this doc.",
+        variant: "destructive",
+      });
+      return;
+    }
+    const confirmed = window.confirm("Delete this doc?");
+    if (!confirmed) {
+      return;
+    }
+    try {
+      await deleteDoc.mutateAsync(docId);
+      toast({ title: "Doc deleted" });
+      navigate(`/projects/${projectId}/docs`);
+    } catch (error: any) {
+      console.error(error);
+      toast({ title: "Delete failed", description: error?.message ?? "Could not delete doc", variant: "destructive" });
+    }
+  };
+
+  const handleTogglePublish = async (value: boolean) => {
+    if (!docId) {
+      return;
+    }
+    try {
+      await updateDoc.mutateAsync({ id: docId, patch: { is_published: value } });
+      toast({ title: value ? "Doc published" : "Doc hidden" });
+    } catch (error: any) {
+      console.error(error);
+      toast({ title: "Update failed", description: error?.message ?? "Could not update doc", variant: "destructive" });
+    }
+  };
+
+  const handleCopyLink = async () => {
+    if (!projectId || !docId) {
+      return;
+    }
+    const url = `${window.location.origin}/projects/${projectId}/docs/${docId}`;
+    await navigator.clipboard.writeText(url);
+    toast({ title: "Link copied" });
+  };
+
+  const handleMove = async () => {
+    if (!docId) {
+      return;
+    }
+    const parent_id = moveTarget === "none" ? null : moveTarget;
+    if (parent_id && descendantIds.has(parent_id)) {
+      toast({
+        title: "Invalid move",
+        description: "Choose a parent outside of this doc's subtree.",
+        variant: "destructive",
+      });
+      return;
+    }
+    try {
+      await updateDoc.mutateAsync({ id: docId, patch: { parent_id } });
+      toast({ title: "Doc moved" });
+      setMoveOpen(false);
+    } catch (error: any) {
+      console.error(error);
+      toast({ title: "Move failed", description: error?.message ?? "Could not move doc", variant: "destructive" });
+    }
+  };
+
+  const handleRestore = async (version: number) => {
+    if (!docId || !docQuery.data) {
+      return;
+    }
+    try {
+      const { data, error } = await supabase
+        .from("doc_versions")
+        .select("title, body_markdown")
+        .eq("doc_id", docId)
+        .eq("version", version)
+        .maybeSingle();
+      if (error || !data) {
+        throw error ?? new Error("Version not found");
+      }
+      await createDocVersionFromCurrent(docId);
+      await updateDoc.mutateAsync({
+        id: docId,
+        patch: {
+          title: data.title,
+          body_markdown: data.body_markdown ?? "",
+          version: docQuery.data.version + 1,
+        },
+      });
+      toast({ title: "Version restored" });
+      setVersionsOpen(false);
+    } catch (error: any) {
+      console.error(error);
+      toast({ title: "Restore failed", description: error?.message ?? "Could not restore version", variant: "destructive" });
+    }
+  };
+
+  if (docQuery.isLoading) {
+    return <div className="p-6 text-sm text-muted-foreground">Loading doc...</div>;
+  }
+
+  if (docQuery.isError || !docMatchesProject) {
+    return (
+      <div className="p-6">
+        <Alert variant="destructive">
+          <AlertTitle>We could not load this doc</AlertTitle>
+          <AlertDescription>
+            {docQuery.error instanceof Error && docQuery.error.message.includes("permission")
+              ? "You do not have access."
+              : "Try reloading the page."}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  if (!docQuery.data) {
+    return <div className="p-6 text-sm text-muted-foreground">Doc not found.</div>;
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-4xl space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">{docQuery.data.title}</h1>
+          <p className="text-sm text-muted-foreground">Version {docQuery.data.version}</p>
+        </div>
+        <Button onClick={() => navigate(`/projects/${projectId}/docs/${docId}/edit`)}>Edit</Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <DocToolbar
+              doc={docQuery.data}
+              onCreate={() => navigate(`/projects/${projectId}/docs/new?parent=${docQuery.data.id}`)}
+              onEdit={() => navigate(`/projects/${projectId}/docs/${docId}/edit`)}
+              onDelete={handleDelete}
+              onMove={() => {
+                setMoveTarget(docQuery.data?.parent_id ?? "none");
+                setMoveOpen(true);
+              }}
+              onShowVersions={() => setVersionsOpen(true)}
+              onCopyLink={handleCopyLink}
+              onTogglePublish={handleTogglePublish}
+            />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div
+            className="prose max-w-none text-sm"
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(docQuery.data.body_markdown ?? "") }}
+          />
+        </CardContent>
+      </Card>
+
+      <Dialog open={isVersionsOpen} onOpenChange={setVersionsOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Version history</DialogTitle>
+          </DialogHeader>
+          {versionsQuery.isLoading ? (
+            <div className="py-6 text-center text-sm text-muted-foreground">Loading versions...</div>
+          ) : versionsQuery.isError ? (
+            <div className="py-6 text-center text-sm text-destructive">Could not load versions.</div>
+          ) : (
+            <VersionHistory versions={versionsQuery.data ?? []} onRestore={handleRestore} />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isMoveOpen} onOpenChange={setMoveOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Move doc</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Select value={moveTarget} onValueChange={setMoveTarget}>
+              <SelectTrigger>
+                <SelectValue placeholder="Top level" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">Top level</SelectItem>
+                {parentOptions.map((doc) => (
+                  <SelectItem key={doc.id} value={doc.id}>
+                    {doc.title}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setMoveOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleMove} disabled={updateDoc.isPending}>
+              {updateDoc.isPending ? "Moving..." : "Move"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/projects/ProjectDocEdit.tsx
+++ b/src/pages/projects/ProjectDocEdit.tsx
@@ -1,0 +1,217 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { MarkdownEditor } from "@/components/docs/MarkdownEditor";
+import { useDoc, useDocs, useUpdateDoc } from "@/hooks/useDocs";
+import { createDocVersionFromCurrent } from "@/services/docs";
+import { useToast } from "@/hooks/use-toast";
+import { useProjectMeta } from "@/hooks/useProjectMeta";
+import { useUnsavedChangesPrompt } from "@/hooks/useUnsavedChangesPrompt";
+
+export default function ProjectDocEdit() {
+  const { projectId, docId } = useParams<{ projectId: string; docId: string }>();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const docQuery = useDoc(docId);
+  const docsQuery = useDocs({ projectId });
+  const updateDoc = useUpdateDoc();
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [parentId, setParentId] = useState<string | "none">("none");
+  const [isPublished, setIsPublished] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isDirty, setDirty] = useState(false);
+
+  const projectMeta = useProjectMeta(projectId);
+
+  useEffect(() => {
+    if (docQuery.data) {
+      setTitle(docQuery.data.title);
+      setBody(docQuery.data.body_markdown ?? "");
+      setParentId(docQuery.data.parent_id ?? "none");
+      setIsPublished(docQuery.data.is_published);
+    }
+  }, [docQuery.data]);
+
+  useEffect(() => {
+    const projectLabel = projectMeta.data?.name ?? projectId ?? "Project";
+    if (docQuery.data?.title) {
+      document.title = `Projects / ${projectLabel} / Docs / ${docQuery.data.title} / Edit`;
+    } else {
+      document.title = `Projects / ${projectLabel} / Docs / Edit`;
+    }
+  }, [docQuery.data?.title, projectMeta.data?.name, projectId]);
+
+  useUnsavedChangesPrompt(isDirty);
+
+  const descendantIds = useMemo(() => {
+    if (!docQuery.data || !docsQuery.data) {
+      return new Set<string>();
+    }
+    const ids = new Set<string>();
+    const walk = (id: string) => {
+      docsQuery.data
+        ?.filter((doc) => doc.parent_id === id)
+        .forEach((child) => {
+          if (!ids.has(child.id)) {
+            ids.add(child.id);
+            walk(child.id);
+          }
+        });
+    };
+    walk(docQuery.data.id);
+    return ids;
+  }, [docQuery.data, docsQuery.data]);
+
+  const parentOptions = useMemo(() => {
+    if (!docsQuery.data || !docQuery.data) {
+      return [];
+    }
+    return docsQuery.data.filter(
+      (doc) => doc.id !== docQuery.data!.id && !descendantIds.has(doc.id)
+    );
+  }, [docsQuery.data, docQuery.data, descendantIds]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!docId || !docQuery.data) {
+      return;
+    }
+    setError(null);
+
+    if (!title.trim()) {
+      setError("Title is required.");
+      return;
+    }
+
+    try {
+      if (title.trim() !== docQuery.data.title || body !== (docQuery.data.body_markdown ?? "")) {
+        await createDocVersionFromCurrent(docId);
+      }
+      if (parentId !== "none" && descendantIds.has(parentId)) {
+        setError("Select a parent outside of this doc's subtree.");
+        return;
+      }
+
+      await updateDoc.mutateAsync({
+        id: docId,
+        patch: {
+          title: title.trim(),
+          body_markdown: body,
+          parent_id: parentId === "none" ? null : parentId,
+          is_published: isPublished,
+          version: docQuery.data.version + 1,
+        },
+      });
+      setDirty(false);
+      toast({ title: "Doc updated" });
+      navigate(`/projects/${projectId}/docs/${docId}`);
+    } catch (mutationError: any) {
+      console.error(mutationError);
+      setError(mutationError?.message ?? "Could not update doc.");
+    }
+  };
+
+  if (docQuery.isLoading) {
+    return <div className="p-6 text-sm text-muted-foreground">Loading doc...</div>;
+  }
+
+  if (docQuery.isError || !docQuery.data || docQuery.data.project_id !== projectId) {
+    return (
+      <div className="p-6">
+        <Alert variant="destructive">
+          <AlertTitle>We could not load this doc</AlertTitle>
+          <AlertDescription>
+            {docQuery.error instanceof Error && docQuery.error.message.includes("permission")
+              ? "You do not have access."
+              : "Try reloading the page."}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-4xl p-6">
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-6"
+        onChange={() => setDirty(true)}
+      >
+        <Card>
+          <CardHeader>
+            <CardTitle>Edit doc</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {error && (
+              <Alert variant="destructive">
+                <AlertTitle>Something went wrong</AlertTitle>
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="title">Title</Label>
+              <Input
+                id="title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                required
+              />
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Parent</Label>
+                <Select value={parentId} onValueChange={setParentId}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Top level" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">Top level</SelectItem>
+                    {parentOptions.map((doc) => (
+                      <SelectItem key={doc.id} value={doc.id}>
+                        {doc.title}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label className="flex items-center gap-2">
+                  Published
+                  <Switch checked={isPublished} onCheckedChange={setIsPublished} />
+                </Label>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Content</Label>
+              <MarkdownEditor value={body} onChange={setBody} />
+            </div>
+          </CardContent>
+          <CardFooter className="flex items-center justify-between">
+            <Button type="button" variant="ghost" onClick={() => navigate(-1)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={updateDoc.isPending}>
+              {updateDoc.isPending ? "Saving..." : "Save changes"}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/projects/ProjectDocsHome.tsx
+++ b/src/pages/projects/ProjectDocsHome.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useDocs, useDocSearch, useDeleteDoc, useUpdateDoc, useDocVersions } from "@/hooks/useDocs";
+import { DocTree } from "@/components/docs/DocTree";
+import { DocToolbar } from "@/components/docs/DocToolbar";
+import { VersionHistory } from "@/components/docs/VersionHistory";
+import { renderMarkdown } from "@/components/docs/MarkdownEditor";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useToast } from "@/hooks/use-toast";
+import { useProjectMeta } from "@/hooks/useProjectMeta";
+
+export default function ProjectDocsHome() {
+  const { projectId } = useParams<{ projectId: string }>();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [search, setSearch] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [isVersionsOpen, setVersionsOpen] = useState(false);
+
+  const projectMeta = useProjectMeta(projectId);
+
+  const projectLabel = projectMeta.data?.name ?? projectId ?? "Project";
+
+  useEffect(() => {
+    document.title = `Projects / ${projectLabel} / Docs`;
+  }, [projectLabel]);
+
+  const docsQuery = useDocs({ projectId });
+  const deleteDoc = useDeleteDoc();
+  const updateDoc = useUpdateDoc();
+  const versionsQuery = useDocVersions(isVersionsOpen ? selectedId ?? undefined : undefined);
+
+  useEffect(() => {
+    if (!selectedId && docsQuery.data?.length) {
+      setSelectedId(docsQuery.data[0].id);
+    }
+  }, [docsQuery.data, selectedId]);
+
+  const filteredDocs = useDocSearch(docsQuery.data, search);
+
+  const selectedDoc = useMemo(() => {
+    if (!selectedId || !docsQuery.data) {
+      return null;
+    }
+    return docsQuery.data.find((doc) => doc.id === selectedId) ?? null;
+  }, [selectedId, docsQuery.data]);
+
+  const handleCreate = (parentId?: string | null) => {
+    if (!projectId) {
+      return;
+    }
+    const params = new URLSearchParams();
+    if (parentId) {
+      params.set("parent", parentId);
+    }
+    navigate(`/projects/${projectId}/docs/new${params.toString() ? `?${params.toString()}` : ""}`);
+  };
+
+  const handleEdit = () => {
+    if (!projectId || !selectedDoc) {
+      return;
+    }
+    navigate(`/projects/${projectId}/docs/${selectedDoc.id}/edit`);
+  };
+
+  const handleDelete = async () => {
+    if (!selectedDoc) {
+      return;
+    }
+    const hasChildren = docsQuery.data?.some((doc) => doc.parent_id === selectedDoc.id);
+    if (hasChildren) {
+      toast({
+        title: "Cannot delete",
+        description: "Move or delete child pages before removing this doc.",
+        variant: "destructive",
+      });
+      return;
+    }
+    const confirmed = window.confirm("Delete this doc?");
+    if (!confirmed) {
+      return;
+    }
+    try {
+      await deleteDoc.mutateAsync(selectedDoc.id);
+      toast({ title: "Doc deleted" });
+      setSelectedId(null);
+    } catch (error: any) {
+      console.error(error);
+      toast({ title: "Delete failed", description: error?.message ?? "Could not delete doc", variant: "destructive" });
+    }
+  };
+
+  const handleTogglePublish = async (value: boolean) => {
+    if (!selectedDoc) {
+      return;
+    }
+    try {
+      await updateDoc.mutateAsync({ id: selectedDoc.id, patch: { is_published: value } });
+      toast({ title: value ? "Doc published" : "Doc hidden" });
+    } catch (error: any) {
+      console.error(error);
+      toast({ title: "Update failed", description: error?.message ?? "Could not update doc", variant: "destructive" });
+    }
+  };
+
+  const handleCopyLink = async () => {
+    if (!projectId || !selectedDoc) {
+      return;
+    }
+    const url = `${window.location.origin}/projects/${projectId}/docs/${selectedDoc.id}`;
+    await navigator.clipboard.writeText(url);
+    toast({ title: "Link copied" });
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl gap-6 p-6">
+      <aside className="hidden w-full max-w-xs flex-shrink-0 flex-col gap-4 rounded border bg-background p-4 md:flex">
+        <Input
+          placeholder="Search docs"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+        />
+        {docsQuery.isLoading ? (
+          <div className="py-10 text-center text-sm text-muted-foreground">Loading docs...</div>
+        ) : docsQuery.isError ? (
+          <div className="py-10 text-center text-sm text-destructive">
+            {docsQuery.error instanceof Error && docsQuery.error.message.includes("permission")
+              ? "You do not have access."
+              : "We could not load docs."}
+          </div>
+        ) : (
+          <DocTree
+            docs={filteredDocs}
+            activeId={selectedId ?? undefined}
+            onSelect={(doc) => setSelectedId(doc.id)}
+            onCreate={handleCreate}
+          />
+        )}
+      </aside>
+      <main className="flex-1 space-y-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">Docs</h1>
+            <p className="text-sm text-muted-foreground">{projectLabel} documentation</p>
+          </div>
+          <Button onClick={() => handleCreate(null)}>New doc</Button>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex flex-col gap-2">
+              <span>{selectedDoc?.title ?? "Select a doc"}</span>
+              {selectedDoc && projectId && (
+                <DocToolbar
+                  doc={selectedDoc}
+                  onCreate={() => handleCreate(selectedDoc.id)}
+                  onEdit={handleEdit}
+                  onDelete={handleDelete}
+                  onShowVersions={() => setVersionsOpen(true)}
+                  onCopyLink={handleCopyLink}
+                  onTogglePublish={handleTogglePublish}
+                />
+              )}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {docsQuery.isLoading ? (
+              <div className="py-10 text-center text-sm text-muted-foreground">Loading doc...</div>
+            ) : !selectedDoc ? (
+              <div className="py-10 text-center text-sm text-muted-foreground">
+                Select a doc from the list to preview its contents.
+              </div>
+            ) : (
+              <div
+                className="prose max-w-none text-sm"
+                dangerouslySetInnerHTML={{ __html: renderMarkdown(selectedDoc.body_markdown ?? "") }}
+              />
+            )}
+          </CardContent>
+        </Card>
+      </main>
+
+      <Dialog open={isVersionsOpen} onOpenChange={setVersionsOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Version history</DialogTitle>
+          </DialogHeader>
+          {versionsQuery.isLoading ? (
+            <div className="py-6 text-center text-sm text-muted-foreground">Loading versions...</div>
+          ) : versionsQuery.isError ? (
+            <div className="py-6 text-center text-sm text-destructive">Could not load versions.</div>
+          ) : (
+            <VersionHistory versions={versionsQuery.data ?? []} />
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/reports/ReportCreate.tsx
+++ b/src/pages/reports/ReportCreate.tsx
@@ -1,0 +1,172 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { supabase } from "@/integrations/supabase/client";
+import { useCreateReport } from "@/hooks/useReports";
+
+interface ProjectOption {
+  id: string;
+  name: string;
+}
+
+const DEFAULT_CONFIG = {
+  source: "tasks",
+  limit: 50,
+};
+
+export default function ReportCreate() {
+  const navigate = useNavigate();
+  const createReport = useCreateReport();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [projectId, setProjectId] = useState<string | "all">("all");
+  const [configText, setConfigText] = useState(JSON.stringify(DEFAULT_CONFIG, null, 2));
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    document.title = "Reports / New";
+  }, []);
+
+  const projectsQuery = useQuery<ProjectOption[]>({
+    queryKey: ["projects", "options"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("projects")
+        .select("id, name")
+        .order("name", { ascending: true });
+      if (error) {
+        console.error("Failed to load projects", error);
+        throw error;
+      }
+      return data ?? [];
+    },
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const isValid = useMemo(() => name.trim().length > 0, [name]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    let parsedConfig: any;
+    try {
+      parsedConfig = configText.trim() ? JSON.parse(configText) : {};
+    } catch (_parseError) {
+      setError("Config must be valid JSON.");
+      return;
+    }
+
+    if (!isValid) {
+      setError("Name is required.");
+      return;
+    }
+
+    try {
+      const result = await createReport.mutateAsync({
+        name: name.trim(),
+        description: description.trim() || undefined,
+        projectId: projectId === "all" ? null : projectId,
+        config: parsedConfig,
+      });
+      navigate(`/reports/${result.id}`);
+    } catch (mutationError: any) {
+      console.error(mutationError);
+      setError(mutationError?.message ?? "Could not create report.");
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-3xl p-6">
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Create report</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {error && (
+              <Alert variant="destructive">
+                <AlertTitle>Something went wrong</AlertTitle>
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Weekly status report"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Description</Label>
+              <Textarea
+                id="description"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                placeholder="Summarize the purpose of this report"
+                rows={3}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Project scope</Label>
+              <Select value={projectId} onValueChange={setProjectId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="All projects" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All projects</SelectItem>
+                  {projectsQuery.data?.map((project) => (
+                    <SelectItem key={project.id} value={project.id}>
+                      {project.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="config">Config JSON</Label>
+              <Textarea
+                id="config"
+                value={configText}
+                onChange={(event) => setConfigText(event.target.value)}
+                rows={12}
+                className="font-mono text-sm"
+              />
+              <p className="text-xs text-muted-foreground">
+                Configure source, filters, and limits using JSON.
+              </p>
+            </div>
+          </CardContent>
+          <CardFooter className="flex items-center justify-between">
+            <Button type="button" variant="ghost" onClick={() => navigate(-1)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!isValid || createReport.isPending}>
+              {createReport.isPending ? "Saving..." : "Create"}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/reports/ReportDetail.tsx
+++ b/src/pages/reports/ReportDetail.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { supabase } from "@/integrations/supabase/client";
+import { useDeleteReport, useReport, useRunReport } from "@/hooks/useReports";
+
+interface ProjectSummary {
+  id: string;
+  name: string;
+}
+
+export default function ReportDetail() {
+  const navigate = useNavigate();
+  const { reportId } = useParams<{ reportId: string }>();
+  const [runError, setRunError] = useState<string | null>(null);
+  const [runResult, setRunResult] = useState<{ rows: any[]; meta: any } | null>(null);
+
+  const reportQuery = useReport(reportId);
+  const runReportMutation = useRunReport(reportId);
+  const deleteReport = useDeleteReport();
+
+  const projectQuery = useQuery<ProjectSummary | null>({
+    queryKey: ["projects", "detail", reportQuery.data?.project_id],
+    enabled: Boolean(reportQuery.data?.project_id),
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("projects")
+        .select("id, name")
+        .eq("id", reportQuery.data?.project_id ?? "")
+        .maybeSingle();
+      if (error) {
+        console.error("Failed to load project", error);
+        throw error;
+      }
+      return data;
+    },
+    staleTime: 1000 * 60 * 5,
+  });
+
+  useEffect(() => {
+    if (reportQuery.data?.name) {
+      document.title = `Reports / ${reportQuery.data.name}`;
+    }
+  }, [reportQuery.data?.name]);
+
+  const handleRun = async () => {
+    if (!reportQuery.data) {
+      return;
+    }
+    setRunError(null);
+    try {
+      const result = await runReportMutation.mutateAsync({ config: reportQuery.data.config });
+      setRunResult(result);
+    } catch (error: any) {
+      console.error(error);
+      setRunError(error?.message ?? "Failed to run report.");
+    }
+  };
+
+  const handleExportJson = () => {
+    if (!runResult) {
+      return;
+    }
+    const blob = new Blob([JSON.stringify(runResult.rows, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${reportQuery.data?.name ?? "report"}.json`;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportCsv = () => {
+    if (!runResult || runResult.rows.length === 0) {
+      return;
+    }
+    const headers = Object.keys(runResult.rows[0]);
+    const csvRows = [headers.join(",")];
+    for (const row of runResult.rows) {
+      const values = headers.map((header) => {
+        const value = row[header];
+        if (value == null) {
+          return "";
+        }
+        if (typeof value === "string" && value.includes(",")) {
+          return `"${value.replace(/"/g, '""')}"`;
+        }
+        return String(value);
+      });
+      csvRows.push(values.join(","));
+    }
+    const blob = new Blob([csvRows.join("\n")], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${reportQuery.data?.name ?? "report"}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleDelete = async () => {
+    if (!reportId) {
+      return;
+    }
+    const confirmed = window.confirm("Delete this report?");
+    if (!confirmed) {
+      return;
+    }
+    try {
+      await deleteReport.mutateAsync(reportId);
+      navigate("/reports");
+    } catch (error: any) {
+      console.error(error);
+      setRunError(error?.message ?? "Failed to delete report.");
+    }
+  };
+
+  const columns = useMemo(() => {
+    if (!runResult || runResult.rows.length === 0) {
+      return [] as string[];
+    }
+    const keys = new Set<string>();
+    for (const row of runResult.rows) {
+      Object.keys(row).forEach((key) => keys.add(key));
+    }
+    return Array.from(keys);
+  }, [runResult]);
+
+  if (reportQuery.isLoading) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground">Loading report...</div>
+    );
+  }
+
+  if (reportQuery.isError) {
+    return (
+      <div className="flex flex-col items-center gap-3 p-6 text-center">
+        <p className="text-sm text-destructive">We could not load this report.</p>
+        <Button variant="outline" size="sm" onClick={() => reportQuery.refetch()}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  if (!reportQuery.data) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground">Report not found.</div>
+    );
+  }
+
+  const projectName = reportQuery.data.project_id
+    ? projectQuery.data?.name ?? reportQuery.data.project_id
+    : "All projects";
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            {reportQuery.data.name}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {reportQuery.data.description || "Custom report"}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" onClick={() => navigate(`/reports/${reportId}/edit`)}>
+            Edit
+          </Button>
+          <Button variant="outline" onClick={handleRun} disabled={runReportMutation.isPending}>
+            {runReportMutation.isPending ? "Running..." : "Run"}
+          </Button>
+          <Button variant="destructive" onClick={handleDelete} disabled={deleteReport.isPending}>
+            Delete
+          </Button>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Summary</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm text-muted-foreground">
+          <div>
+            <span className="font-medium text-foreground">Scope:</span> {projectName}
+          </div>
+          <div className="overflow-hidden rounded border bg-muted/40">
+            <pre className="max-h-64 overflow-auto p-4 text-xs text-muted-foreground">
+              {JSON.stringify(reportQuery.data.config, null, 2)}
+            </pre>
+          </div>
+        </CardContent>
+      </Card>
+
+      {runError && (
+        <Alert variant="destructive">
+          <AlertTitle>Report error</AlertTitle>
+          <AlertDescription>{runError}</AlertDescription>
+        </Alert>
+      )}
+
+      {runResult && (
+        <Card>
+          <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <CardTitle className="text-base">Results</CardTitle>
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="outline">Rows: {runResult.rows.length}</Badge>
+              <Button size="sm" variant="outline" onClick={handleExportCsv}>
+                Export CSV
+              </Button>
+              <Button size="sm" variant="outline" onClick={handleExportJson}>
+                Export JSON
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {runResult.rows.length === 0 ? (
+              <div className="py-10 text-center text-sm text-muted-foreground">
+                No data
+              </div>
+            ) : (
+              <div className="max-h-96 overflow-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      {columns.map((column) => (
+                        <TableHead key={column}>{column}</TableHead>
+                      ))}
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {runResult.rows.map((row, index) => (
+                      <TableRow key={index}>
+                        {columns.map((column) => (
+                          <TableCell key={column} className="text-xs">
+                            {formatCellValue(row[column])}
+                          </TableCell>
+                        ))}
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+          <CardFooter>
+            <div className="text-xs text-muted-foreground">
+              {runResult.meta ? JSON.stringify(runResult.meta) : null}
+            </div>
+          </CardFooter>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function formatCellValue(value: any) {
+  if (value == null) {
+    return "";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}

--- a/src/pages/reports/ReportEdit.tsx
+++ b/src/pages/reports/ReportEdit.tsx
@@ -1,0 +1,198 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { supabase } from "@/integrations/supabase/client";
+import { useReport, useUpdateReport } from "@/hooks/useReports";
+
+interface ProjectOption {
+  id: string;
+  name: string;
+}
+
+export default function ReportEdit() {
+  const navigate = useNavigate();
+  const { reportId } = useParams<{ reportId: string }>();
+  const reportQuery = useReport(reportId);
+  const updateReport = useUpdateReport();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [projectId, setProjectId] = useState<string | "all">("all");
+  const [configText, setConfigText] = useState("{}");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (reportQuery.data) {
+      setName(reportQuery.data.name);
+      setDescription(reportQuery.data.description ?? "");
+      setProjectId(reportQuery.data.project_id ?? "all");
+      setConfigText(JSON.stringify(reportQuery.data.config ?? {}, null, 2));
+      document.title = `Reports / ${reportQuery.data.name} / Edit`;
+    }
+  }, [reportQuery.data]);
+
+  const projectsQuery = useQuery<ProjectOption[]>({
+    queryKey: ["projects", "options"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("projects")
+        .select("id, name")
+        .order("name", { ascending: true });
+      if (error) {
+        console.error("Failed to load projects", error);
+        throw error;
+      }
+      return data ?? [];
+    },
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const isValid = useMemo(() => name.trim().length > 0, [name]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!reportId) {
+      return;
+    }
+    setError(null);
+
+    let parsedConfig: any;
+    try {
+      parsedConfig = configText.trim() ? JSON.parse(configText) : {};
+    } catch (_parseError) {
+      setError("Config must be valid JSON.");
+      return;
+    }
+
+    if (!isValid) {
+      setError("Name is required.");
+      return;
+    }
+
+    try {
+      const result = await updateReport.mutateAsync({
+        id: reportId,
+        patch: {
+          name: name.trim(),
+          description: description.trim() || null,
+          project_id: projectId === "all" ? null : projectId,
+          config: parsedConfig,
+        },
+      });
+      navigate(`/reports/${result.id}`);
+    } catch (mutationError: any) {
+      console.error(mutationError);
+      setError(mutationError?.message ?? "Could not update report.");
+    }
+  };
+
+  if (reportQuery.isLoading) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground">Loading report...</div>
+    );
+  }
+
+  if (reportQuery.isError || !reportQuery.data) {
+    return (
+      <div className="flex flex-col items-center gap-3 p-6 text-center">
+        <p className="text-sm text-destructive">We could not load this report.</p>
+        <Button variant="outline" size="sm" onClick={() => reportQuery.refetch()}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-3xl p-6">
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Edit report</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {error && (
+              <Alert variant="destructive">
+                <AlertTitle>Something went wrong</AlertTitle>
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Weekly status report"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Description</Label>
+              <Textarea
+                id="description"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                placeholder="Summarize the purpose of this report"
+                rows={3}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Project scope</Label>
+              <Select value={projectId} onValueChange={setProjectId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="All projects" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All projects</SelectItem>
+                  {projectsQuery.data?.map((project) => (
+                    <SelectItem key={project.id} value={project.id}>
+                      {project.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="config">Config JSON</Label>
+              <Textarea
+                id="config"
+                value={configText}
+                onChange={(event) => setConfigText(event.target.value)}
+                rows={12}
+                className="font-mono text-sm"
+              />
+              <p className="text-xs text-muted-foreground">
+                Configure source, filters, and limits using JSON.
+              </p>
+            </div>
+          </CardContent>
+          <CardFooter className="flex items-center justify-between">
+            <Button type="button" variant="ghost" onClick={() => navigate(-1)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!isValid || updateReport.isPending}>
+              {updateReport.isPending ? "Saving..." : "Save changes"}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/reports/ReportsHome.tsx
+++ b/src/pages/reports/ReportsHome.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { formatDistanceToNow } from "date-fns";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { supabase } from "@/integrations/supabase/client";
+import { useReports, useReportSearch } from "@/hooks/useReports";
+import type { Report } from "@/types";
+
+interface ProjectOption {
+  id: string;
+  name: string;
+}
+
+export default function ReportsHome() {
+  const navigate = useNavigate();
+  const [search, setSearch] = useState("");
+  const [projectId, setProjectId] = useState<string | "all">("all");
+
+  useEffect(() => {
+    document.title = "Reports";
+  }, []);
+
+  const projectsQuery = useQuery<ProjectOption[]>({
+    queryKey: ["projects", "options"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("projects")
+        .select("id, name")
+        .order("name", { ascending: true });
+      if (error) {
+        console.error("Failed to load projects", error);
+        throw error;
+      }
+      return data ?? [];
+    },
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const reportsQuery = useReports({ projectId: projectId === "all" ? undefined : projectId });
+
+  const projectMap = useMemo(() => {
+    const map = new Map<string, string>();
+    projectsQuery.data?.forEach((project) => {
+      map.set(project.id, project.name);
+    });
+    return map;
+  }, [projectsQuery.data]);
+
+  const projectFilteredReports = useMemo(() => {
+    if (!reportsQuery.data) {
+      return undefined;
+    }
+    if (projectId === "all") {
+      return reportsQuery.data;
+    }
+    return reportsQuery.data.filter((report) => report.project_id === projectId);
+  }, [projectId, reportsQuery.data]);
+
+  const filteredReports = useReportSearch(projectFilteredReports, search);
+
+  const handleCreate = () => {
+    navigate("/reports/new");
+  };
+
+  const handleRowClick = (report: Report) => {
+    navigate(`/reports/${report.id}`);
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Reports</h1>
+          <p className="text-sm text-muted-foreground">
+            Track key metrics across projects and teams.
+          </p>
+        </div>
+        <Button onClick={handleCreate}>New report</Button>
+      </div>
+
+      <Card>
+        <CardHeader className="gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <CardTitle className="text-base">Filters</CardTitle>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Input
+              placeholder="Search reports"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              className="w-full sm:w-64"
+            />
+            <Select value={projectId} onValueChange={setProjectId}>
+              <SelectTrigger className="w-full sm:w-48">
+                <SelectValue placeholder="All projects" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All projects</SelectItem>
+                {projectsQuery.data?.map((project) => (
+                  <SelectItem key={project.id} value={project.id}>
+                    {project.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {reportsQuery.isLoading ? (
+            <div className="py-10 text-center text-sm text-muted-foreground">
+              Loading reports...
+            </div>
+          ) : reportsQuery.isError ? (
+            <div className="flex flex-col items-center gap-3 py-10 text-center">
+              <p className="text-sm text-destructive">
+                We could not load reports.
+              </p>
+              <Button variant="outline" size="sm" onClick={() => reportsQuery.refetch()}>
+                Try again
+              </Button>
+            </div>
+          ) : filteredReports.length === 0 ? (
+            <div className="py-10 text-center text-sm text-muted-foreground">
+              No reports yet. Create your first report to get started.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead className="hidden sm:table-cell">Project</TableHead>
+                  <TableHead className="hidden md:table-cell">Updated</TableHead>
+                  <TableHead className="hidden lg:table-cell">Description</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredReports.map((report) => (
+                  <TableRow
+                    key={report.id}
+                    onClick={() => handleRowClick(report)}
+                    className="cursor-pointer hover:bg-muted/60"
+                  >
+                    <TableCell className="font-medium">{report.name}</TableCell>
+                    <TableCell className="hidden sm:table-cell">
+                      {report.project_id ? projectMap.get(report.project_id) ?? report.project_id : "All"}
+                    </TableCell>
+                    <TableCell className="hidden md:table-cell text-sm text-muted-foreground">
+                      {report.updated_at
+                        ? formatDistanceToNow(new Date(report.updated_at), { addSuffix: true })
+                        : ""}
+                    </TableCell>
+                    <TableCell className="hidden lg:table-cell text-sm text-muted-foreground">
+                      {report.description ?? ""}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/reports/__tests__/ReportPages.test.tsx
+++ b/src/pages/reports/__tests__/ReportPages.test.tsx
@@ -1,0 +1,210 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useParams } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import ReportCreate from "../ReportCreate";
+import ReportDetail from "../ReportDetail";
+import ReportEdit from "../ReportEdit";
+
+jest.mock("@/hooks/useReports", () => {
+  const actual = jest.requireActual("@/hooks/useReports");
+  return {
+    ...actual,
+    useCreateReport: jest.fn(),
+    useReport: jest.fn(),
+    useRunReport: jest.fn(),
+    useDeleteReport: jest.fn(),
+    useUpdateReport: jest.fn(),
+  };
+});
+
+jest.mock("@/integrations/supabase/client", () => {
+  const createBuilder = () => {
+    const result = { data: [], error: null };
+    const builder: any = {
+      select: jest.fn(() => builder),
+      order: jest.fn(() => Promise.resolve(result)),
+      eq: jest.fn(() => builder),
+      limit: jest.fn(() => builder),
+      is: jest.fn(() => builder),
+      or: jest.fn(() => builder),
+      maybeSingle: jest.fn(() => Promise.resolve({ data: null, error: null })),
+      single: jest.fn(() => Promise.resolve({ data: null, error: null })),
+      insert: jest.fn(() => ({
+        select: () => ({
+          single: () => Promise.resolve({ data: { id: "report-1" }, error: null }),
+        }),
+      })),
+      update: jest.fn(() => ({
+        select: () => ({
+          single: () => Promise.resolve({ data: { id: "report-1" }, error: null }),
+        }),
+      })),
+      delete: jest.fn(() => Promise.resolve({ error: null })),
+      then: (resolve: (value: any) => void) => Promise.resolve(result).then(resolve),
+      catch: (reject: (reason: any) => void) => Promise.resolve(result).catch(reject),
+      finally: (callback: () => void) => Promise.resolve(result).finally(callback),
+    };
+    return builder;
+  };
+
+  return {
+    supabase: {
+      from: jest.fn(() => createBuilder()),
+      auth: {
+        getUser: jest.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+      },
+    },
+  };
+});
+
+const { useCreateReport, useReport, useRunReport, useDeleteReport, useUpdateReport } =
+  jest.requireMock("@/hooks/useReports");
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+const ReportDetailStub = () => {
+  const params = useParams();
+  return <div>Report detail {params.reportId}</div>;
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+describe("Report pages", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates a report and navigates to detail", async () => {
+    const mutateAsync = jest.fn().mockResolvedValue({ id: "report-1" });
+    (useCreateReport as jest.Mock).mockReturnValue({ mutateAsync, isPending: false });
+
+    const client = createQueryClient();
+    client.setQueryData(["projects", "options"], []);
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={["/reports/new"]}>
+          <Routes>
+            <Route path="/reports/new" element={<ReportCreate />} />
+            <Route path="/reports/:reportId" element={<ReportDetailStub />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Weekly summary" } });
+    fireEvent.change(screen.getByLabelText("Config JSON"), {
+      target: { value: JSON.stringify({ source: "tasks" }) },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+    expect(await screen.findByText("Report detail report-1")).toBeInTheDocument();
+  });
+
+  it("runs a report and renders results", async () => {
+    (useReport as jest.Mock).mockReturnValue({
+      data: {
+        id: "report-1",
+        owner: "user-1",
+        name: "Status",
+        description: "",
+        config: {},
+        project_id: null,
+        created_at: "",
+        updated_at: "",
+      },
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+    const mutateAsync = jest
+      .fn()
+      .mockResolvedValue({ rows: [{ id: 1, name: "Task Alpha" }], meta: {} });
+    (useRunReport as jest.Mock).mockReturnValue({ mutateAsync, isPending: false });
+    (useDeleteReport as jest.Mock).mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+
+    const client = createQueryClient();
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={["/reports/report-1"]}>
+          <Routes>
+            <Route path="/reports/:reportId" element={<ReportDetail />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+
+    expect(await screen.findByText("Task Alpha")).toBeInTheDocument();
+  });
+
+  it("edits a report and saves changes", async () => {
+    (useReport as jest.Mock).mockReturnValue({
+      data: {
+        id: "report-1",
+        owner: "user-1",
+        name: "Status",
+        description: "Old",
+        config: { source: "tasks" },
+        project_id: null,
+        created_at: "",
+        updated_at: "",
+      },
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+    const mutateAsync = jest.fn().mockResolvedValue({ id: "report-1" });
+    (useUpdateReport as jest.Mock).mockReturnValue({ mutateAsync, isPending: false });
+
+    const client = createQueryClient();
+    client.setQueryData(["projects", "options"], []);
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={["/reports/report-1/edit"]}>
+          <Routes>
+            <Route path="/reports/:reportId/edit" element={<ReportEdit />} />
+            <Route path="/reports/:reportId" element={<ReportDetailStub />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Status Updated" } });
+    fireEvent.change(screen.getByLabelText("Config JSON"), {
+      target: { value: JSON.stringify({ source: "projects" }) },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+    expect(mutateAsync.mock.calls[0][0].patch.config).toEqual({ source: "projects" });
+    expect(await screen.findByText("Report detail report-1")).toBeInTheDocument();
+  });
+});

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { Navigate, useRoutes } from "react-router-dom";
+import { Navigate, Outlet, useRoutes } from "react-router-dom";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { ErrorBoundary } from "@/components/common/ErrorBoundary";
 import HomePage from "@/pages/ia/HomePage";
@@ -11,8 +11,14 @@ import CalendarPage from "@/pages/ia/CalendarPage";
 import TimelinePage from "@/pages/ia/TimelinePage";
 import WorkloadPage from "@/pages/ia/WorkloadPage";
 import DashboardsPage from "@/pages/ia/DashboardsPage";
-import ReportsPage from "@/pages/ia/ReportsPage";
-import DocsPage from "@/pages/ia/DocsPage";
+import DocsHome from "@/pages/docs/DocsHome";
+import DocCreate from "@/pages/docs/DocCreate";
+import DocDetail from "@/pages/docs/DocDetail";
+import DocEdit from "@/pages/docs/DocEdit";
+import ReportsHome from "@/pages/reports/ReportsHome";
+import ReportCreate from "@/pages/reports/ReportCreate";
+import ReportDetail from "@/pages/reports/ReportDetail";
+import ReportEdit from "@/pages/reports/ReportEdit";
 import FilesPage from "@/pages/ia/FilesPage";
 import AutomationsPage from "@/pages/ia/AutomationsPage";
 import IntegrationsPage from "@/pages/ia/IntegrationsPage";
@@ -40,7 +46,10 @@ import ProjectCalendarPage from "@/pages/ia/projects/ProjectCalendarPage";
 import ProjectTimelinePage from "@/pages/ia/projects/ProjectTimelinePage";
 import ProjectDependenciesPage from "@/pages/ia/projects/ProjectDependenciesPage";
 import ProjectReportsPage from "@/pages/ia/projects/ProjectReportsPage";
-import ProjectDocsPage from "@/pages/ia/projects/ProjectDocsPage";
+import ProjectDocsHome from "@/pages/projects/ProjectDocsHome";
+import ProjectDocCreate from "@/pages/projects/ProjectDocCreate";
+import ProjectDocDetail from "@/pages/projects/ProjectDocDetail";
+import ProjectDocEdit from "@/pages/projects/ProjectDocEdit";
 import ProjectFilesPage from "@/pages/ia/projects/ProjectFilesPage";
 import ProjectAutomationsPage from "@/pages/ia/projects/ProjectAutomationsPage";
 import ProjectSettingsPage from "@/pages/ia/projects/ProjectSettingsPage";
@@ -86,7 +95,16 @@ export function AppRoutes() {
         { path: "projects/:id/timeline", element: <ProjectTimelinePage /> },
         { path: "projects/:id/dependencies", element: <ProjectDependenciesPage /> },
         { path: "projects/:id/reports", element: <ProjectReportsPage /> },
-        { path: "projects/:id/docs", element: <ProjectDocsPage /> },
+        {
+          path: "projects/:projectId/docs",
+          element: <Outlet />,
+          children: [
+            { index: true, element: <ProjectDocsHome /> },
+            { path: "new", element: <ProjectDocCreate /> },
+            { path: ":docId", element: <ProjectDocDetail /> },
+            { path: ":docId/edit", element: <ProjectDocEdit /> },
+          ],
+        },
         { path: "projects/:id/files", element: <ProjectFilesPage /> },
         { path: "projects/:id/automations", element: <ProjectAutomationsPage /> },
         { path: "projects/:id/settings", element: <ProjectSettingsPage /> },
@@ -97,8 +115,26 @@ export function AppRoutes() {
         { path: "workload", element: <WorkloadPage /> },
         { path: "dashboards", element: <DashboardsPage /> },
         { path: "dashboards/new", element: <NewDashboardPage /> },
-        { path: "reports", element: <ReportsPage /> },
-        { path: "docs", element: <DocsPage /> },
+        {
+          path: "reports",
+          element: <Outlet />,
+          children: [
+            { index: true, element: <ReportsHome /> },
+            { path: "new", element: <ReportCreate /> },
+            { path: ":reportId", element: <ReportDetail /> },
+            { path: ":reportId/edit", element: <ReportEdit /> },
+          ],
+        },
+        {
+          path: "docs",
+          element: <Outlet />,
+          children: [
+            { index: true, element: <DocsHome /> },
+            { path: "new", element: <DocCreate /> },
+            { path: ":docId", element: <DocDetail /> },
+            { path: ":docId/edit", element: <DocEdit /> },
+          ],
+        },
         { path: "files", element: <FilesPage /> },
         { path: "automations", element: <AutomationsPage /> },
         { path: "integrations", element: <IntegrationsPage /> },

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from "react";
+import { Suspense, type ReactNode } from "react";
 import { Navigate, Outlet, useRoutes } from "react-router-dom";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { ErrorBoundary } from "@/components/common/ErrorBoundary";
@@ -64,7 +64,7 @@ import Profile from "@/pages/Profile";
 import Settings from "@/pages/Settings";
 import SearchPage from "@/pages/Search";
 
-const Suspended = ({ children }: { children: React.ReactNode }) => (
+const Suspended = ({ children }: { children: ReactNode }) => (
   <Suspense fallback={<div className="p-6">Loading...</div>}>
     <ErrorBoundary>{children}</ErrorBoundary>
   </Suspense>

--- a/src/services/docs.ts
+++ b/src/services/docs.ts
@@ -1,0 +1,322 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { DocPage } from "@/types";
+
+type ListDocsParams = {
+  projectId?: string;
+  parentId?: string | null;
+  q?: string;
+};
+
+type CreateDocInput = {
+  title: string;
+  body_markdown?: string;
+  parent_id?: string | null;
+  project_id?: string | null;
+  is_published?: boolean;
+};
+
+type UpdateDocPatch = Partial<
+  Pick<DocPage, "title" | "body_markdown" | "is_published" | "parent_id" | "version">
+>;
+
+type DocVersionSummary = {
+  version: number;
+  created_at: string;
+  created_by: string | null;
+};
+
+const DOC_TABLE = "doc_pages";
+const DOC_VERSION_TABLE = "doc_versions";
+
+function slugify(input: string) {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    || "untitled";
+}
+
+async function ensureUniqueSlug(
+  baseSlug: string,
+  projectId: string | null,
+  excludeId?: string
+) {
+  let attempt = baseSlug;
+  let counter = 1;
+
+  while (true) {
+    const query = supabase
+      .from(DOC_TABLE)
+      .select("id")
+      .eq("slug", attempt)
+      .limit(1);
+
+    if (projectId) {
+      query.eq("project_id", projectId);
+    } else {
+      query.is("project_id", null);
+    }
+
+    if (excludeId) {
+      query.neq("id", excludeId);
+    }
+
+    const { data, error } = await query.maybeSingle();
+
+    if (error && error.code !== "PGRST116") {
+      console.error("Failed to check slug uniqueness", error);
+      throw error;
+    }
+
+    if (!data) {
+      return attempt;
+    }
+
+    counter += 1;
+    attempt = `${baseSlug}-${counter}`;
+
+    if (counter > 50) {
+      attempt = `${baseSlug}-${Date.now()}`;
+    }
+  }
+}
+
+function buildSearchFilter(query: any, q?: string) {
+  if (!q) {
+    return query;
+  }
+
+  const raw = q.trim();
+  if (!raw) {
+    return query;
+  }
+
+  const escaped = raw.replace(/[%_]/g, (char) => `\\${char}`);
+  const tsQuery = raw
+    .split(/\s+/)
+    .map((part) => part.replace(/[':*!&|]/g, ""))
+    .filter(Boolean)
+    .join(" & ");
+
+  if (tsQuery) {
+    query.or(
+      `title.ilike.%${escaped}%,search.fts.${tsQuery}`
+    );
+  } else {
+    query.ilike("title", `%${escaped}%`);
+  }
+
+  return query;
+}
+
+async function fetchDoc(id: string): Promise<DocPage | null> {
+  const { data, error } = await supabase
+    .from(DOC_TABLE)
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    console.error("Failed to fetch doc", error);
+    throw error;
+  }
+
+  return data as DocPage | null;
+}
+
+async function cloneDocVersion(doc: DocPage, userId: string | null) {
+  const { error } = await supabase.from(DOC_VERSION_TABLE).insert({
+    doc_id: doc.id,
+    version: doc.version,
+    title: doc.title,
+    body_markdown: doc.body_markdown,
+    body_html: doc.body_html,
+    created_by: userId,
+  });
+
+  if (error) {
+    console.error("Failed to create doc version", error);
+    throw error;
+  }
+}
+
+export async function listDocs(params: ListDocsParams = {}): Promise<DocPage[]> {
+  const { projectId, parentId, q } = params;
+
+  let query = supabase
+    .from(DOC_TABLE)
+    .select("*")
+    .order("title", { ascending: true });
+
+  if (projectId === null) {
+    query.is("project_id", null);
+  } else if (projectId) {
+    query.eq("project_id", projectId);
+  }
+
+  if (typeof parentId !== "undefined") {
+    if (parentId === null) {
+      query.is("parent_id", null);
+    } else {
+      query.eq("parent_id", parentId);
+    }
+  }
+
+  query = buildSearchFilter(query, q);
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error("Failed to load docs", error);
+    throw error;
+  }
+
+  return (data as DocPage[]) ?? [];
+}
+
+export async function getDoc(id: string): Promise<DocPage | null> {
+  return fetchDoc(id);
+}
+
+export async function createDoc(input: CreateDocInput): Promise<DocPage> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new Error("You must be signed in to create docs.");
+  }
+
+  const projectId = input.project_id ?? null;
+  const title = input.title.trim();
+  const baseSlug = slugify(title);
+  const slug = await ensureUniqueSlug(baseSlug, projectId);
+
+  const payload = {
+    owner: user.id,
+    created_by: user.id,
+    updated_by: user.id,
+    title,
+    slug,
+    body_markdown: input.body_markdown ?? "",
+    parent_id: input.parent_id ?? null,
+    project_id: projectId,
+    is_published: input.is_published ?? true,
+  };
+
+  const { data, error } = await supabase
+    .from(DOC_TABLE)
+    .insert(payload)
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Failed to create doc", error);
+    throw error;
+  }
+
+  return data as DocPage;
+}
+
+export async function updateDoc(id: string, patch: UpdateDocPatch): Promise<DocPage> {
+  const doc = await fetchDoc(id);
+  if (!doc) {
+    throw new Error("Document not found");
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const cleanedPatch = Object.fromEntries(
+    Object.entries(patch).filter(([, value]) => value !== undefined)
+  ) as UpdateDocPatch;
+
+  let slug = doc.slug ?? slugify(doc.title);
+  if (
+    typeof cleanedPatch.title === "string" &&
+    cleanedPatch.title.trim() &&
+    cleanedPatch.title.trim() !== doc.title
+  ) {
+    slug = await ensureUniqueSlug(
+      slugify(cleanedPatch.title),
+      doc.project_id ?? null,
+      doc.id
+    );
+  }
+
+  const shouldVersion =
+    typeof cleanedPatch.version === "number"
+      ? false
+      : typeof cleanedPatch.title === "string" || typeof cleanedPatch.body_markdown === "string";
+
+  if (shouldVersion) {
+    await cloneDocVersion(doc, user?.id ?? null);
+  }
+
+  const payload = {
+    ...cleanedPatch,
+    slug,
+    ...(shouldVersion
+      ? { version: doc.version + 1 }
+      : typeof cleanedPatch.version === "number"
+      ? { version: cleanedPatch.version }
+      : {}),
+    updated_at: new Date().toISOString(),
+    updated_by: user?.id ?? doc.updated_by ?? null,
+  } as Partial<DocPage>;
+
+  const { data, error } = await supabase
+    .from(DOC_TABLE)
+    .update(payload)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Failed to update doc", error);
+    throw error;
+  }
+
+  return data as DocPage;
+}
+
+export async function deleteDoc(id: string): Promise<void> {
+  const { error } = await supabase.from(DOC_TABLE).delete().eq("id", id);
+
+  if (error) {
+    console.error("Failed to delete doc", error);
+    throw error;
+  }
+}
+
+export async function listDocVersions(docId: string): Promise<DocVersionSummary[]> {
+  const { data, error } = await supabase
+    .from(DOC_VERSION_TABLE)
+    .select("version, created_at, created_by")
+    .eq("doc_id", docId)
+    .order("version", { ascending: false });
+
+  if (error) {
+    console.error("Failed to load doc versions", error);
+    throw error;
+  }
+
+  return (data as DocVersionSummary[]) ?? [];
+}
+
+export async function createDocVersionFromCurrent(docId: string): Promise<void> {
+  const doc = await fetchDoc(docId);
+  if (!doc) {
+    throw new Error("Document not found");
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  await cloneDocVersion(doc, user?.id ?? null);
+}

--- a/src/services/projects.ts
+++ b/src/services/projects.ts
@@ -1,0 +1,27 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { ProjectMeta } from "@/types";
+
+const PROJECT_TABLE = "projects";
+
+export async function getProjectMeta(projectId: string): Promise<ProjectMeta | null> {
+  if (!projectId) {
+    return null;
+  }
+
+  const { data, error } = await supabase
+    .from(PROJECT_TABLE)
+    .select("id, name, code")
+    .eq("id", projectId)
+    .maybeSingle();
+
+  if (error) {
+    console.error("Failed to fetch project", error);
+    throw error;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return data as ProjectMeta;
+}

--- a/src/services/reports.ts
+++ b/src/services/reports.ts
@@ -1,0 +1,180 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { Report } from "@/types";
+
+type ReportCreateInput = {
+  name: string;
+  description?: string;
+  projectId?: string | null;
+  config?: any;
+};
+
+type ReportUpdatePatch = Partial<
+  Pick<Report, "name" | "description" | "config" | "project_id">
+>;
+
+const TABLE = "reports";
+
+export async function listReports(projectId?: string): Promise<Report[]> {
+  const query = supabase
+    .from(TABLE)
+    .select("*")
+    .order("updated_at", { ascending: false });
+
+  if (projectId) {
+    query.eq("project_id", projectId);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error("Failed to load reports", error);
+    throw error;
+  }
+
+  return data ?? [];
+}
+
+export async function getReport(id: string): Promise<Report | null> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    console.error("Failed to fetch report", error);
+    throw error;
+  }
+
+  return data ?? null;
+}
+
+export async function createReport(input: ReportCreateInput): Promise<Report> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new Error("You must be signed in to create reports.");
+  }
+
+  const payload = {
+    owner: user.id,
+    name: input.name,
+    description: input.description ?? null,
+    project_id: input.projectId ?? null,
+    config: input.config ?? {},
+  };
+
+  const { data, error } = await supabase
+    .from(TABLE)
+    .insert(payload)
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Failed to create report", error);
+    throw error;
+  }
+
+  return data as Report;
+}
+
+export async function updateReport(
+  id: string,
+  patch: ReportUpdatePatch
+): Promise<Report> {
+  const updatePayload = {
+    ...patch,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { data, error } = await supabase
+    .from(TABLE)
+    .update(updatePayload)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Failed to update report", error);
+    throw error;
+  }
+
+  return data as Report;
+}
+
+export async function deleteReport(id: string): Promise<void> {
+  const { error } = await supabase.from(TABLE).delete().eq("id", id);
+
+  if (error) {
+    console.error("Failed to delete report", error);
+    throw error;
+  }
+}
+
+type ReportRunResult = {
+  rows: any[];
+  meta: any;
+};
+
+export async function runReport(config: any): Promise<ReportRunResult> {
+  const source = config?.source ?? "tasks";
+  const limit = typeof config?.limit === "number" ? config.limit : 100;
+
+  if (source === "projects") {
+    const query = supabase
+      .from("projects")
+      .select("id, name, status, owner, updated_at")
+      .order("updated_at", { ascending: false })
+      .limit(limit);
+
+    const { data, error } = await query;
+
+    if (error) {
+      console.error("Failed to run project report", error);
+      throw error;
+    }
+
+    return {
+      rows: data ?? [],
+      meta: {
+        source: "projects",
+        count: data?.length ?? 0,
+      },
+    };
+  }
+
+  const taskQuery = supabase
+    .from("tasks")
+    .select("id, name, status, priority, project_id, assignee_id, updated_at")
+    .order("updated_at", { ascending: false })
+    .limit(limit);
+
+  if (config?.projectId) {
+    taskQuery.eq("project_id", config.projectId);
+  }
+
+  if (config?.status) {
+    taskQuery.eq("status", config.status);
+  }
+
+  const { data, error } = await taskQuery;
+
+  if (error) {
+    console.error("Failed to run task report", error);
+    throw error;
+  }
+
+  return {
+    rows: data ?? [],
+    meta: {
+      source: "tasks",
+      count: data?.length ?? 0,
+      filters: {
+        projectId: config?.projectId ?? null,
+        status: config?.status ?? null,
+      },
+    },
+  };
+}

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,0 +1,30 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export async function uploadDocImage(file: File, userId: string): Promise<{ publicUrl: string }> {
+  if (!file) {
+    throw new Error("File is required");
+  }
+
+  const bucket = "docs";
+  const fileName = `${Date.now()}-${file.name}`.replace(/\s+/g, "-");
+  const path = `${userId}/${fileName}`;
+
+  const { error: uploadError } = await supabase.storage
+    .from(bucket)
+    .upload(path, file, {
+      cacheControl: "3600",
+      upsert: true,
+    });
+
+  if (uploadError) {
+    console.error("Failed to upload image", uploadError);
+    throw uploadError;
+  }
+
+  const { data } = supabase.storage.from(bucket).getPublicUrl(path);
+  if (!data?.publicUrl) {
+    throw new Error("Could not resolve public URL for image");
+  }
+
+  return { publicUrl: data.publicUrl };
+}

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -6,8 +6,9 @@ export async function uploadDocImage(file: File, userId: string): Promise<{ publ
   }
 
   const bucket = "docs";
-  const fileName = `${Date.now()}-${file.name}`.replace(/\s+/g, "-");
-  const path = `${userId}/${fileName}`;
+  const timestamp = Date.now();
+  const sanitizedName = file.name.replace(/\s+/g, "-");
+  const path = `${userId}/${timestamp}-${sanitizedName}`;
 
   const { error: uploadError } = await supabase.storage
     .from(bucket)

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,4 +1,7 @@
 import "@testing-library/jest-dom";
+import { jest } from "@jest/globals";
+
+jest.mock("@/integrations/supabase/client");
 
 class ResizeObserver {
   observe() {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,33 @@
+export type Report = {
+  id: string;
+  owner: string;
+  project_id?: string | null;
+  name: string;
+  description?: string | null;
+  config: any;
+  created_at: string;
+  updated_at: string;
+};
+
+export type DocPage = {
+  id: string;
+  owner: string;
+  project_id?: string | null;
+  parent_id?: string | null;
+  title: string;
+  slug?: string | null;
+  body_markdown: string;
+  body_html?: string | null;
+  is_published: boolean;
+  version: number;
+  created_by?: string | null;
+  updated_by?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ProjectMeta = {
+  id: string;
+  name: string | null;
+  code?: string | null;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,3 +31,9 @@ export type ProjectMeta = {
   name: string | null;
   code?: string | null;
 };
+
+export type DocVersionSummary = {
+  version: number;
+  created_at: string;
+  created_by: string | null;
+};

--- a/supabase/migrations/20251005060000_add_reports.sql
+++ b/supabase/migrations/20251005060000_add_reports.sql
@@ -1,0 +1,32 @@
+-- Reports table and policies
+create table if not exists public.reports (
+  id uuid primary key default gen_random_uuid(),
+  owner uuid not null references auth.users(id) on delete cascade,
+  project_id uuid references public.projects(id) on delete cascade,
+  name text not null,
+  description text,
+  config jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.reports enable row level security;
+
+create policy if not exists "reports_owner_rw" on public.reports
+for all to authenticated
+using (owner = auth.uid())
+with check (owner = auth.uid());
+
+create policy if not exists "reports_project_read" on public.reports
+for select to authenticated
+using (
+  project_id is not null and project_id in (
+    select id from public.projects where owner = auth.uid()
+    union
+    select project_id from public.project_members where user_id = auth.uid()
+  )
+);
+
+create index if not exists reports_owner_idx on public.reports(owner);
+create index if not exists reports_project_idx on public.reports(project_id);
+create index if not exists reports_updated_at_idx on public.reports(updated_at);

--- a/supabase/migrations/20251005060010_add_docs.sql
+++ b/supabase/migrations/20251005060010_add_docs.sql
@@ -1,0 +1,73 @@
+-- Docs & Wiki tables and search helpers
+create table if not exists public.doc_pages (
+  id uuid primary key default gen_random_uuid(),
+  owner uuid not null references auth.users(id) on delete cascade,
+  project_id uuid references public.projects(id) on delete cascade,
+  parent_id uuid references public.doc_pages(id) on delete cascade,
+  title text not null,
+  slug text,
+  body_markdown text not null default '',
+  body_html text,
+  is_published boolean not null default true,
+  version int not null default 1,
+  created_by uuid references auth.users(id),
+  updated_by uuid references auth.users(id),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.doc_pages enable row level security;
+
+create table if not exists public.doc_versions (
+  id uuid primary key default gen_random_uuid(),
+  doc_id uuid not null references public.doc_pages(id) on delete cascade,
+  version int not null,
+  title text not null,
+  body_markdown text not null,
+  body_html text,
+  created_by uuid references auth.users(id),
+  created_at timestamptz not null default now(),
+  unique (doc_id, version)
+);
+
+alter table public.doc_versions enable row level security;
+
+alter table public.doc_pages add column if not exists search tsvector;
+create index if not exists doc_pages_search_idx on public.doc_pages using gin(search);
+
+create or replace function public.doc_pages_tsv_update() returns trigger language plpgsql as $$
+begin
+  new.search :=
+    setweight(to_tsvector('simple', coalesce(new.title,'')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(new.body_markdown,'')), 'B');
+  return new;
+end$$;
+
+drop trigger if exists trg_doc_pages_tsv on public.doc_pages;
+create trigger trg_doc_pages_tsv before insert or update on public.doc_pages
+for each row execute function public.doc_pages_tsv_update();
+
+create policy if not exists "docs_owner_rw" on public.doc_pages
+for all to authenticated
+using (owner = auth.uid())
+with check (owner = auth.uid());
+
+create policy if not exists "docs_project_read" on public.doc_pages
+for select to authenticated
+using (
+  project_id is null
+  or project_id in (
+    select id from public.projects where owner = auth.uid()
+    union
+    select project_id from public.project_members where user_id = auth.uid()
+  )
+);
+
+create policy if not exists "doc_versions_owner_rw" on public.doc_versions
+for all to authenticated
+using (
+  doc_id in (select id from public.doc_pages where owner = auth.uid())
+)
+with check (
+  doc_id in (select id from public.doc_pages where owner = auth.uid())
+);

--- a/supabase/migrations/20251005060020_add_docs_bucket.sql
+++ b/supabase/migrations/20251005060020_add_docs_bucket.sql
@@ -1,0 +1,18 @@
+-- Storage bucket for doc images
+select storage.create_bucket('docs', public => true);
+
+create policy if not exists "docs_bucket_read_public" on storage.objects
+for select to public
+using (bucket_id = 'docs');
+
+create policy if not exists "docs_bucket_write_auth" on storage.objects
+for insert to authenticated
+with check (bucket_id = 'docs');
+
+create policy if not exists "docs_bucket_update_auth" on storage.objects
+for update to authenticated
+using (bucket_id = 'docs');
+
+create policy if not exists "docs_bucket_delete_auth" on storage.objects
+for delete to authenticated
+using (bucket_id = 'docs');


### PR DESCRIPTION
## Summary
- add project-aware breadcrumbs and navigation wiring for reports and docs
- harden docs hierarchy workflows with move safeguards, project labels, and unsaved-change prompts
- add smoke tests for reports and docs flows plus Supabase schema and storage migrations

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e33580ce188327974a6ef5c5a5ce74