### PR TITLE
Fix global search palette regressions and tests

### DIFF
--- a/docs/search-inventory.md
+++ b/docs/search-inventory.md
@@ -1,0 +1,43 @@
+# Search & Command Palette Inventory (2025-10-05)
+
+## Existing search/palette code
+- `src/components/advanced-ux/CommandPalette.tsx` – legacy command palette UI (not wired into providers) with static actions.
+- `src/components/command/CommandPalette.tsx`, `CommandKProvider.tsx`, `useCommandK.ts` – new command palette implementation with search + actions.
+- `src/components/ui/command.tsx` – UI primitives (Radix-based) used across app.
+- `src/components/search/*` – legacy advanced search components (dialog, search bar).
+- `src/pages/search/GlobalSearchPage.tsx`, `SearchResultItem.tsx` – new global search page with filters.
+- `src/pages/Search.tsx` – older search page (appears unused; confirm routing).
+- `src/hooks/useAdvancedSearch.tsx` – local storage driven search state hook.
+- `src/features/search/__tests__/search-flow.test.tsx` – palette/search smoke tests.
+- `src/services/search.ts` – unified Supabase-backed search queries.
+- `src/services/savedSearches.ts` – saved search helpers.
+
+## Entities indexed / related models
+- Tasks: multiple components/pages (`src/pages/Tasks.tsx`, kanban components, etc.).
+- Projects: numerous pages under `src/pages/ia/projects/*` and `src/pages/Projects.tsx`.
+- Docs: `doc_pages` features in `src/pages/Documents.tsx`, `src/components/docs/*`.
+- Files: `project_files` references in `src/pages/ia/projects/ProjectFilesPage.tsx` and `src/hooks/useFileUpload.tsx`.
+- Comments: `src/components/comments/*`, `src/components/comments/CommentsSystem.tsx` using `comments` table.
+- Profiles/People: `src/pages/TeamDirectory.tsx`, `src/pages/TeamMemberProfile.tsx`, `src/state/profile.tsx`.
+- Legacy wiki references: `src/components/knowledge/WikiKnowledgeBase.tsx` (no direct Supabase integration noted).
+
+## Navigation / routing touchpoints
+- `src/App.tsx` – wraps router provider.
+- `src/routes.tsx` – defines route tree including `/search` pointing to `GlobalSearchPage`.
+- Layout: `src/components/layout/AppLayout.tsx`, `Topbar.tsx`, `AppSidebar.tsx`, `Sidebar.tsx`.
+- Additional layout entry points: `src/layouts/AppShell.tsx`, `src/components/layout/AppHeader.tsx`.
+
+## Services and hooks
+- Supabase services directory already includes `search.ts` and `savedSearches.ts`.
+- Hooks include domain-specific logic (`useProjectNavigation`, `useTaskRelationships`, etc.) but no dedicated search hook besides `useAdvancedSearch` (local state).
+
+## Supabase migrations referencing search/full-text
+- Recent migrations `20251005060000_search_tasks.sql` through `20251005060050_search_profiles.sql` implement tsvector columns/triggers.
+- `20251005060060_saved_searches.sql` introduces saved searches table with RLS.
+- Older migrations mainly adjust function search_path; no prior full-text indexes detected.
+
+## Gaps / TODO surfaced during inventory
+- Duplicate search UIs (`src/pages/Search.tsx` vs new `GlobalSearchPage.tsx`); need consolidation.
+- Radix `Select` warning noted in tests (`project` filter default empty string).
+- App layout tests failing due to missing providers (`useProfile` dependency) when Topbar renders palette button.
+- Confirm routing removes references to legacy `Search` page to avoid dead links.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,8 @@ import { ProfileProvider } from "./state/profile";
 import { SecurityProvider } from "./components/security/SecurityProvider";
 import { AccessibilityProvider } from "./components/accessibility/AccessibilityProvider";
 import { OperationsProvider } from "./components/operations/OperationsProvider";
-import { CommandPalette } from "./components/advanced-ux/CommandPalette";
+import { CommandKProvider } from "./components/command/CommandKProvider";
+import { CommandPalette } from "./components/command/CommandPalette";
 import { KeyboardShortcuts } from "./components/advanced-ux/KeyboardShortcuts";
 import { OutpagedThemeProvider } from "./components/theme/OutpagedThemeProvider";
 import { SlackProvider } from "./components/integrations/SlackProvider";
@@ -48,9 +49,11 @@ const App = () => (
                         <Toaster />
                         <Sonner />
                         <BrowserRouter>
-                          <CommandPalette />
-                          <KeyboardShortcuts />
-                          <AppRoutes />
+                          <CommandKProvider>
+                            <CommandPalette />
+                            <KeyboardShortcuts />
+                            <AppRoutes />
+                          </CommandKProvider>
                         </BrowserRouter>
                       </TooltipProvider>
                     </MarketingProvider>

--- a/src/components/command/CommandKProvider.tsx
+++ b/src/components/command/CommandKProvider.tsx
@@ -1,0 +1,108 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import type { SearchResult } from "@/types";
+
+const isTextInputLike = (element: Element | null) => {
+  if (!element) return false;
+  const tagName = element.tagName;
+  if (tagName === "INPUT" || tagName === "TEXTAREA") {
+    return true;
+  }
+  const editable = (element as HTMLElement).isContentEditable;
+  return editable;
+};
+
+type CommandScope = {
+  projectId?: string;
+  types?: Array<SearchResult["type"]>;
+};
+
+type CommandKContextValue = {
+  open: boolean;
+  query: string;
+  scope: CommandScope;
+  openPalette: (options?: {
+    query?: string;
+    projectId?: string;
+    types?: Array<SearchResult["type"]>;
+  }) => void;
+  closePalette: () => void;
+  togglePalette: () => void;
+  setQuery: (value: string) => void;
+};
+
+const CommandKContext = createContext<CommandKContextValue | undefined>(
+  undefined
+);
+
+export const CommandKProvider = ({ children }: { children: ReactNode }) => {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [scope, setScope] = useState<CommandScope>({});
+
+  const openPalette = useCallback(
+    (options?: { query?: string; projectId?: string; types?: Array<SearchResult["type"]> }) => {
+      if (options?.query !== undefined) {
+        setQuery(options.query);
+      }
+      setScope({ projectId: options?.projectId, types: options?.types });
+      setOpen(true);
+    },
+    []
+  );
+
+  const closePalette = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+    setScope({});
+  }, []);
+
+  const togglePalette = useCallback(() => {
+    setOpen((prev) => !prev);
+  }, []);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() === "k" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        openPalette();
+        return;
+      }
+
+      if (event.key === "/" && !event.metaKey && !event.ctrlKey && !event.altKey) {
+        const active = document.activeElement;
+        if (!isTextInputLike(active)) {
+          event.preventDefault();
+          openPalette();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [openPalette]);
+
+  const value = useMemo(
+    () => ({ open, query, scope, openPalette, closePalette, togglePalette, setQuery }),
+    [open, query, scope, openPalette, closePalette, togglePalette, setQuery]
+  );
+
+  return (
+    <CommandKContext.Provider value={value}>{children}</CommandKContext.Provider>
+  );
+};
+
+export const useCommandKContext = () => {
+  const context = useContext(CommandKContext);
+  if (!context) {
+    throw new Error("useCommandKContext must be used within a CommandKProvider");
+  }
+  return context;
+};

--- a/src/components/command/CommandPalette.tsx
+++ b/src/components/command/CommandPalette.tsx
@@ -1,0 +1,383 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import { useCommandK } from "./useCommandK";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { searchSuggest } from "@/services/search";
+import type { SearchResult } from "@/types";
+import { listSavedSearches } from "@/services/savedSearches";
+import {
+  CircleHelp,
+  FileText,
+  File,
+  FolderKanban,
+  Inbox,
+  ListTodo,
+  Loader2,
+  MessageSquare,
+  Bookmark,
+  PlusCircle,
+  Sun,
+  User,
+  type LucideIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const TYPE_LABELS: Record<SearchResult["type"], string> = {
+  task: "Tasks",
+  project: "Projects",
+  doc: "Docs",
+  file: "Files",
+  comment: "Comments",
+  person: "People",
+};
+
+const TYPE_ICONS: Record<SearchResult["type"], LucideIcon> = {
+  task: ListTodo,
+  project: FolderKanban,
+  doc: FileText,
+  file: File,
+  comment: MessageSquare,
+  person: User,
+};
+
+type QuickAction = {
+  id: string;
+  label: string;
+  description?: string;
+  Icon: LucideIcon;
+  onSelect: () => void;
+};
+
+const useDebouncedValue = (value: string, delay: number) => {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const handle = window.setTimeout(() => setDebounced(value), delay);
+    return () => window.clearTimeout(handle);
+  }, [value, delay]);
+
+  return debounced;
+};
+
+type Suggestion = Awaited<ReturnType<typeof searchSuggest>> extends Array<infer Item>
+  ? Item
+  : never;
+
+export const CommandPalette = () => {
+  const { open, query, setQuery, closePalette, scope } = useCommandK();
+  const [tab, setTab] = useState<"search" | "actions">("search");
+  const navigate = useNavigate();
+  const location = useLocation();
+  const lastPathnameRef = useRef(location.pathname);
+  const debouncedQuery = useDebouncedValue(query, 250);
+  const savedSearchesQuery = useQuery({
+    queryKey: ["saved-searches"],
+    queryFn: listSavedSearches,
+    enabled: open,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const navigateAndClose = useCallback(
+    (url: string) => {
+      closePalette();
+      navigate(url);
+    },
+    [closePalette, navigate]
+  );
+
+  const goToSearchPage = useCallback(() => {
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    const params = new URLSearchParams();
+    params.set("q", trimmed);
+    if (scope.projectId) {
+      params.set("projectId", scope.projectId);
+    }
+    if (scope.types?.length) {
+      params.set("type", scope.types.join(","));
+    }
+    closePalette();
+    navigate(`/search?${params.toString()}`);
+  }, [closePalette, navigate, query, scope.projectId, scope.types]);
+
+  const quickActions: QuickAction[] = useMemo(
+    () => [
+      {
+        id: "new-task",
+        label: "New task",
+        description: "Create a task",
+        Icon: PlusCircle,
+        onSelect: () => navigateAndClose("/tasks/new"),
+      },
+      {
+        id: "new-project",
+        label: "New project",
+        description: "Start a project",
+        Icon: FolderKanban,
+        onSelect: () => navigateAndClose("/projects/new"),
+      },
+      {
+        id: "my-day",
+        label: "Go to My Day",
+        description: "Focus view",
+        Icon: Sun,
+        onSelect: () => navigateAndClose("/my-work?view=day"),
+      },
+      {
+        id: "inbox",
+        label: "Go to Inbox",
+        description: "Catch up",
+        Icon: Inbox,
+        onSelect: () => navigateAndClose("/inbox"),
+      },
+      {
+        id: "help",
+        label: "Open Help",
+        description: "Get support",
+        Icon: CircleHelp,
+        onSelect: () => navigateAndClose("/help"),
+      },
+    ],
+    [navigateAndClose]
+  );
+
+  const savedSearchActions = useMemo(() => {
+    const items = (savedSearchesQuery.data ?? []).slice(0, 5);
+    return items.map((saved) => {
+      const params = new URLSearchParams();
+      params.set("q", saved.query);
+      const filters = (saved.filters ?? {}) as {
+        type?: string | null;
+        projectId?: string | null;
+      };
+      if (filters.type && filters.type !== "all") {
+        params.set("type", String(filters.type));
+      }
+      if (filters.projectId) {
+        params.set("projectId", String(filters.projectId));
+      }
+      return {
+        id: `saved-${saved.id}`,
+        label: saved.name,
+        description: saved.query,
+        Icon: Bookmark,
+        onSelect: () => navigateAndClose(`/search?${params.toString()}`),
+      } satisfies QuickAction;
+    });
+  }, [navigateAndClose, savedSearchesQuery.data]);
+
+  useEffect(() => {
+    if (!open) {
+      setTab("search");
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      lastPathnameRef.current = location.pathname;
+      return;
+    }
+
+    if (lastPathnameRef.current !== location.pathname) {
+      lastPathnameRef.current = location.pathname;
+      closePalette();
+    }
+  }, [closePalette, location.pathname, open]);
+
+  const suggestions = useQuery({
+    queryKey: [
+      "command-suggest",
+      debouncedQuery,
+      scope.projectId ?? null,
+      scope.types?.join(",") ?? null,
+    ],
+    queryFn: () => searchSuggest(debouncedQuery),
+    enabled: open && Boolean(debouncedQuery.trim()),
+    staleTime: 1000 * 30,
+  });
+
+  const groupedSuggestions = useMemo(() => {
+    const groups = new Map<SearchResult["type"], Suggestion[]>();
+    (suggestions.data ?? []).forEach((item) => {
+      const existing = groups.get(item.type) ?? [];
+      existing.push(item);
+      groups.set(item.type, existing);
+    });
+    return groups;
+  }, [suggestions.data]);
+
+  const handleInputKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Enter" && tab === "search" && query.trim()) {
+        const activeItem = document.querySelector(
+          "[cmdk-item][data-selected='true']"
+        );
+        if (!activeItem) {
+          event.preventDefault();
+          goToSearchPage();
+        }
+      }
+    },
+    [goToSearchPage, query, tab]
+  );
+
+  const renderSuggestion = (item: Suggestion) => {
+    const Icon = TYPE_ICONS[item.type];
+    return (
+      <CommandItem
+        key={`${item.type}-${item.url}`}
+        value={`${TYPE_LABELS[item.type]} ${item.title}`}
+        onSelect={() => navigateAndClose(item.url)}
+      >
+        <Icon className="mr-2 h-4 w-4 text-muted-foreground" aria-hidden="true" />
+        <div className="flex flex-col">
+          <span className="text-sm font-medium">{item.title}</span>
+          <span className="text-xs text-muted-foreground">
+            {TYPE_LABELS[item.type]}
+          </span>
+        </div>
+      </CommandItem>
+    );
+  };
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          closePalette();
+        }
+      }}
+    >
+      <div className="border-b px-3 py-2">
+        <Tabs value={tab} onValueChange={(value) => setTab(value as typeof tab)}>
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="search">Search</TabsTrigger>
+            <TabsTrigger value="actions">Actions</TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
+      <CommandInput
+        placeholder={tab === "search" ? "Search tasks, docs, people..." : "Filter actions"}
+        value={query}
+        onValueChange={setQuery}
+        onKeyDown={handleInputKeyDown}
+        aria-label={tab === "search" ? "Search" : "Filter actions"}
+      />
+      <CommandList>
+        {tab === "search" ? (
+          <>
+            <CommandEmpty aria-live="polite">
+              <div className="flex items-center justify-center gap-2">
+                {suggestions.isFetching ? (
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                ) : null}
+                <span>
+                  {suggestions.isFetching
+                    ? "Searching..."
+                    : query.trim()
+                    ? "No matches"
+                    : "Type to search"}
+                </span>
+              </div>
+            </CommandEmpty>
+            {Array.from(groupedSuggestions.entries()).map(([type, items]) => (
+              <CommandGroup key={type} heading={TYPE_LABELS[type]}>
+                {items.map((item) => renderSuggestion(item))}
+              </CommandGroup>
+            ))}
+            {savedSearchActions.length > 0 ? (
+              <CommandGroup heading="Saved searches">
+                {savedSearchActions.map(({ id, label, description, Icon, onSelect }) => (
+                  <CommandItem
+                    key={`search-tab-${id}`}
+                    value={`${label} ${description ?? ""}`}
+                    onSelect={onSelect}
+                  >
+                    <Icon className="mr-2 h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                    <div className="flex flex-col">
+                      <span className="text-sm font-medium">{label}</span>
+                      {description ? (
+                        <span className="text-xs text-muted-foreground">{description}</span>
+                      ) : null}
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ) : null}
+          </>
+        ) : (
+          <>
+            <CommandEmpty aria-live="polite">No actions found</CommandEmpty>
+            <CommandGroup heading="Quick actions">
+              {quickActions.map(({ id, label, description, Icon, onSelect }) => (
+                <CommandItem
+                  key={id}
+                  value={`${label} ${description ?? ""}`}
+                  onSelect={onSelect}
+                >
+                  <Icon className="mr-2 h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                  <div className="flex flex-col">
+                    <span className="text-sm font-medium">{label}</span>
+                    {description ? (
+                      <span className="text-xs text-muted-foreground">{description}</span>
+                    ) : null}
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+            {savedSearchActions.length > 0 ? (
+              <CommandGroup heading="Saved searches">
+                {savedSearchActions.map(({ id, label, description, Icon, onSelect }) => (
+                  <CommandItem
+                    key={id}
+                    value={`${label} ${description ?? ""}`}
+                    onSelect={onSelect}
+                  >
+                    <Icon className="mr-2 h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                    <div className="flex flex-col">
+                      <span className="text-sm font-medium">{label}</span>
+                      {description ? (
+                        <span className="text-xs text-muted-foreground">{description}</span>
+                      ) : null}
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ) : null}
+          </>
+        )}
+      </CommandList>
+      {tab === "search" && (suggestions.data?.length ?? 0) > 0 ? (
+        <CommandSeparator />
+      ) : null}
+      {tab === "search" && query.trim() ? (
+        <button
+          type="button"
+          className={cn(
+            "flex w-full items-center justify-between gap-3 px-4 py-2 text-sm text-muted-foreground",
+            "hover:bg-muted"
+          )}
+          onClick={goToSearchPage}
+        >
+          <span>Open full search</span>
+          <span className="text-xs">Enter</span>
+        </button>
+      ) : null}
+    </CommandDialog>
+  );
+};

--- a/src/components/command/useCommandK.ts
+++ b/src/components/command/useCommandK.ts
@@ -1,0 +1,3 @@
+import { useCommandKContext } from "./CommandKProvider";
+
+export const useCommandK = () => useCommandKContext();

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -5,6 +5,27 @@ import HomePage from "@/pages/ia/HomePage";
 import ProjectsPage from "@/pages/ia/ProjectsPage";
 import HelpPage from "@/pages/ia/HelpPage";
 
+jest.mock("@/components/command/useCommandK", () => ({
+  useCommandK: () => ({
+    openPalette: jest.fn(),
+    closePalette: jest.fn(),
+    togglePalette: jest.fn(),
+    open: false,
+    query: "",
+    scope: {},
+    setQuery: jest.fn(),
+  }),
+}));
+
+jest.mock("@/state/profile", () => ({
+  useProfile: () => ({
+    profile: { full_name: "Test User", role: "manager" },
+    loading: false,
+    error: null,
+    refresh: jest.fn(),
+  }),
+}));
+
 describe("AppLayout", () => {
   beforeAll(() => {
     Object.defineProperty(window, "matchMedia", {

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -1,7 +1,6 @@
 import { Fragment, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -25,6 +24,7 @@ import { NAV } from "@/lib/navConfig";
 import { getCurrentUser } from "@/lib/auth";
 import { useProfile } from "@/state/profile";
 import { PROJECT_TABS } from "@/components/common/TabBar";
+import { useCommandK } from "@/components/command/useCommandK";
 
 function findNavLabel(path: string) {
   const walk = (items = NAV): string | undefined => {
@@ -62,6 +62,7 @@ export function Topbar({ onToggleSidebar }: TopbarProps) {
   const user = getCurrentUser();
   const { profile, error: profileError } = useProfile();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const { openPalette } = useCommandK();
 
   const actions = useMemo(
     () => [
@@ -144,9 +145,19 @@ export function Topbar({ onToggleSidebar }: TopbarProps) {
         </Breadcrumb>
       </div>
 
-      <div className="mx-auto hidden w-full max-w-xl items-center gap-2 md:flex">
-        <Search className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-        <Input placeholder="Search tasks, projects, and people" className="border-0 shadow-none focus-visible:ring-0" />
+      <div className="mx-auto hidden w-full max-w-xl md:flex">
+        <button
+          type="button"
+          onClick={() => openPalette()}
+          className="flex h-10 w-full items-center gap-2 rounded-md border border-input bg-background px-3 text-left text-sm text-muted-foreground shadow-sm transition hover:border-primary/50 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+          aria-label="Open search"
+        >
+          <Search className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          <span className="flex-1 text-left">Search everything</span>
+          <span className="hidden items-center rounded border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground sm:flex">
+            Ctrl&nbsp;K
+          </span>
+        </button>
       </div>
 
       <div className="ml-auto flex items-center gap-2">

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -4,7 +4,7 @@ import { Command as CommandPrimitive } from "cmdk"
 import { Search } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -26,7 +26,11 @@ interface CommandDialogProps extends DialogProps {}
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent
+        className="overflow-hidden p-0 shadow-lg"
+        aria-describedby={undefined}
+      >
+        <DialogTitle className="sr-only">Command menu</DialogTitle>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/src/features/search/__tests__/search-flow.test.tsx
+++ b/src/features/search/__tests__/search-flow.test.tsx
@@ -1,0 +1,211 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
+import { CommandPalette } from "@/components/command/CommandPalette";
+import { CommandKProvider } from "@/components/command/CommandKProvider";
+import GlobalSearchPage from "@/pages/search/GlobalSearchPage";
+import { act } from "react";
+
+jest.mock("@/services/search", () => ({
+  searchAll: jest.fn(),
+  searchSuggest: jest.fn(() => Promise.resolve([])),
+}));
+
+const saved: any[] = [];
+
+jest.mock("@/services/savedSearches", () => ({
+  listSavedSearches: jest.fn(() => Promise.resolve([...saved])),
+  createSavedSearch: jest.fn(({ name, query, filters }) => {
+    const entry = {
+      id: `${saved.length + 1}`,
+      name,
+      query,
+      filters: filters ?? {},
+      created_at: new Date().toISOString(),
+    };
+    saved.unshift(entry);
+    return Promise.resolve(entry);
+  }),
+  deleteSavedSearch: jest.fn((id: string) => {
+    const index = saved.findIndex((item) => item.id === id);
+    if (index >= 0) {
+      saved.splice(index, 1);
+    }
+    return Promise.resolve();
+  }),
+  __reset: () => {
+    saved.length = 0;
+  },
+}));
+
+const createSupabaseBuilder = () => {
+  const builder: any = {
+    select: jest.fn(() => builder),
+    order: jest.fn(() => Promise.resolve({ data: [], error: null })),
+    limit: jest.fn(() => Promise.resolve({ data: [], error: null })),
+    insert: jest.fn(() => builder),
+    update: jest.fn(() => builder),
+    delete: jest.fn(() => builder),
+    eq: jest.fn(() => builder),
+    filter: jest.fn(() => builder),
+    textSearch: jest.fn(() => builder),
+    single: jest.fn(() => Promise.resolve({ data: null, error: null })),
+    maybeSingle: jest.fn(() => Promise.resolve({ data: null, error: null })),
+  };
+  return builder;
+};
+
+jest.mock("@/integrations/supabase/client", () => ({
+  supabaseConfigured: true,
+  supabase: {
+    from: jest.fn(() => createSupabaseBuilder()),
+  },
+}));
+
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+const searchModule = jest.requireMock("@/services/search") as {
+  searchAll: jest.Mock;
+  searchSuggest: jest.Mock;
+};
+
+const savedSearchModule = jest.requireMock("@/services/savedSearches") as {
+  __reset: () => void;
+};
+
+let latestLocation: ReturnType<typeof useLocation>;
+
+const LocationSpy = () => {
+  const location = useLocation();
+  latestLocation = location;
+  return null;
+};
+
+const renderWithProviders = (initialEntries: string[]) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, cacheTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CommandKProvider>
+        <MemoryRouter initialEntries={initialEntries}>
+          <LocationSpy />
+          <CommandPalette />
+          <Routes>
+            <Route path="/search" element={<GlobalSearchPage />} />
+            <Route path="*" element={<div />} />
+          </Routes>
+        </MemoryRouter>
+      </CommandKProvider>
+    </QueryClientProvider>
+  );
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  savedSearchModule.__reset();
+  searchModule.searchSuggest.mockResolvedValue([]);
+});
+
+describe("Command palette", () => {
+  it("opens with cmd+k and navigates to full search on enter", async () => {
+    searchModule.searchAll.mockResolvedValue([]);
+    renderWithProviders(["/search?q=alpha"]);
+
+    act(() => {
+      const event = new KeyboardEvent("keydown", { key: "k", ctrlKey: true });
+      window.dispatchEvent(event);
+    });
+
+    const input = await screen.findByLabelText("Search");
+    fireEvent.change(input, { target: { value: "plan" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(latestLocation.pathname).toBe("/search");
+      expect(latestLocation.search).toBe("?q=plan");
+    });
+  });
+});
+
+describe("Global search page", () => {
+  it("requests type-specific results when filter changes", async () => {
+    searchModule.searchAll.mockImplementation(({ types }) => {
+      if (types?.includes("doc")) {
+        return Promise.resolve([
+          {
+            id: "d1",
+            type: "doc",
+            title: "Design Doc",
+            url: "/docs/d1",
+            snippet: null,
+          },
+        ]);
+      }
+      return Promise.resolve([
+        {
+          id: "p1",
+          type: "project",
+          title: "Alpha Project",
+          url: "/projects/p1",
+          snippet: null,
+        },
+      ]);
+    });
+
+    renderWithProviders(["/search?q=alpha"]);
+
+    await screen.findByText("Alpha Project");
+
+    const docsTab = screen.getByRole("tab", { name: /docs/i });
+    fireEvent.click(docsTab);
+
+    await waitFor(() => {
+      expect(searchModule.searchAll).toHaveBeenLastCalledWith(
+        expect.objectContaining({ types: ["doc"] })
+      );
+    });
+  });
+});
+
+describe("Saved searches", () => {
+  it("appear as palette actions after saving", async () => {
+    searchModule.searchAll.mockResolvedValue([
+      {
+        id: "p1",
+        type: "project",
+        title: "Alpha Project",
+        url: "/projects/p1",
+        snippet: null,
+      },
+    ]);
+
+    renderWithProviders(["/search?q=alpha"]);
+
+    const saveButton = await screen.findByRole("button", { name: /save search/i });
+    fireEvent.click(saveButton);
+
+    const nameInput = await screen.findByPlaceholderText("Search name");
+    fireEvent.change(nameInput, { target: { value: "Alpha" } });
+    const confirmButton = screen.getByRole("button", { name: /^save$/i });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /save search/i })).toBeEnabled();
+    });
+
+    act(() => {
+      const event = new KeyboardEvent("keydown", { key: "k", ctrlKey: true });
+      window.dispatchEvent(event);
+    });
+
+    const savedAction = await screen.findByRole("option", { name: /alpha/i });
+    expect(savedAction).toBeInTheDocument();
+  });
+});

--- a/src/pages/ia/projects/ProjectDocsPage.tsx
+++ b/src/pages/ia/projects/ProjectDocsPage.tsx
@@ -1,10 +1,27 @@
+import { useParams } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { useCommandK } from "@/components/command/useCommandK";
 import { ProjectPageTemplate } from "./ProjectPageTemplate";
 
 export default function ProjectDocsPage() {
+  const { projectId } = useParams();
+  const { openPalette } = useCommandK();
+
   return (
     <ProjectPageTemplate
       title="Docs"
       description="Capture project knowledge, briefs, and decisions in one place."
+      headerExtras={
+        projectId ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => openPalette({ projectId, types: ["doc"] })}
+          >
+            Search docs
+          </Button>
+        ) : null
+      }
     />
   );
 }

--- a/src/pages/ia/projects/ProjectFilesPage.tsx
+++ b/src/pages/ia/projects/ProjectFilesPage.tsx
@@ -1,10 +1,27 @@
+import { useParams } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { useCommandK } from "@/components/command/useCommandK";
 import { ProjectPageTemplate } from "./ProjectPageTemplate";
 
 export default function ProjectFilesPage() {
+  const { projectId } = useParams();
+  const { openPalette } = useCommandK();
+
   return (
     <ProjectPageTemplate
       title="Files"
       description="Browse and manage project assets with approvals and version history."
+      headerExtras={
+        projectId ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => openPalette({ projectId, types: ["file"] })}
+          >
+            Search files
+          </Button>
+        ) : null
+      }
     />
   );
 }

--- a/src/pages/ia/projects/ProjectPageTemplate.tsx
+++ b/src/pages/ia/projects/ProjectPageTemplate.tsx
@@ -1,22 +1,40 @@
 import { ReactNode } from "react";
 import { useParams } from "react-router-dom";
 import { TabBar } from "@/components/common/TabBar";
+import { Button } from "@/components/ui/button";
+import { useCommandK } from "@/components/command/useCommandK";
 
 interface ProjectPageTemplateProps {
   title: string;
   description: string;
   children?: ReactNode;
+  headerExtras?: ReactNode;
 }
 
-export function ProjectPageTemplate({ title, description, children }: ProjectPageTemplateProps) {
+export function ProjectPageTemplate({ title, description, children, headerExtras }: ProjectPageTemplateProps) {
   const { projectId } = useParams();
+  const { openPalette } = useCommandK();
 
   return (
     <section className="flex flex-col gap-6">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
-        <p className="text-muted-foreground">{description}</p>
-        <p className="text-sm text-muted-foreground">Project reference: {projectId ?? "Unknown"}</p>
+      <header className="space-y-3">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
+          <p className="text-muted-foreground">{description}</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+          <span>Project reference: {projectId ?? "Unknown"}</span>
+          {projectId ? (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => openPalette({ projectId })}
+            >
+              Search in project
+            </Button>
+          ) : null}
+          {headerExtras}
+        </div>
         {/* TODO: Replace reference with actual project name */}
       </header>
       <TabBar />

--- a/src/pages/search/GlobalSearchPage.tsx
+++ b/src/pages/search/GlobalSearchPage.tsx
@@ -1,0 +1,539 @@
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { searchAll } from "@/services/search";
+import type { SearchResult } from "@/types";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SearchResultItem } from "./SearchResultItem";
+import { Loader2, Search as SearchIcon, Trash2 } from "lucide-react";
+import { supabase, supabaseConfigured } from "@/integrations/supabase/client";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  createSavedSearch,
+  deleteSavedSearch,
+  listSavedSearches,
+  type SavedSearch,
+} from "@/services/savedSearches";
+import { useToast } from "@/hooks/use-toast";
+
+const TYPE_FILTERS: Array<{ value: "all" | SearchResult["type"]; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "task", label: "Tasks" },
+  { value: "project", label: "Projects" },
+  { value: "doc", label: "Docs" },
+  { value: "file", label: "Files" },
+  { value: "comment", label: "Comments" },
+  { value: "person", label: "People" },
+];
+
+const DEFAULT_LIMIT = 20;
+
+type ProjectOption = {
+  id: string;
+  name: string;
+};
+
+const fetchProjects = async (): Promise<ProjectOption[]> => {
+  if (!supabaseConfigured) {
+    return [];
+  }
+  const { data, error } = await supabase
+    .from("projects")
+    .select("id, name")
+    .order("name", { ascending: true });
+
+  if (error) {
+    console.warn("Failed to load projects for search filter", error);
+    return [];
+  }
+
+  return data ?? [];
+};
+
+export const GlobalSearchPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const queryParam = searchParams.get("q") ?? "";
+  const projectFilterParam = searchParams.get("projectId");
+  const projectFilter =
+    projectFilterParam && projectFilterParam.trim().length > 0
+      ? projectFilterParam
+      : "all";
+  const typeParam = searchParams.get("type");
+  const [inputValue, setInputValue] = useState(queryParam);
+  const [limit, setLimit] = useState(DEFAULT_LIMIT);
+  const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
+  const [saveName, setSaveName] = useState("");
+
+  const activeType: "all" | SearchResult["type"] = TYPE_FILTERS.some(
+    (filter) => filter.value === typeParam
+  )
+    ? (typeParam as SearchResult["type"] | "all")
+    : "all";
+
+  const [selectedType, setSelectedType] = useState<
+    "all" | SearchResult["type"]
+  >(activeType);
+  const [selectedProject, setSelectedProject] = useState(projectFilter);
+
+  useEffect(() => {
+    setInputValue(queryParam);
+  }, [queryParam]);
+
+  useEffect(() => {
+    setSelectedType(activeType);
+  }, [activeType]);
+
+  useEffect(() => {
+    setSelectedProject(projectFilter);
+  }, [projectFilter]);
+
+  useEffect(() => {
+    setLimit(DEFAULT_LIMIT);
+  }, [queryParam, selectedProject, selectedType]);
+
+  const projectsQuery = useQuery({
+    queryKey: ["search-project-options"],
+    queryFn: fetchProjects,
+    staleTime: 1000 * 60 * 10,
+  });
+
+  const savedSearchesQuery = useQuery({
+    queryKey: ["saved-searches"],
+    queryFn: listSavedSearches,
+    enabled: supabaseConfigured,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const createSavedSearchMutation = useMutation({
+    mutationFn: createSavedSearch,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["saved-searches"] });
+      toast({ title: "Search saved" });
+      setIsSaveDialogOpen(false);
+      setSaveName("");
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Could not save search",
+        description: error?.message ?? "Please try again.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const deleteSavedSearchMutation = useMutation({
+    mutationFn: deleteSavedSearch,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["saved-searches"] });
+      toast({ title: "Search removed" });
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Could not delete search",
+        description: error?.message ?? "Please try again.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const searchEnabled = queryParam.trim().length > 0;
+
+  const resultsQuery = useQuery({
+    queryKey: [
+      "global-search",
+      queryParam,
+      selectedType,
+      selectedProject,
+      limit,
+    ],
+    queryFn: () =>
+      searchAll({
+        q: queryParam,
+        projectId:
+          selectedProject !== "all" ? selectedProject : undefined,
+        limit,
+        types: selectedType === "all" ? undefined : [selectedType],
+        includeComments:
+          selectedType === "all" || selectedType === "comment",
+      }),
+    enabled: searchEnabled,
+    staleTime: 0,
+  });
+
+  const counts = useMemo(() => {
+    const map = new Map<SearchResult["type"], number>();
+    (resultsQuery.data ?? []).forEach((result) => {
+      map.set(result.type, (map.get(result.type) ?? 0) + 1);
+    });
+    return map;
+  }, [resultsQuery.data]);
+
+  const groupedResults = useMemo(() => {
+    if (!resultsQuery.data) {
+      return [] as Array<[SearchResult["type"], SearchResult[]]>;
+    }
+    const groups = new Map<SearchResult["type"], SearchResult[]>();
+    resultsQuery.data.forEach((item) => {
+      if (selectedType !== "all" && item.type !== selectedType) {
+        return;
+      }
+      const existing = groups.get(item.type) ?? [];
+      existing.push(item);
+      groups.set(item.type, existing);
+    });
+    return TYPE_FILTERS.filter((filter) => filter.value !== "all")
+      .map((filter) => [filter.value, groups.get(filter.value) ?? []] as [
+        SearchResult["type"],
+        SearchResult[]
+      ])
+      .filter(([, items]) => items.length > 0);
+  }, [resultsQuery.data, selectedType]);
+
+  const totalResults = resultsQuery.data?.length ?? 0;
+  const showLoadMore = resultsQuery.data
+    ? resultsQuery.data.length >= limit
+    : false;
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const next = new URLSearchParams(searchParams);
+    const trimmed = inputValue.trim();
+    if (trimmed) {
+      next.set("q", trimmed);
+    } else {
+      next.delete("q");
+    }
+    setLimit(DEFAULT_LIMIT);
+    setSearchParams(next);
+    queryClient.invalidateQueries({ queryKey: ["global-search"] });
+  };
+
+  const handleTypeChange = (value: string) => {
+    if (value === selectedType) {
+      return;
+    }
+    const next = new URLSearchParams(searchParams);
+    if (value === "all") {
+      next.delete("type");
+    } else {
+      next.set("type", value);
+    }
+    setLimit(DEFAULT_LIMIT);
+    setSelectedType(value as "all" | SearchResult["type"]);
+    setSearchParams(next);
+    queryClient.invalidateQueries({ queryKey: ["global-search"] });
+  };
+
+  const handleProjectChange = (value: string) => {
+    if (value === selectedProject) {
+      return;
+    }
+    const next = new URLSearchParams(searchParams);
+    if (value === "all") {
+      next.delete("projectId");
+    } else {
+      next.set("projectId", value);
+    }
+    setLimit(DEFAULT_LIMIT);
+    setSelectedProject(value);
+    setSearchParams(next);
+    queryClient.invalidateQueries({ queryKey: ["global-search"] });
+  };
+
+  const handleOpenSaveDialog = () => {
+    setSaveName(queryParam.trim() || "");
+    setIsSaveDialogOpen(true);
+  };
+
+  const handleSaveSearch = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedQuery = queryParam.trim();
+    const trimmedName = saveName.trim();
+    if (!trimmedQuery || !trimmedName) {
+      return;
+    }
+    const filters: Record<string, unknown> = {};
+    if (selectedType !== "all") {
+      filters.type = selectedType;
+    }
+    if (selectedProject !== "all") {
+      filters.projectId = selectedProject;
+    }
+    createSavedSearchMutation.mutate({
+      name: trimmedName,
+      query: trimmedQuery,
+      filters,
+    });
+  };
+
+  const applySavedSearch = (saved: SavedSearch) => {
+    const next = new URLSearchParams();
+    next.set("q", saved.query);
+    const filters = (saved.filters ?? {}) as {
+      type?: string | null;
+      projectId?: string | null;
+    };
+    const typeValue =
+      filters.type && filters.type !== "all"
+        ? (String(filters.type) as SearchResult["type"] | "all")
+        : "all";
+    if (typeValue !== "all") {
+      next.set("type", typeValue);
+    }
+    const projectValue =
+      filters.projectId && String(filters.projectId).trim().length > 0
+        ? String(filters.projectId)
+        : "all";
+    if (projectValue !== "all") {
+      next.set("projectId", projectValue);
+    }
+    setSelectedType(typeValue);
+    setSelectedProject(projectValue);
+    setLimit(DEFAULT_LIMIT);
+    setSearchParams(next);
+    queryClient.invalidateQueries({ queryKey: ["global-search"] });
+  };
+
+  const handleDeleteSavedSearch = (id: string, event: React.MouseEvent) => {
+    event.stopPropagation();
+    deleteSavedSearchMutation.mutate(id);
+  };
+
+  return (
+    <div className="container mx-auto space-y-6 py-8">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold">Search</h1>
+          <p className="text-sm text-muted-foreground">
+            Find tasks, projects, docs, files, comments, and teammates.
+          </p>
+        </div>
+        <form
+          onSubmit={handleSubmit}
+          className="flex w-full max-w-xl items-center gap-2"
+        >
+          <div className="relative w-full">
+            <SearchIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
+            <Input
+              value={inputValue}
+              onChange={(event) => setInputValue(event.target.value)}
+              placeholder="Search across work"
+              className="pl-10"
+              aria-label="Global search"
+            />
+          </div>
+          <Button type="submit">Search</Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleOpenSaveDialog}
+            disabled={
+              !searchEnabled ||
+              createSavedSearchMutation.isPending ||
+              !supabaseConfigured
+            }
+          >
+            Save search
+          </Button>
+        </form>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Tabs
+          value={selectedType}
+          onValueChange={handleTypeChange}
+          className="w-full md:w-auto"
+        >
+          <TabsList className="flex flex-wrap justify-start">
+            {TYPE_FILTERS.map((filter) => (
+              <TabsTrigger
+                key={filter.value}
+                value={filter.value}
+                className="gap-1"
+                onClick={() => handleTypeChange(filter.value)}
+              >
+                {filter.label}
+                {filter.value !== "all" ? (
+                  <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                    {counts.get(filter.value as SearchResult["type"]) ?? 0}
+                  </span>
+                ) : null}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+        <Select value={selectedProject} onValueChange={handleProjectChange}>
+          <SelectTrigger className="w-[220px]">
+            <SelectValue placeholder="All projects" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All projects</SelectItem>
+            {(projectsQuery.data ?? []).map((project) => (
+              <SelectItem key={project.id} value={project.id}>
+                {project.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[260px_1fr]">
+        <aside className="space-y-4">
+          <div className="rounded-lg border border-border bg-background p-4 shadow-sm">
+            <h2 className="text-sm font-semibold">Result summary</h2>
+            <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+              {TYPE_FILTERS.filter((filter) => filter.value !== "all").map((filter) => (
+                <li key={filter.value} className="flex items-center justify-between">
+                  <span>{filter.label}</span>
+                  <span>{counts.get(filter.value as SearchResult["type"]) ?? 0}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="rounded-lg border border-border bg-background p-4 shadow-sm">
+            <h2 className="text-sm font-semibold">Saved searches</h2>
+            {!supabaseConfigured ? (
+              <p className="mt-3 text-sm text-muted-foreground">
+                Connect Supabase to save searches.
+              </p>
+            ) : savedSearchesQuery.isLoading ? (
+              <p className="mt-3 text-sm text-muted-foreground">Loading saved searches...</p>
+            ) : savedSearchesQuery.data?.length ? (
+              <ul className="mt-3 space-y-2">
+                {savedSearchesQuery.data.map((saved) => (
+                  <li
+                    key={saved.id}
+                    className="flex items-center justify-between gap-2 rounded-md border border-transparent px-3 py-2 hover:border-border hover:bg-muted/60"
+                  >
+                    <button
+                      type="button"
+                      className="flex flex-1 flex-col items-start gap-1 text-left"
+                      onClick={() => applySavedSearch(saved)}
+                    >
+                      <span className="text-sm font-medium">{saved.name}</span>
+                      <span className="w-full truncate text-xs text-muted-foreground">{saved.query}</span>
+                    </button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={(event) => handleDeleteSavedSearch(saved.id, event)}
+                      disabled={deleteSavedSearchMutation.isPending}
+                      aria-label="Delete saved search"
+                    >
+                      <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mt-3 text-sm text-muted-foreground">No saved searches yet.</p>
+            )}
+          </div>
+        </aside>
+
+        <main className="space-y-6">
+          {!searchEnabled ? (
+            <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+              Start typing to search your workspace.
+            </div>
+          ) : resultsQuery.isLoading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              Searching...
+            </div>
+          ) : resultsQuery.isError ? (
+            <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+              {(resultsQuery.error as Error)?.message ?? "Search failed."}
+            </div>
+          ) : totalResults === 0 ? (
+            <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+              No results yet. Try refining your keywords or filters.
+            </div>
+          ) : (
+            groupedResults.map(([type, items]) => (
+              <section key={type} className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-sm font-semibold text-muted-foreground">
+                    {TYPE_FILTERS.find((filter) => filter.value === type)?.label ?? type}
+                  </h2>
+                  <span className="text-xs text-muted-foreground">{items.length}</span>
+                </div>
+                <ul className="space-y-3">
+                  {items.map((item) => (
+                    <SearchResultItem key={`${item.type}-${item.id}`} result={item} query={queryParam} />
+                  ))}
+                </ul>
+              </section>
+            ))
+          )}
+
+          {showLoadMore && searchEnabled ? (
+            <div className="flex justify-center">
+              <Button variant="outline" onClick={() => setLimit((value) => value + DEFAULT_LIMIT)}>
+                Load more
+              </Button>
+            </div>
+          ) : null}
+        </main>
+      </div>
+      <Dialog open={isSaveDialogOpen} onOpenChange={setIsSaveDialogOpen}>
+        <DialogContent aria-describedby={undefined}>
+          <DialogHeader>
+            <DialogTitle>Save this search</DialogTitle>
+          </DialogHeader>
+          <form className="space-y-4" onSubmit={handleSaveSearch}>
+            <Input
+              value={saveName}
+              onChange={(event) => setSaveName(event.target.value)}
+              placeholder="Search name"
+              autoFocus
+            />
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setIsSaveDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={
+                  createSavedSearchMutation.isPending ||
+                  !saveName.trim() ||
+                  !queryParam.trim()
+                }
+              >
+                Save
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default GlobalSearchPage;

--- a/src/pages/search/SearchResultItem.tsx
+++ b/src/pages/search/SearchResultItem.tsx
@@ -1,0 +1,87 @@
+import { Link } from "react-router-dom";
+import { Badge } from "@/components/ui/badge";
+import type { SearchResult } from "@/types";
+import { formatDistanceToNow } from "date-fns";
+import { cn } from "@/lib/utils";
+
+const TYPE_LABELS: Record<SearchResult["type"], string> = {
+  task: "Task",
+  project: "Project",
+  doc: "Doc",
+  file: "File",
+  comment: "Comment",
+  person: "Person",
+};
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const buildHighlightedSnippet = (snippet: string, query: string) => {
+  const terms = query
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (!terms.length) {
+    return snippet;
+  }
+
+  const pattern = terms.map((term) => escapeRegExp(term)).join("|");
+  const regex = new RegExp(`(${pattern})`, "gi");
+  const parts = snippet.split(regex);
+
+  return parts.map((part, index) => {
+    if (!part) {
+      return null;
+    }
+    const key = `${part}-${index}`;
+    if (index % 2 === 1) {
+      return (
+        <mark key={key} className="rounded bg-primary/10 px-1 text-primary">
+          {part}
+        </mark>
+      );
+    }
+    return <span key={key}>{part}</span>;
+  });
+};
+
+type SearchResultItemProps = {
+  result: SearchResult;
+  query: string;
+};
+
+export const SearchResultItem = ({ result, query }: SearchResultItemProps) => {
+  const updatedAt = result.updated_at
+    ? formatDistanceToNow(new Date(result.updated_at), { addSuffix: true })
+    : null;
+
+  const snippet = result.snippet ? buildHighlightedSnippet(result.snippet, query) : null;
+
+  return (
+    <li className="rounded-lg border border-border bg-background p-4 shadow-sm transition hover:border-primary/40">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex flex-col gap-1">
+            <Link to={result.url} className="text-sm font-semibold text-primary hover:underline">
+              {result.title || TYPE_LABELS[result.type]}
+            </Link>
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <Badge variant="outline" className="uppercase">
+                {TYPE_LABELS[result.type]}
+              </Badge>
+              <span className="truncate">{result.url}</span>
+            </div>
+          </div>
+          {updatedAt ? (
+            <time className="text-xs text-muted-foreground" dateTime={result.updated_at ?? undefined}>
+              {updatedAt}
+            </time>
+          ) : null}
+        </div>
+        {snippet ? (
+          <p className={cn("text-sm text-muted-foreground", "line-clamp-3")}>{snippet}</p>
+        ) : null}
+      </div>
+    </li>
+  );
+};

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -53,7 +53,7 @@ import AuthCallback from "@/pages/AuthCallback";
 import NotFound from "@/pages/NotFound";
 import Profile from "@/pages/Profile";
 import Settings from "@/pages/Settings";
-import SearchPage from "@/pages/Search";
+import GlobalSearchPage from "@/pages/search/GlobalSearchPage";
 
 const Suspended = ({ children }: { children: React.ReactNode }) => (
   <Suspense fallback={<div className="p-6">Loading...</div>}>
@@ -110,7 +110,7 @@ export function AppRoutes() {
         { path: "tasks/new", element: <NewTaskPage /> },
         { path: "profile", element: <Profile /> },
         { path: "settings", element: <Settings /> },
-        { path: "search", element: <SearchPage /> },
+        { path: "search", element: <GlobalSearchPage /> },
         { path: "admin", element: <AdminHomePage /> },
         { path: "admin/workspace", element: <AdminWorkspacePage /> },
         { path: "admin/permissions", element: <AdminPermissionsPage /> },

--- a/src/services/__tests__/search.test.ts
+++ b/src/services/__tests__/search.test.ts
@@ -1,0 +1,64 @@
+import { searchAll } from "../search";
+
+jest.mock("@/integrations/supabase/client", () => {
+  const mockData: Record<string, any[]> = {};
+
+  const createBuilder = (table: string) => {
+    const builder: any = {
+      select: jest.fn(() => builder),
+      textSearch: jest.fn(() => builder),
+      order: jest.fn(() => builder),
+      limit: jest.fn(() => Promise.resolve({ data: mockData[table] ?? [], error: null })),
+      or: jest.fn(() => builder),
+      filter: jest.fn(() => builder),
+      eq: jest.fn(() => builder),
+    };
+    return builder;
+  };
+
+  const supabase = {
+    from: jest.fn((table: string) => createBuilder(table)),
+  };
+
+  return {
+    supabaseConfigured: true,
+    supabase,
+    __setMockData: (data: Record<string, any[]>) => {
+      Object.keys(mockData).forEach((key) => delete mockData[key]);
+      Object.assign(mockData, data);
+    },
+  };
+});
+
+const supabaseMock = jest.requireMock("@/integrations/supabase/client") as {
+  __setMockData: (data: Record<string, any[]>) => void;
+};
+
+describe("searchAll", () => {
+  beforeEach(() => {
+    supabaseMock.__setMockData({
+      projects: [
+        {
+          id: "p1",
+          name: "Alpha Project",
+          description: "Alpha initiative",
+          updated_at: new Date().toISOString(),
+        },
+      ],
+      tasks: [],
+      doc_pages: [],
+      project_files: [],
+      comments: [],
+      profiles: [],
+    });
+  });
+
+  it("returns project results for matching query", async () => {
+    const results = await searchAll({ q: "Alpha" });
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "p1", type: "project" }),
+      ])
+    );
+  });
+});

--- a/src/services/savedSearches.ts
+++ b/src/services/savedSearches.ts
@@ -1,0 +1,69 @@
+import { supabase, supabaseConfigured } from "@/integrations/supabase/client";
+
+export type SavedSearch = {
+  id: string;
+  name: string;
+  query: string;
+  filters: Record<string, unknown>;
+  created_at: string;
+};
+
+type CreateSavedSearchInput = {
+  name: string;
+  query: string;
+  filters?: Record<string, unknown>;
+};
+
+export const listSavedSearches = async (): Promise<SavedSearch[]> => {
+  if (!supabaseConfigured) {
+    return [];
+  }
+
+  const { data, error } = await supabase
+    .from("saved_searches")
+    .select("id, name, query, filters, created_at")
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (error) {
+    throw error;
+  }
+
+  return data ?? [];
+};
+
+export const createSavedSearch = async (
+  input: CreateSavedSearchInput
+): Promise<SavedSearch> => {
+  if (!supabaseConfigured) {
+    throw new Error("Supabase is not configured");
+  }
+
+  const { data, error } = await supabase
+    .from("saved_searches")
+    .insert({
+      name: input.name,
+      query: input.query,
+      filters: input.filters ?? {},
+    })
+    .select("id, name, query, filters, created_at")
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
+};
+
+export const deleteSavedSearch = async (id: string): Promise<void> => {
+  if (!supabaseConfigured) {
+    throw new Error("Supabase is not configured");
+  }
+
+  const { error } = await supabase.from("saved_searches").delete().eq("id", id);
+
+  if (error) {
+    throw error;
+  }
+};

--- a/src/services/search.ts
+++ b/src/services/search.ts
@@ -1,0 +1,514 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { supabase, supabaseConfigured } from "@/integrations/supabase/client";
+import type { SearchResult } from "@/types";
+
+const DEFAULT_LIMIT = 10;
+const SUPPORTED_TYPES: SearchResult["type"][] = [
+  "task",
+  "project",
+  "doc",
+  "file",
+  "comment",
+  "person",
+];
+
+type SearchParams = {
+  q: string;
+  limit?: number;
+  projectId?: string;
+  types?: Array<SearchResult["type"]>;
+  includeComments?: boolean;
+};
+
+type Suggestion = Pick<SearchResult, "type" | "title" | "url">;
+
+type QueryContext = {
+  limit: number;
+  ts: string;
+  ilike: string;
+  projectId?: string;
+  query: string;
+};
+
+type QueryBuilder<T> = (
+  client: SupabaseClient<any>,
+  ctx: QueryContext
+) => Promise<T[]>;
+
+export const normalizeQuery = (input: string): { ts: string; ilike: string } => {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return { ts: "", ilike: "" };
+  }
+
+  const cleaned = trimmed
+    .replace(/["'`~!@#$%^&*()+=\[\]{}|\\:;<>?/]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  const tsTerms = cleaned
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((term) => `${term}:*`);
+
+  const ts = tsTerms.join(" & ");
+  const ilike = `%${cleaned.replace(/[%_]/g, (match) => `\\${match}`)}%`;
+
+  return { ts, ilike };
+};
+
+const buildWithFallback = async <T>(
+  ctx: QueryContext,
+  buildTsQuery: () => Promise<{ data: T[] | null; error: any }>,
+  buildIlikeQuery: () => Promise<{ data: T[] | null; error: any }>
+): Promise<T[]> => {
+  if (!supabaseConfigured) {
+    return [];
+  }
+
+  if (ctx.ts) {
+    try {
+      const { data, error } = await buildTsQuery();
+      if (!error && data?.length) {
+        return data;
+      }
+    } catch (error) {
+      console.warn("Search TS query failed", error);
+    }
+  }
+
+  try {
+    const { data, error } = await buildIlikeQuery();
+    if (error) {
+      console.warn("Search ILIKE query failed", error);
+      return [];
+    }
+    return data ?? [];
+  } catch (error) {
+    console.warn("Search ILIKE query threw", error);
+    return [];
+  }
+};
+
+const selectWithRank = (columns: string[], ts: string) => {
+  const rankExpression = ts
+    ? `, ts_rank(search, to_tsquery('simple', '${ts.replace(/'/g, "''")}')) as score`
+    : ", NULL::float as score";
+  return `${columns.join(", ")}${rankExpression}`;
+};
+
+const stripMarkdown = (value: string | null | undefined) => {
+  if (!value) {
+    return "";
+  }
+  return value
+    .replace(/`{1,3}[^`]*`{1,3}/g, " ")
+    .replace(/\!\[[^\]]*]\([^)]*\)/g, " ")
+    .replace(/\[[^\]]*]\([^)]*\)/g, "$1")
+    .replace(/[#*_>~`]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+};
+
+const createSnippet = (value: string | null | undefined, query: string, maxLength = 160) => {
+  const cleaned = stripMarkdown(value);
+  if (!cleaned) {
+    return null;
+  }
+  if (!query.trim()) {
+    return cleaned.length > maxLength ? `${cleaned.slice(0, maxLength)}…` : cleaned;
+  }
+  const terms = query
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  const lower = cleaned.toLowerCase();
+  for (const term of terms) {
+    const index = lower.indexOf(term.toLowerCase());
+    if (index !== -1) {
+      const start = Math.max(0, index - 60);
+      const end = Math.min(cleaned.length, index + term.length + 60);
+      let excerpt = cleaned.slice(start, end);
+      if (start > 0) {
+        excerpt = `…${excerpt}`;
+      }
+      if (end < cleaned.length) {
+        excerpt = `${excerpt}…`;
+      }
+      return excerpt.length > maxLength ? `${excerpt.slice(0, maxLength)}…` : excerpt;
+    }
+  }
+
+  return cleaned.length > maxLength ? `${cleaned.slice(0, maxLength)}…` : cleaned;
+};
+
+const searchTasks = async (
+  client: SupabaseClient<any>,
+  ctx: QueryContext
+): Promise<SearchResult[]> => {
+  const columns = selectWithRank(
+    ["id", "title", "description", "project_id", "updated_at"],
+    ctx.ts
+  );
+
+  const getBaseQuery = () => {
+    let query = client.from("tasks").select(columns);
+    if (ctx.projectId) {
+      query = query.eq("project_id", ctx.projectId);
+    }
+    return query;
+  };
+
+  const rows = await buildWithFallback(
+    ctx,
+    () =>
+      getBaseQuery()
+        .textSearch("search", ctx.ts, { config: "simple", type: "raw" })
+        .order("score", { ascending: false, nullsLast: true })
+        .limit(ctx.limit),
+    () =>
+      getBaseQuery()
+        .or(`title.ilike.${ctx.ilike},description.ilike.${ctx.ilike}`)
+        .order("updated_at", { ascending: false, nullsLast: true })
+        .limit(ctx.limit)
+  );
+
+  return rows
+    .map((row: any) => {
+      const title = row.title || "Untitled task";
+      const projectId = row.project_id ?? undefined;
+      const url = projectId
+        ? `/projects/${projectId}/board?task=${row.id}`
+        : `/tasks/${row.id}`;
+      const result: SearchResult = {
+        id: row.id,
+        type: "task",
+        title,
+        snippet: createSnippet(row.description, ctx.query),
+        url,
+        project_id: projectId,
+        updated_at: row.updated_at ?? null,
+        score: typeof row.score === "number" ? row.score : undefined,
+      };
+      return result;
+    })
+    .filter(Boolean);
+};
+
+const searchProjects = async (
+  client: SupabaseClient<any>,
+  ctx: QueryContext
+): Promise<SearchResult[]> => {
+  const columns = selectWithRank(
+    ["id", "name", "description", "updated_at"],
+    ctx.ts
+  );
+
+  const getBaseQuery = () => client.from("projects").select(columns);
+
+  const rows = await buildWithFallback(
+    ctx,
+    () =>
+      getBaseQuery()
+        .textSearch("search", ctx.ts, { config: "simple", type: "raw" })
+        .order("score", { ascending: false, nullsLast: true })
+        .limit(ctx.limit),
+    () =>
+      getBaseQuery()
+        .or(`name.ilike.${ctx.ilike},description.ilike.${ctx.ilike}`)
+        .order("updated_at", { ascending: false, nullsLast: true })
+        .limit(ctx.limit)
+  );
+
+  return rows.map((row: any) => ({
+    id: row.id,
+    type: "project",
+    title: row.name ?? "Untitled project",
+    snippet: createSnippet(row.description, ctx.query),
+    url: `/projects/${row.id}`,
+    updated_at: row.updated_at ?? null,
+    score: typeof row.score === "number" ? row.score : undefined,
+  }));
+};
+
+const searchDocs = async (
+  client: SupabaseClient<any>,
+  ctx: QueryContext
+): Promise<SearchResult[]> => {
+  const columns = selectWithRank(
+    ["id", "title", "body_markdown", "project_id", "updated_at"],
+    ctx.ts
+  );
+
+  const getBaseQuery = () => client.from("doc_pages").select(columns);
+
+  const rows = await buildWithFallback(
+    ctx,
+    () =>
+      getBaseQuery()
+        .textSearch("search", ctx.ts, { config: "simple", type: "raw" })
+        .order("score", { ascending: false, nullsLast: true })
+        .limit(ctx.limit),
+    () =>
+      getBaseQuery()
+        .or(`title.ilike.${ctx.ilike},body_markdown.ilike.${ctx.ilike}`)
+        .order("updated_at", { ascending: false, nullsLast: true })
+        .limit(ctx.limit)
+  );
+
+  return rows.map((row: any) => {
+    const projectId = row.project_id ?? undefined;
+    const baseUrl = projectId
+      ? `/projects/${projectId}/docs/${row.id}`
+      : `/docs/${row.id}`;
+    return {
+      id: row.id,
+      type: "doc",
+      title: row.title ?? "Untitled doc",
+      snippet: createSnippet(row.body_markdown, ctx.query),
+      url: baseUrl,
+      project_id: projectId,
+      updated_at: row.updated_at ?? null,
+      score: typeof row.score === "number" ? row.score : undefined,
+    } satisfies SearchResult;
+  });
+};
+
+const searchFiles = async (
+  client: SupabaseClient<any>,
+  ctx: QueryContext
+): Promise<SearchResult[]> => {
+  const columns = selectWithRank(
+    ["id", "title", "path", "project_id", "updated_at"],
+    ctx.ts
+  );
+
+  const getBaseQuery = () => client.from("project_files").select(columns);
+
+  const rows = await buildWithFallback(
+    ctx,
+    () =>
+      getBaseQuery()
+        .textSearch("search", ctx.ts, { config: "simple", type: "raw" })
+        .order("score", { ascending: false, nullsLast: true })
+        .limit(ctx.limit),
+    () =>
+      getBaseQuery()
+        .or(`title.ilike.${ctx.ilike},path.ilike.${ctx.ilike}`)
+        .order("updated_at", { ascending: false, nullsLast: true })
+        .limit(ctx.limit)
+  );
+
+  return rows.map((row: any) => {
+    const projectId = row.project_id ?? undefined;
+    const baseUrl = projectId
+      ? `/projects/${projectId}/files?file=${encodeURIComponent(row.id)}`
+      : `/files?file=${encodeURIComponent(row.id)}`;
+    return {
+      id: row.id,
+      type: "file",
+      title: row.title ?? row.path ?? "File",
+      snippet: createSnippet(row.path, ctx.query),
+      url: baseUrl,
+      project_id: projectId,
+      updated_at: row.updated_at ?? null,
+      score: typeof row.score === "number" ? row.score : undefined,
+    } satisfies SearchResult;
+  });
+};
+
+const resolveCommentUrl = (row: any): string | null => {
+  const entityType = row.entity_type as string | null;
+  const entityId = row.entity_id as string | null;
+  if (!entityType || !entityId) {
+    return null;
+  }
+
+  switch (entityType) {
+    case "task":
+      return row.project_id
+        ? `/projects/${row.project_id}/board?task=${entityId}`
+        : `/tasks/${entityId}`;
+    case "project":
+      return `/projects/${entityId}`;
+    case "doc":
+      return row.project_id
+        ? `/projects/${row.project_id}/docs/${entityId}`
+        : `/docs/${entityId}`;
+    default:
+      return null;
+  }
+};
+
+const searchComments = async (
+  client: SupabaseClient<any>,
+  ctx: QueryContext
+): Promise<SearchResult[]> => {
+  const columns = selectWithRank(
+    [
+      "id",
+      "body_markdown",
+      "entity_type",
+      "entity_id",
+      "project_id",
+      "updated_at",
+    ],
+    ctx.ts
+  );
+
+  const getBaseQuery = () => client.from("comments").select(columns);
+
+  const rows = await buildWithFallback(
+    ctx,
+    () =>
+      getBaseQuery()
+        .textSearch("search", ctx.ts, { config: "simple", type: "raw" })
+        .order("score", { ascending: false, nullsLast: true })
+        .limit(ctx.limit),
+    () =>
+      getBaseQuery()
+        .filter("body_markdown", "ilike", ctx.ilike)
+        .order("updated_at", { ascending: false, nullsLast: true })
+        .limit(ctx.limit)
+  );
+
+  return rows
+    .map((row: any) => {
+      const url = resolveCommentUrl(row);
+      if (!url) {
+        return null;
+      }
+      return {
+        id: row.id,
+        type: "comment",
+        title: "Comment",
+        snippet: createSnippet(row.body_markdown, ctx.query),
+        url,
+        project_id: row.project_id ?? undefined,
+        updated_at: row.updated_at ?? null,
+        score: typeof row.score === "number" ? row.score : undefined,
+      } satisfies SearchResult;
+    })
+    .filter((item): item is SearchResult => Boolean(item));
+};
+
+const searchProfiles = async (
+  client: SupabaseClient<any>,
+  ctx: QueryContext
+): Promise<SearchResult[]> => {
+  const columns = selectWithRank(
+    ["id", "full_name", "title", "department", "updated_at"],
+    ctx.ts
+  );
+
+  const getBaseQuery = () => client.from("profiles").select(columns);
+
+  const rows = await buildWithFallback(
+    client,
+    ctx,
+    () =>
+      getBaseQuery()
+        .textSearch("search", ctx.ts, { config: "simple", type: "raw" })
+        .order("score", { ascending: false, nullsLast: true })
+        .limit(ctx.limit),
+    () =>
+      getBaseQuery()
+        .or(
+          `full_name.ilike.${ctx.ilike},title.ilike.${ctx.ilike},department.ilike.${ctx.ilike}`
+        )
+        .order("updated_at", { ascending: false, nullsLast: true })
+        .limit(ctx.limit)
+  );
+
+  return rows.map((row: any) => ({
+    id: row.id,
+    type: "person",
+    title: row.full_name ?? "Team member",
+    snippet: createSnippet(
+      [row.title, row.department].filter(Boolean).join(" • "),
+      ctx.query
+    ),
+    url: `/people/${row.id}`,
+    updated_at: row.updated_at ?? null,
+    score: typeof row.score === "number" ? row.score : undefined,
+  }));
+};
+
+const typeToSearchFn: Record<SearchResult["type"], QueryBuilder<any>> = {
+  task: searchTasks,
+  project: searchProjects,
+  doc: searchDocs,
+  file: searchFiles,
+  comment: searchComments,
+  person: searchProfiles,
+};
+
+export const searchAll = async ({
+  q,
+  limit = DEFAULT_LIMIT,
+  projectId,
+  types,
+  includeComments,
+}: SearchParams): Promise<SearchResult[]> => {
+  if (!q.trim()) {
+    return [];
+  }
+
+  const normalizedTypes = (types ?? SUPPORTED_TYPES).filter((type) =>
+    SUPPORTED_TYPES.includes(type)
+  );
+
+  const { ts, ilike } = normalizeQuery(q);
+  const ctx: QueryContext = { limit, ts, ilike, projectId, query: q };
+  const client = supabase as SupabaseClient<any>;
+
+  const tasksToRun = normalizedTypes.filter((type) =>
+    type !== "comment" ? true : includeComments ?? true
+  );
+
+  const queries = tasksToRun.map((type) =>
+    typeToSearchFn[type](client, ctx).catch((error) => {
+      console.warn(`Search query failed for ${type}`, error);
+      return [];
+    })
+  );
+
+  const results = await Promise.all(queries);
+
+  const merged = new Map<string, SearchResult>();
+  results.flat().forEach((item) => {
+    const key = `${item.type}:${item.id}`;
+    const existing = merged.get(key);
+    if (!existing || (item.score ?? 0) > (existing.score ?? 0)) {
+      merged.set(key, item);
+    }
+  });
+
+  return Array.from(merged.values()).sort((a, b) => {
+    const scoreA = a.score ?? 0;
+    const scoreB = b.score ?? 0;
+    if (scoreA !== scoreB) {
+      return scoreB - scoreA;
+    }
+    const timeA = a.updated_at ? Date.parse(a.updated_at) : 0;
+    const timeB = b.updated_at ? Date.parse(b.updated_at) : 0;
+    return timeB - timeA;
+  });
+};
+
+export const searchSuggest = async (
+  q: string
+): Promise<Suggestion[]> => {
+  const results = await searchAll({
+    q,
+    limit: 5,
+    includeComments: false,
+  });
+
+  return results.slice(0, 5).map(({ type, title, url }) => ({
+    type,
+    title,
+    url,
+  }));
+};

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,32 @@
 import "@testing-library/jest-dom";
 
+jest.mock("@/integrations/supabase/client", () => {
+  const createBuilder = () => {
+    const builder: any = {
+      select: jest.fn(() => builder),
+      insert: jest.fn(() => builder),
+      update: jest.fn(() => builder),
+      delete: jest.fn(() => builder),
+      order: jest.fn(() => builder),
+      limit: jest.fn(() => Promise.resolve({ data: [], error: null })),
+      textSearch: jest.fn(() => builder),
+      filter: jest.fn(() => builder),
+      eq: jest.fn(() => builder),
+      or: jest.fn(() => builder),
+      single: jest.fn(() => Promise.resolve({ data: null, error: null })),
+      maybeSingle: jest.fn(() => Promise.resolve({ data: null, error: null })),
+    };
+    return builder;
+  };
+
+  return {
+    supabaseConfigured: false,
+    supabase: {
+      from: jest.fn(() => createBuilder()),
+    },
+  };
+});
+
 class ResizeObserver {
   observe() {}
   unobserve() {}
@@ -31,4 +58,8 @@ if (!globalThis.crypto) {
     value: randomUUID,
     configurable: true,
   });
+}
+
+if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,10 @@
+export type SearchResult = {
+  id: string;
+  type: 'task' | 'project' | 'doc' | 'file' | 'comment' | 'person';
+  title: string;
+  snippet?: string | null;
+  url: string;
+  project_id?: string | null;
+  updated_at?: string | null;
+  score?: number;
+};

--- a/supabase/migrations/20251005060000_search_tasks.sql
+++ b/supabase/migrations/20251005060000_search_tasks.sql
@@ -1,0 +1,18 @@
+-- 20251005060000_search_tasks.sql
+DO $$
+BEGIN
+  IF to_regclass('public.tasks') IS NOT NULL THEN
+    ALTER TABLE public.tasks ADD COLUMN IF NOT EXISTS search tsvector;
+    CREATE INDEX IF NOT EXISTS tasks_search_idx ON public.tasks USING gin(search);
+    CREATE OR REPLACE FUNCTION public.tasks_tsv_update() RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+      NEW.search :=
+        setweight(to_tsvector('simple', coalesce(NEW.title, '')), 'A') ||
+        setweight(to_tsvector('simple', coalesce(NEW.description, '')), 'B');
+      RETURN NEW;
+    END$$;
+    DROP TRIGGER IF EXISTS trg_tasks_tsv ON public.tasks;
+    CREATE TRIGGER trg_tasks_tsv BEFORE INSERT OR UPDATE ON public.tasks
+    FOR EACH ROW EXECUTE FUNCTION public.tasks_tsv_update();
+  END IF;
+END$$;

--- a/supabase/migrations/20251005060010_search_projects.sql
+++ b/supabase/migrations/20251005060010_search_projects.sql
@@ -1,0 +1,18 @@
+-- 20251005060010_search_projects.sql
+DO $$
+BEGIN
+  IF to_regclass('public.projects') IS NOT NULL THEN
+    ALTER TABLE public.projects ADD COLUMN IF NOT EXISTS search tsvector;
+    CREATE INDEX IF NOT EXISTS projects_search_idx ON public.projects USING gin(search);
+    CREATE OR REPLACE FUNCTION public.projects_tsv_update() RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+      NEW.search :=
+        setweight(to_tsvector('simple', coalesce(NEW.name, '')), 'A') ||
+        setweight(to_tsvector('simple', coalesce(NEW.description, '')), 'B');
+      RETURN NEW;
+    END$$;
+    DROP TRIGGER IF EXISTS trg_projects_tsv ON public.projects;
+    CREATE TRIGGER trg_projects_tsv BEFORE INSERT OR UPDATE ON public.projects
+    FOR EACH ROW EXECUTE FUNCTION public.projects_tsv_update();
+  END IF;
+END$$;

--- a/supabase/migrations/20251005060020_search_docs.sql
+++ b/supabase/migrations/20251005060020_search_docs.sql
@@ -1,0 +1,18 @@
+-- 20251005060020_search_docs.sql
+DO $$
+BEGIN
+  IF to_regclass('public.doc_pages') IS NOT NULL THEN
+    ALTER TABLE public.doc_pages ADD COLUMN IF NOT EXISTS search tsvector;
+    CREATE INDEX IF NOT EXISTS doc_pages_search_idx ON public.doc_pages USING gin(search);
+    CREATE OR REPLACE FUNCTION public.doc_pages_tsv_update() RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+      NEW.search :=
+        setweight(to_tsvector('simple', coalesce(NEW.title, '')), 'A') ||
+        setweight(to_tsvector('simple', coalesce(NEW.body_markdown, '')), 'B');
+      RETURN NEW;
+    END$$;
+    DROP TRIGGER IF EXISTS trg_doc_pages_tsv ON public.doc_pages;
+    CREATE TRIGGER trg_doc_pages_tsv BEFORE INSERT OR UPDATE ON public.doc_pages
+    FOR EACH ROW EXECUTE FUNCTION public.doc_pages_tsv_update();
+  END IF;
+END$$;

--- a/supabase/migrations/20251005060030_search_files.sql
+++ b/supabase/migrations/20251005060030_search_files.sql
@@ -1,0 +1,18 @@
+-- 20251005060030_search_files.sql
+DO $$
+BEGIN
+  IF to_regclass('public.project_files') IS NOT NULL THEN
+    ALTER TABLE public.project_files ADD COLUMN IF NOT EXISTS search tsvector;
+    CREATE INDEX IF NOT EXISTS project_files_search_idx ON public.project_files USING gin(search);
+    CREATE OR REPLACE FUNCTION public.project_files_tsv_update() RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+      NEW.search :=
+        setweight(to_tsvector('simple', coalesce(NEW.title, '')), 'A') ||
+        setweight(to_tsvector('simple', coalesce(NEW.path, '')), 'B');
+      RETURN NEW;
+    END$$;
+    DROP TRIGGER IF EXISTS trg_project_files_tsv ON public.project_files;
+    CREATE TRIGGER trg_project_files_tsv BEFORE INSERT OR UPDATE ON public.project_files
+    FOR EACH ROW EXECUTE FUNCTION public.project_files_tsv_update();
+  END IF;
+END$$;

--- a/supabase/migrations/20251005060040_search_comments.sql
+++ b/supabase/migrations/20251005060040_search_comments.sql
@@ -1,0 +1,16 @@
+-- 20251005060040_search_comments.sql
+DO $$
+BEGIN
+  IF to_regclass('public.comments') IS NOT NULL THEN
+    ALTER TABLE public.comments ADD COLUMN IF NOT EXISTS search tsvector;
+    CREATE INDEX IF NOT EXISTS comments_search_idx ON public.comments USING gin(search);
+    CREATE OR REPLACE FUNCTION public.comments_tsv_update() RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+      NEW.search := setweight(to_tsvector('simple', coalesce(NEW.body_markdown, '')), 'B');
+      RETURN NEW;
+    END$$;
+    DROP TRIGGER IF EXISTS trg_comments_tsv ON public.comments;
+    CREATE TRIGGER trg_comments_tsv BEFORE INSERT OR UPDATE ON public.comments
+    FOR EACH ROW EXECUTE FUNCTION public.comments_tsv_update();
+  END IF;
+END$$;

--- a/supabase/migrations/20251005060050_search_profiles.sql
+++ b/supabase/migrations/20251005060050_search_profiles.sql
@@ -1,0 +1,19 @@
+-- 20251005060050_search_profiles.sql
+DO $$
+BEGIN
+  IF to_regclass('public.profiles') IS NOT NULL THEN
+    ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS search tsvector;
+    CREATE INDEX IF NOT EXISTS profiles_search_idx ON public.profiles USING gin(search);
+    CREATE OR REPLACE FUNCTION public.profiles_tsv_update() RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+      NEW.search :=
+        setweight(to_tsvector('simple', coalesce(NEW.full_name, '')), 'A') ||
+        setweight(to_tsvector('simple', coalesce(NEW.title, '')), 'B') ||
+        setweight(to_tsvector('simple', coalesce(NEW.department, '')), 'C');
+      RETURN NEW;
+    END$$;
+    DROP TRIGGER IF EXISTS trg_profiles_tsv ON public.profiles;
+    CREATE TRIGGER trg_profiles_tsv BEFORE INSERT OR UPDATE ON public.profiles
+    FOR EACH ROW EXECUTE FUNCTION public.profiles_tsv_update();
+  END IF;
+END$$;

--- a/supabase/migrations/20251005060060_saved_searches.sql
+++ b/supabase/migrations/20251005060060_saved_searches.sql
@@ -1,0 +1,50 @@
+-- 20251005060060_saved_searches.sql
+DO $$
+BEGIN
+  IF to_regclass('public.saved_searches') IS NULL THEN
+    CREATE TABLE public.saved_searches (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+      name text NOT NULL,
+      query text NOT NULL,
+      filters jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+    ALTER TABLE public.saved_searches ENABLE ROW LEVEL SECURITY;
+    CREATE POLICY saved_searches_self_rw ON public.saved_searches
+      FOR ALL TO authenticated
+      USING (user_id = auth.uid())
+      WITH CHECK (user_id = auth.uid());
+    CREATE INDEX IF NOT EXISTS saved_searches_user_idx
+      ON public.saved_searches(user_id, created_at DESC);
+  ELSE
+    ALTER TABLE public.saved_searches
+      ADD COLUMN IF NOT EXISTS name text NOT NULL,
+      ADD COLUMN IF NOT EXISTS query text NOT NULL,
+      ADD COLUMN IF NOT EXISTS filters jsonb NOT NULL DEFAULT '{}'::jsonb,
+      ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now(),
+      ADD COLUMN IF NOT EXISTS user_id uuid;
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND indexname = 'saved_searches_user_idx'
+    ) THEN
+      CREATE INDEX saved_searches_user_idx
+        ON public.saved_searches(user_id, created_at DESC);
+    END IF;
+    BEGIN
+      ALTER TABLE public.saved_searches ENABLE ROW LEVEL SECURITY;
+    EXCEPTION
+      WHEN duplicate_object THEN NULL;
+    END;
+    BEGIN
+      CREATE POLICY saved_searches_self_rw ON public.saved_searches
+        FOR ALL TO authenticated
+        USING (user_id = auth.uid())
+        WITH CHECK (user_id = auth.uid());
+    EXCEPTION
+      WHEN duplicate_object THEN NULL;
+    END;
+  END IF;
+END$$;


### PR DESCRIPTION
## Summary
- keep the command palette open on route changes and surface saved searches in the search tab
- stabilize global search filters and saved-search state handling for type and project scopes
- mock layout dependencies in tests and extend the Jest setup (including a scrollIntoView polyfill)

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e33e950cd08327a8f9be59790049c6