### PR TITLE
refactor: split app types into domain modules

### DIFF
--- a/src/components/search/AdvancedSearch.tsx
+++ b/src/components/search/AdvancedSearch.tsx
@@ -42,11 +42,11 @@ import {
 } from 'lucide-react';
 import { format } from 'date-fns';
 import { cn } from '@/lib/utils';
-import { useAdvancedSearch, SearchFilters, SearchResult } from '@/hooks/useAdvancedSearch';
+import { useAdvancedSearch, SearchFilters, type AdvancedSearchResult } from '@/hooks/useAdvancedSearch';
 import { toast } from '@/hooks/use-toast';
 
 interface AdvancedSearchProps {
-  onResultSelect?: (result: SearchResult) => void;
+  onResultSelect?: (result: AdvancedSearchResult) => void;
   embedded?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,44 +1,6 @@
-export type HelpArticle = {
-  id: string;
-  owner: string;
-  title: string;
-  slug?: string | null;
-  category?: string | null;
-  tags?: string[] | null;
-  body_markdown: string;
-  body_html?: string | null;
-  is_published: boolean;
-  created_at: string;
-  updated_at: string;
-};
-
-export type Announcement = {
-  id: string;
-  title: string;
-  version?: string | null;
-  body_markdown: string;
-  body_html?: string | null;
-  published_at: string;
-  created_by?: string | null;
-};
-
-export type SupportTicket = {
-  id: string;
-  user_id: string;
-  subject: string;
-  body: string;
-  status: "open" | "in_progress" | "resolved" | "closed";
-  priority: "low" | "normal" | "high" | "urgent";
-  created_at: string;
-  updated_at: string;
-};
-
-export type FeedbackItem = {
-  id: string;
-  user_id: string;
-  type: "bug" | "idea" | "question";
-  page_path?: string | null;
-  message: string;
-  screenshot_url?: string | null;
-  created_at: string;
-};
+/**
+ * DO NOT ADD TYPES HERE.
+ * This file only re-exports from src/types/index.ts to keep imports stable.
+ * Add new types under src/types/<domain>.ts and export them from src/types/index.ts.
+ */
+export * from "./types";

--- a/src/types/comments.ts
+++ b/src/types/comments.ts
@@ -1,0 +1,23 @@
+import type { ID } from "./core";
+
+export type CommentEntityType = "task" | "project" | "doc";
+
+export type Comment = {
+  id: ID;
+  entity_type: CommentEntityType;
+  entity_id: ID;
+  author: ID;
+  parent_id?: ID | null;
+  body_markdown: string;
+  body_html?: string | null;
+  created_at: string;
+  updated_at: string;
+  edited_at?: string | null;
+};
+
+export type CommentMention = {
+  id: ID;
+  comment_id: ID;
+  mentioned_user: ID;
+  created_at: string;
+};

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -1,0 +1,2 @@
+// Core primitives shared across domains
+export type ID = string;

--- a/src/types/files.ts
+++ b/src/types/files.ts
@@ -1,0 +1,13 @@
+import type { ID } from "./core";
+
+export type ProjectFile = {
+  id: ID;
+  project_id: ID;
+  bucket?: "files";
+  path: string;
+  size_bytes?: number;
+  mime_type?: string | null;
+  title?: string | null;
+  uploaded_by?: ID;
+  created_at?: string;
+};

--- a/src/types/help.ts
+++ b/src/types/help.ts
@@ -1,0 +1,46 @@
+import type { ID } from "./core";
+
+export type HelpArticle = {
+  id: ID;
+  owner: ID;
+  title: string;
+  slug?: string | null;
+  category?: string | null;
+  tags?: string[] | null;
+  body_markdown: string;
+  body_html?: string | null;
+  is_published: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Announcement = {
+  id: ID;
+  title: string;
+  version?: string | null;
+  body_markdown: string;
+  body_html?: string | null;
+  published_at: string;
+  created_by?: ID | null;
+};
+
+export type SupportTicket = {
+  id: ID;
+  user_id: ID;
+  subject: string;
+  body: string;
+  status: "open" | "in_progress" | "resolved" | "closed";
+  priority: "low" | "normal" | "high" | "urgent";
+  created_at: string;
+  updated_at: string;
+};
+
+export type FeedbackItem = {
+  id: ID;
+  user_id: ID;
+  type: "bug" | "idea" | "question";
+  page_path?: string | null;
+  message: string;
+  screenshot_url?: string | null;
+  created_at: string;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,44 +1,13 @@
-export type CommentEntityType = 'task' | 'project' | 'doc';
-
-export type Comment = {
-  id: string;
-  entity_type: CommentEntityType;
-  entity_id: string;
-  author: string;
-  parent_id?: string | null;
-  body_markdown: string;
-  body_html?: string | null;
-  created_at: string;
-  updated_at: string;
-  edited_at?: string | null;
-};
-
-export type CommentMention = {
-  id: string;
-  comment_id: string;
-  mentioned_user: string;
-  created_at: string;
-};
-
-export type NotificationType = 'mention' | 'info' | 'success' | 'warning' | 'error';
-
-export type Notification = {
-  id: string;
-  user_id: string;
-  type: NotificationType;
-  title?: string | null;
-  body?: string | null;
-  entity_type?: CommentEntityType | null;
-  entity_id?: string | null;
-  read_at?: string | null;
-  created_at: string;
-};
-
-export type ProfileLite = {
-  id: string;
-  full_name?: string | null;
-  avatar_url?: string | null;
-  email?: string | null;
-};
-
-export * from './backlog';
+/**
+ * Barrel exports for application types.
+ * Add new domain files here; do not edit src/types.ts directly.
+ */
+export * from "./core";
+export * from "./search";
+export * from "./help";
+export * from "./profile";
+export * from "./files";
+export * from "./notifications";
+export * from "./integrations";
+export * from "./comments";
+export * from "./backlog";

--- a/src/types/integrations.ts
+++ b/src/types/integrations.ts
@@ -1,0 +1,28 @@
+import type { ID } from "./core";
+
+export type IntegrationKey =
+  | "gmail"
+  | "google_calendar"
+  | "google_docs"
+  | "github"
+  | "webhooks";
+
+export type UserIntegration = {
+  id: ID;
+  user_id: ID;
+  project_id?: ID | null;
+  provider: IntegrationKey;
+  display_name?: string | null;
+  access_data: any;
+  created_at: string;
+};
+
+export type Webhook = {
+  id: ID;
+  owner: ID;
+  project_id?: ID | null;
+  target_url: string;
+  secret?: string | null;
+  active: boolean;
+  created_at: string;
+};

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -1,0 +1,32 @@
+import type { ID } from "./core";
+
+export type NotificationType =
+  | "mention"
+  | "assigned"
+  | "comment_reply"
+  | "status_change"
+  | "due_soon"
+  | "automation"
+  | "file_shared"
+  | "doc_comment"
+  | "info"
+  | "success"
+  | "warning"
+  | "error";
+
+export type NotificationItem = {
+  id: ID;
+  user_id: ID;
+  type: NotificationType;
+  title?: string | null;
+  body?: string | null;
+  entity_type?: "task" | "project" | "doc" | "file" | "automation" | null;
+  entity_id?: ID | null;
+  project_id?: ID | null;
+  link?: string | null;
+  read_at?: string | null;
+  archived_at?: string | null;
+  created_at?: string;
+};
+
+export type Notification = NotificationItem;

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,19 @@
+import type { ID } from "./core";
+
+export type ProfileLite = {
+  id: ID;
+  full_name?: string | null;
+  avatar_url?: string | null;
+  email?: string | null;
+};
+
+export type Profile = {
+  id: ID;
+  full_name?: string | null;
+  avatar_url?: string | null;
+  title?: string | null;
+  department?: string | null;
+  timezone?: string | null;
+  capacity_hours_per_week?: number | null;
+  updated_at: string;
+};

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,0 +1,12 @@
+import type { ID } from "./core";
+
+export type SearchResult = {
+  id: ID;
+  type: "task" | "project" | "doc" | "file" | "comment" | "person";
+  title: string;
+  snippet?: string | null;
+  url: string;
+  project_id?: ID | null;
+  updated_at?: string | null;
+  score?: number;
+};


### PR DESCRIPTION
## Summary
- add domain-focused type modules and a central barrel to export them
- forward `src/types.ts` to the barrel to resolve conflicts while keeping existing import paths stable
- update advanced search types to extend the shared SearchResult contract

## Testing
- npm run type-check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e348c099a483279546d1810f694d6f