### PR TITLE
feat: add project scoping to search services

### DIFF
--- a/src/services/__tests__/search.test.ts
+++ b/src/services/__tests__/search.test.ts
@@ -1,0 +1,112 @@
+import { searchComments, searchDocs, searchFiles } from '@/services/search';
+
+jest.mock('@/integrations/supabase/client', () => {
+  return {
+    supabase: {
+      from: jest.fn(),
+    },
+  };
+});
+
+const { supabase } = require('@/integrations/supabase/client') as {
+  supabase: {
+    from: jest.Mock;
+  };
+};
+
+type QueryResult<Row> = { data: Row[] | null; error: Error | null };
+
+type QueryStub<Row> = {
+  select: jest.Mock;
+  textSearch: jest.Mock;
+  or: jest.Mock;
+  eq: jest.Mock;
+  order: jest.Mock;
+  limit: jest.Mock;
+  then: jest.Mock;
+  catch: jest.Mock;
+  finally: jest.Mock;
+};
+
+function createQueryStub<Row>(result: QueryResult<Row>): QueryStub<Row> {
+  const thenable = Promise.resolve(result);
+  const stub: Partial<QueryStub<Row>> = {};
+
+  stub.select = jest.fn(() => stub);
+  stub.textSearch = jest.fn(() => stub);
+  stub.or = jest.fn(() => stub);
+  stub.eq = jest.fn(() => stub);
+  stub.order = jest.fn(() => stub);
+  stub.limit = jest.fn(() => stub);
+  stub.then = jest.fn((onFulfilled: (value: QueryResult<Row>) => unknown) => thenable.then(onFulfilled));
+  stub.catch = jest.fn((onRejected?: (reason: unknown) => unknown) => thenable.catch(onRejected as any));
+  stub.finally = jest.fn((onFinally?: () => void) => thenable.finally(onFinally));
+
+  return stub as QueryStub<Row>;
+}
+
+describe('search services', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('searchDocs', () => {
+    it('applies the project filter when projectId is provided', async () => {
+      const stub = createQueryStub({ data: [], error: null });
+      supabase.from.mockReturnValue(stub);
+
+      await searchDocs('product strategy', { projectId: 'project-123' });
+
+      expect(stub.eq).toHaveBeenCalledWith('project_id', 'project-123');
+    });
+
+    it('skips the project filter when projectId is absent', async () => {
+      const stub = createQueryStub({ data: [], error: null });
+      supabase.from.mockReturnValue(stub);
+
+      await searchDocs('product strategy');
+
+      expect(stub.eq).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('searchFiles', () => {
+    it('applies the project filter when projectId is provided', async () => {
+      const stub = createQueryStub({ data: [], error: null });
+      supabase.from.mockReturnValue(stub);
+
+      await searchFiles('roadmap', { projectId: 'proj-42' });
+
+      expect(stub.eq).toHaveBeenCalledWith('project_id', 'proj-42');
+    });
+
+    it('skips the project filter when projectId is absent', async () => {
+      const stub = createQueryStub({ data: [], error: null });
+      supabase.from.mockReturnValue(stub);
+
+      await searchFiles('roadmap');
+
+      expect(stub.eq).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('searchComments', () => {
+    it('applies the project filter when projectId is provided', async () => {
+      const stub = createQueryStub({ data: [], error: null });
+      supabase.from.mockReturnValue(stub);
+
+      await searchComments('launch plan', { projectId: 'project-abc' });
+
+      expect(stub.eq).toHaveBeenCalledWith('project_id', 'project-abc');
+    });
+
+    it('skips the project filter when projectId is absent', async () => {
+      const stub = createQueryStub({ data: [], error: null });
+      supabase.from.mockReturnValue(stub);
+
+      await searchComments('launch plan');
+
+      expect(stub.eq).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/search.ts
+++ b/src/services/search.ts
@@ -1,0 +1,170 @@
+import { supabase } from '@/integrations/supabase/client';
+import type { SupabaseClient, PostgrestFilterBuilder } from '@supabase/supabase-js';
+import type { SearchResult } from '@/types';
+import { escapeLikePattern, mapSupabaseError, normalizeSearchTerm } from './utils';
+
+const DEFAULT_RESULT_LIMIT = 20;
+
+export type SearchContext = {
+  projectId?: string;
+  client?: SupabaseClient<any, any, any>;
+  limit?: number;
+};
+
+type DocumentSearchRow = {
+  id: string;
+  title: string;
+  snippet?: string | null;
+  url?: string | null;
+  project_id?: string | null;
+  updated_at?: string | null;
+  score?: number | null;
+};
+
+type FileSearchRow = {
+  id: string;
+  title?: string | null;
+  path?: string | null;
+  url?: string | null;
+  project_id?: string | null;
+  updated_at?: string | null;
+  size_bytes?: number | null;
+  score?: number | null;
+};
+
+type CommentSearchRow = {
+  id: string;
+  body?: string | null;
+  url?: string | null;
+  project_id?: string | null;
+  updated_at?: string | null;
+  score?: number | null;
+};
+
+type AnyQueryBuilder<Row> = PostgrestFilterBuilder<any, Row, any>;
+
+const getClient = (ctx: SearchContext): SupabaseClient<any, any, any> =>
+  (ctx.client ?? (supabase as SupabaseClient<any, any, any>));
+
+const getLimit = (ctx: SearchContext) => {
+  const limit = ctx.limit ?? DEFAULT_RESULT_LIMIT;
+  return Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : DEFAULT_RESULT_LIMIT;
+};
+
+const applyProjectFilter = <Row>(query: AnyQueryBuilder<Row>, ctx: SearchContext) => {
+  if (!ctx.projectId) {
+    return query;
+  }
+  return query.eq('project_id', ctx.projectId);
+};
+
+const runQuery = async <Row>(
+  query: AnyQueryBuilder<Row>,
+  fallbackMessage: string,
+): Promise<Row[]> => {
+  const { data, error } = await query;
+  if (error) {
+    throw mapSupabaseError(error, fallbackMessage);
+  }
+  return (data ?? []) as Row[];
+};
+
+const mapDocumentRow = (row: DocumentSearchRow): SearchResult => ({
+  id: row.id,
+  type: 'doc',
+  title: row.title,
+  snippet: row.snippet ?? null,
+  url: row.url ?? `/docs/${row.id}`,
+  project_id: row.project_id ?? null,
+  updated_at: row.updated_at ?? null,
+  score: row.score ?? undefined,
+});
+
+const mapFileRow = (row: FileSearchRow): SearchResult => ({
+  id: row.id,
+  type: 'file',
+  title: row.title ?? row.path ?? 'File',
+  snippet: row.path ?? null,
+  url: row.url ?? row.path ?? `/files/${row.id}`,
+  project_id: row.project_id ?? null,
+  updated_at: row.updated_at ?? null,
+  score: row.score ?? undefined,
+});
+
+const mapCommentRow = (row: CommentSearchRow): SearchResult => ({
+  id: row.id,
+  type: 'comment',
+  title: 'Comment',
+  snippet: row.body ?? null,
+  url: row.url ?? `/comments/${row.id}`,
+  project_id: row.project_id ?? null,
+  updated_at: row.updated_at ?? null,
+  score: row.score ?? undefined,
+});
+
+export async function searchDocs(term: string, ctx: SearchContext = {}): Promise<SearchResult[]> {
+  const normalized = normalizeSearchTerm(term);
+  if (!normalized) {
+    return [];
+  }
+
+  const client = getClient(ctx);
+  const limit = getLimit(ctx);
+
+  let query = client
+    .from<DocumentSearchRow>('documents_search')
+    .select('id, title, snippet, url, project_id, updated_at, score')
+    .textSearch('content', normalized, { type: 'websearch' });
+
+  query = applyProjectFilter(query, ctx)
+    .order('score', { ascending: false })
+    .limit(limit);
+
+  const rows = await runQuery(query, 'Unable to search documents.');
+  return rows.map(mapDocumentRow);
+}
+
+export async function searchFiles(term: string, ctx: SearchContext = {}): Promise<SearchResult[]> {
+  const normalized = normalizeSearchTerm(term);
+  if (!normalized) {
+    return [];
+  }
+
+  const client = getClient(ctx);
+  const limit = getLimit(ctx);
+  const pattern = `%${escapeLikePattern(normalized)}%`;
+
+  let query = client
+    .from<FileSearchRow>('project_files')
+    .select('id, title, path, url, project_id, updated_at, size_bytes, score')
+    .or(`title.ilike.${pattern},path.ilike.${pattern}`);
+
+  query = applyProjectFilter(query, ctx)
+    .order('updated_at', { ascending: false, nullsFirst: false })
+    .limit(limit);
+
+  const rows = await runQuery(query, 'Unable to search files.');
+  return rows.map(mapFileRow);
+}
+
+export async function searchComments(term: string, ctx: SearchContext = {}): Promise<SearchResult[]> {
+  const normalized = normalizeSearchTerm(term);
+  if (!normalized) {
+    return [];
+  }
+
+  const client = getClient(ctx);
+  const limit = getLimit(ctx);
+
+  let query = client
+    .from<CommentSearchRow>('comment_search')
+    .select('id, body, url, project_id, updated_at, score')
+    .textSearch('body', normalized, { type: 'websearch' });
+
+  query = applyProjectFilter(query, ctx)
+    .order('updated_at', { ascending: false, nullsFirst: false })
+    .limit(limit);
+
+  const rows = await runQuery(query, 'Unable to search comments.');
+  return rows.map(mapCommentRow);
+}


### PR DESCRIPTION
## Summary
- add Supabase-backed search helpers for documents, files, and comments that respect an optional project context
- normalize search terms, map Supabase rows to SearchResult objects, and share filtering utilities
- cover project-specific filtering for each search helper with unit tests

## Testing
- npm test -- search

------
https://chatgpt.com/codex/tasks/task_e_68e34f3dd9208327a3e671692619983f