### PR TITLE
Add OKR and template migrations

### DIFF
--- a/docs/goals-templates-inventory.md
+++ b/docs/goals-templates-inventory.md
@@ -1,0 +1,19 @@
+# Goals & Templates Inventory
+
+## Goals & OKRs
+- src/pages/ia/GoalsPage.tsx
+
+## Templates
+- src/pages/ia/TemplatesPage.tsx
+
+## Router
+- src/routes.tsx (contains /goals and /templates routes)
+
+## Navigation
+- src/components/layout/AppSidebar.tsx
+- src/components/layout/Sidebar.tsx
+- src/components/layout/Topbar.tsx
+
+## Notes
+- src/routes.tsx includes unresolved scaffold markers like `codex/...` and duplicated imports around people/time routes that appear to break compilation.
+- No dedicated goal/template services, hooks, or project-scoped goal routes exist yet.

--- a/supabase/migrations/20251018090000_okr_cycles.sql
+++ b/supabase/migrations/20251018090000_okr_cycles.sql
@@ -1,0 +1,18 @@
+create table if not exists public.okr_cycles (
+  id uuid primary key default gen_random_uuid(),
+  owner uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  starts_on date not null,
+  ends_on date not null,
+  created_at timestamptz not null default now()
+);
+
+alter table public.okr_cycles enable row level security;
+
+create policy if not exists "cycles_owner_rw" on public.okr_cycles
+for all to authenticated
+using (owner = auth.uid())
+with check (owner = auth.uid());
+
+create index if not exists okr_cycles_owner_idx on public.okr_cycles(owner);
+create index if not exists okr_cycles_dates_idx on public.okr_cycles(starts_on, ends_on);

--- a/supabase/migrations/20251018090100_goals_okrs.sql
+++ b/supabase/migrations/20251018090100_goals_okrs.sql
@@ -1,0 +1,82 @@
+create table if not exists public.goals (
+  id uuid primary key default gen_random_uuid(),
+  owner uuid not null references auth.users(id) on delete cascade,
+  project_id uuid references public.projects(id) on delete cascade,
+  parent_goal_id uuid references public.goals(id) on delete set null,
+  cycle_id uuid references public.okr_cycles(id) on delete set null,
+  title text not null,
+  description text,
+  status text not null default 'on_track',
+  weight numeric not null default 1,
+  progress numeric not null default 0,
+  is_private boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.key_results (
+  id uuid primary key default gen_random_uuid(),
+  goal_id uuid not null references public.goals(id) on delete cascade,
+  title text not null,
+  metric_start numeric,
+  metric_target numeric,
+  metric_current numeric,
+  unit text,
+  weight numeric not null default 1,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.goal_updates (
+  id uuid primary key default gen_random_uuid(),
+  goal_id uuid not null references public.goals(id) on delete cascade,
+  status text not null,
+  note text,
+  progress numeric,
+  created_by uuid references auth.users(id),
+  created_at timestamptz not null default now()
+);
+
+alter table public.goals enable row level security;
+alter table public.key_results enable row level security;
+alter table public.goal_updates enable row level security;
+
+create policy if not exists "goals_owner_rw" on public.goals for all to authenticated
+using (owner = auth.uid())
+with check (owner = auth.uid());
+
+create policy if not exists "goals_project_read" on public.goals for select to authenticated
+using (
+  project_id is null
+  or project_id in (
+    select id from public.projects where owner = auth.uid()
+    union
+    select project_id from public.project_members where user_id = auth.uid()
+  )
+);
+
+create policy if not exists "krs_owner_rw" on public.key_results for all to authenticated
+using (goal_id in (select id from public.goals where owner = auth.uid()))
+with check (goal_id in (select id from public.goals where owner = auth.uid()));
+
+create policy if not exists "krs_project_read" on public.key_results for select to authenticated
+using (goal_id in (
+  select id from public.goals
+  where project_id is null
+     or project_id in (
+       select id from public.projects where owner = auth.uid()
+       union
+       select project_id from public.project_members where user_id = auth.uid()
+     )
+));
+
+create policy if not exists "goal_updates_owner_rw" on public.goal_updates for all to authenticated
+using (goal_id in (select id from public.goals where owner = auth.uid()))
+with check (goal_id in (select id from public.goals where owner = auth.uid()));
+
+create index if not exists goals_owner_idx on public.goals(owner);
+create index if not exists goals_project_idx on public.goals(project_id);
+create index if not exists goals_cycle_idx on public.goals(cycle_id);
+create index if not exists goals_parent_idx on public.goals(parent_goal_id);
+create index if not exists krs_goal_idx on public.key_results(goal_id);
+create index if not exists goal_updates_goal_idx on public.goal_updates(goal_id);

--- a/supabase/migrations/20251018090200_project_templates.sql
+++ b/supabase/migrations/20251018090200_project_templates.sql
@@ -1,0 +1,46 @@
+create table if not exists public.project_templates (
+  id uuid primary key default gen_random_uuid(),
+  owner uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  description text,
+  category text,
+  manifest jsonb not null default '{}'::jsonb,
+  is_public boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.project_templates enable row level security;
+
+create policy if not exists "templates_owner_rw" on public.project_templates
+for all to authenticated
+using (owner = auth.uid())
+with check (owner = auth.uid());
+
+create policy if not exists "templates_public_read" on public.project_templates
+for select to authenticated using (is_public = true or owner = auth.uid());
+
+create index if not exists templates_owner_idx on public.project_templates(owner);
+create index if not exists templates_public_idx on public.project_templates(is_public);
+create index if not exists templates_category_idx on public.project_templates(category);
+
+with first_user as (
+  select id from auth.users limit 1
+)
+insert into public.project_templates (owner, name, description, category, manifest, is_public)
+select
+  first_user.id,
+  tmpl.name,
+  tmpl.description,
+  tmpl.category,
+  tmpl.manifest::jsonb,
+  true
+from first_user,
+  (values
+    ('Product Launch Plan', 'Track GTM tasks from kickoff to launch', 'product', '{"columns":["Backlog","In Progress","Launch"],"tasks":[{"title":"Define launch goals","column":"Backlog"},{"title":"Draft messaging","column":"In Progress"}]}'),
+    ('Marketing Campaign', 'Coordinate multi-channel marketing campaigns', 'marketing', '{"columns":["Ideas","Producing","Scheduled","Live"],"tasks":[{"title":"Audience research","column":"Ideas"},{"title":"Design creatives","column":"Producing"}]}'),
+    ('Customer Onboarding', 'Guide new customers through activation', 'success', '{"columns":["Signed","Kickoff","Adoption","Live"],"tasks":[{"title":"Schedule kickoff","column":"Kickoff"},{"title":"Configure workspace","column":"Adoption"}]}')
+  ) as tmpl(name, description, category, manifest)
+where not exists (
+  select 1 from public.project_templates
+);


### PR DESCRIPTION
## Summary
- add documentation of the existing goals and templates inventory
- add a migration for okr_cycles with row-level security
- add migrations for goals, key results, goal updates, and project templates with seed data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e42a897f7c832795342d4158e82993