### PR TITLE
feat: refresh files and integrations surfaces

### DIFF
--- a/docs/inventory/files-integrations.md
+++ b/docs/inventory/files-integrations.md
@@ -1,0 +1,40 @@
+# Files and Integrations Inventory
+
+## Files-related code
+- `src/pages/files/FilesPage.tsx`
+- `src/pages/projects/ProjectFilesPage.tsx`
+- `src/pages/ia/FilesPage.tsx`
+- `src/pages/ia/projects/ProjectFilesPage.tsx`
+- `src/services/files.ts`
+- `src/services/storage.ts`
+- `src/types/files.ts`
+- `src/components/ui/file-upload.tsx`
+
+## Integration-related code
+- `src/pages/integrations/IntegrationsPage.tsx`
+- `src/pages/projects/ProjectIntegrationsPage.tsx`
+- `src/pages/integrations/IntegrationsHome.tsx`
+- `src/pages/Integrations.tsx`
+- `src/pages/ia/IntegrationsPage.tsx`
+- `src/pages/integrations/ProjectIntegrationsPage.tsx`
+- `src/pages/ia/projects/ProjectIntegrationsPage.tsx`
+- `src/services/integrations.ts`
+- `src/services/webhooks.ts`
+- `src/services/github.ts`
+- `src/services/googleDocs.ts`
+- `src/services/googleCalendar.ts`
+- `src/types/integrations.ts`
+- `src/hooks/useIntegrations.ts`
+
+## Routes referencing these areas
+- `/files` → `FilesPage` via `src/routes.tsx`
+- `/projects/:projectId/files` → `ProjectFilesPage` via `src/routes.tsx`
+- `/integrations` → `IntegrationsPage` via `src/routes.tsx`
+- `/projects/:projectId/integrations` → `ProjectIntegrationsPage` via `src/routes.tsx`
+- Legacy routes in `src/routes.tsx`: `/integrations/google`, `/integrations/github`, `/projects/:projectId/integrations` (duplicate), `/projects/:projectId/integrations/google`, `/projects/:projectId/integrations/github`
+
+## Issues observed
+- `src/routes.tsx` declares `<IntegrationsPage />` but does not import it, and still imports deprecated IA integration pages alongside new drafts, leaving duplicate route entries.
+- Multiple historical IA pages (e.g., `src/pages/ia/FilesPage.tsx`, `src/pages/ia/IntegrationsPage.tsx`) remain as stubs while new implementations live under `src/pages/files` and `src/pages/integrations`, creating ambiguity.
+- `src/routes.tsx` retains raw `codex/...` merge markers and duplicate People/Projects imports that will break builds once the file is touched.
+- Untracked drafts (`src/pages/integrations/IntegrationsPage.tsx`, `src/pages/projects/ProjectIntegrationsPage.tsx`) diverge from the currently routed IA variants.

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -1,0 +1,163 @@
+import { useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  deleteFile as deleteFileService,
+  getSignedUrl as getFileSignedUrl,
+  listFiles,
+  renameFile as renameFileService,
+  uploadFile as uploadFileService,
+} from "@/services/files";
+import type { ProjectFile } from "@/types";
+
+const filesKey = (projectId?: string | null, search?: string | null) => [
+  "files",
+  projectId ?? "all",
+  search?.trim() ?? "",
+];
+
+type UseFilesOptions = {
+  projectId?: string;
+  search?: string;
+  enabled?: boolean;
+};
+
+type UploadFileInput = {
+  projectId: string;
+  file: File;
+};
+
+type RenameFileInput = {
+  id: string;
+  title: string;
+};
+
+export function useFiles(options: UseFilesOptions = {}) {
+  const { projectId, search, enabled = true } = options;
+  const queryClient = useQueryClient();
+  const queryKey = filesKey(projectId ?? null, search ?? null);
+
+  const listQuery = useQuery({
+    queryKey,
+    queryFn: () => listFiles({ projectId: projectId ?? undefined, q: search }),
+    enabled,
+    staleTime: 1000 * 30,
+    gcTime: 1000 * 60 * 5,
+    keepPreviousData: true,
+  });
+
+  const uploadMutation = useMutation({
+    mutationFn: ({ projectId: uploadProjectId, file }: UploadFileInput) =>
+      uploadFileService(uploadProjectId, file),
+    onMutate: async ({ file }) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<ProjectFile[]>(queryKey);
+
+      const optimistic: ProjectFile = {
+        id: `optimistic-${Date.now()}`,
+        project_id: projectId ?? "pending",
+        bucket: "files",
+        path: "pending",
+        size_bytes: file.size,
+        mime_type: file.type || null,
+        title: file.name,
+        uploaded_by: "pending",
+        created_at: new Date().toISOString(),
+      };
+
+      queryClient.setQueryData<ProjectFile[]>(queryKey, (current = []) => [optimistic, ...current]);
+
+      return { previous, optimisticId: optimistic.id };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+    },
+    onSuccess: (result, _variables, context) => {
+      queryClient.setQueryData<ProjectFile[]>(queryKey, (current = []) => {
+        if (!context?.optimisticId) {
+          return [result, ...current];
+        }
+        return [result, ...current.filter((item) => item.id !== context.optimisticId)];
+      });
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["files"] });
+    },
+  });
+
+  const renameMutation = useMutation({
+    mutationFn: ({ id, title }: RenameFileInput) => renameFileService(id, title),
+    onMutate: async ({ id, title }) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<ProjectFile[]>(queryKey);
+      queryClient.setQueryData<ProjectFile[]>(queryKey, (current = []) =>
+        current.map((item) => (item.id === id ? { ...item, title } : item))
+      );
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData<ProjectFile[]>(queryKey, (current = []) =>
+        current.map((item) => (item.id === result.id ? result : item))
+      );
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["files"] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteFileService(id),
+    onMutate: async (id: string) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<ProjectFile[]>(queryKey);
+      queryClient.setQueryData<ProjectFile[]>(queryKey, (current = []) =>
+        current.filter((item) => item.id !== id)
+      );
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["files"] });
+    },
+  });
+
+  return useMemo(
+    () => ({
+      files: listQuery.data ?? [],
+      isLoading: listQuery.isLoading,
+      isFetching: listQuery.isFetching,
+      error: listQuery.error as Error | null,
+      uploadFile: (input: UploadFileInput) => uploadMutation.mutateAsync(input),
+      renameFile: (input: RenameFileInput) => renameMutation.mutateAsync(input),
+      deleteFile: (id: string) => deleteMutation.mutateAsync(id),
+      getSignedUrl: getFileSignedUrl,
+      refetch: listQuery.refetch,
+      isUploading: uploadMutation.isPending,
+      isRenaming: renameMutation.isPending,
+      isDeleting: deleteMutation.isPending,
+    }),
+    [
+      deleteMutation.isPending,
+      deleteMutation.mutateAsync,
+      listQuery.data,
+      listQuery.error,
+      listQuery.isFetching,
+      listQuery.isLoading,
+      listQuery.refetch,
+      renameMutation.isPending,
+      renameMutation.mutateAsync,
+      uploadMutation.isPending,
+      uploadMutation.mutateAsync,
+    ]
+  );
+}

--- a/src/hooks/useIntegrations.ts
+++ b/src/hooks/useIntegrations.ts
@@ -2,104 +2,205 @@ import { useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   connectIntegration as connectIntegrationService,
+  createWebhook as createWebhookService,
+  deleteWebhook as deleteWebhookService,
   disconnectIntegration as disconnectIntegrationService,
   listIntegrations,
   listUserIntegrations,
+  listWebhooks,
   updateIntegrationConfig as updateIntegrationConfigService,
-  type IntegrationRecord,
+  updateUserIntegration as updateUserIntegrationService,
+  updateWebhook as updateWebhookService,
 } from "@/services/integrations";
-import type { IntegrationKey, UserIntegration } from "@/types";
+import type { Integration, UserIntegration, Webhook } from "@/types";
 
 const integrationsKey = ["integrations"] as const;
-const userIntegrationsKey = (projectId?: string | null) => [
-  "user-integrations",
-  projectId ?? "workspace",
-];
+const userIntegrationsKey = (projectId: string | null) => ["user-integrations", projectId ?? "workspace"] as const;
+const workspaceWebhooksKey = ["webhooks", "workspace"] as const;
+const projectWebhooksKey = (projectId: string) => ["webhooks", `project-${projectId}`] as const;
 
-type UseIntegrationsResult = {
-  integrations: IntegrationRecord[];
-  userIntegrations: UserIntegration[];
-  isLoading: boolean;
-  isRefreshing: boolean;
-  isConnecting: boolean;
-  isDisconnecting: boolean;
-  isUpdatingConfig: boolean;
-  connectIntegration: (
-    input: Parameters<typeof connectIntegrationService>[0]
-  ) => Promise<UserIntegration>;
-  disconnectIntegration: (id: string) => Promise<void>;
-  updateIntegrationConfig: (
-    key: IntegrationKey,
-    patch: any
-  ) => Promise<void>;
+type UseIntegrationsOptions = {
+  projectId?: string;
 };
 
-export function useIntegrations(projectId?: string | null): UseIntegrationsResult {
+type ConnectInput = Parameters<typeof connectIntegrationService>[0];
+type UpdateUserIntegrationInput = Parameters<typeof updateUserIntegrationService>[1];
+type CreateWebhookInput = Parameters<typeof createWebhookService>[0];
+type UpdateWebhookInput = Parameters<typeof updateWebhookService>[1];
+
+export function useIntegrations(options: UseIntegrationsOptions = {}) {
+  const projectId = options.projectId ?? null;
   const queryClient = useQueryClient();
 
   const integrationsQuery = useQuery({
     queryKey: integrationsKey,
     queryFn: listIntegrations,
-    staleTime: 1000 * 30,
+    staleTime: 1000 * 60,
   });
 
   const userIntegrationsQuery = useQuery({
-    queryKey: userIntegrationsKey(projectId ?? null),
+    queryKey: userIntegrationsKey(projectId),
     queryFn: () => listUserIntegrations({ projectId: projectId ?? undefined }),
-    staleTime: 1000 * 10,
+    staleTime: 1000 * 30,
+  });
+
+  const workspaceWebhooksQuery = useQuery({
+    queryKey: workspaceWebhooksKey,
+    queryFn: () => listWebhooks(),
+    staleTime: 1000 * 30,
+  });
+
+  const projectWebhooksQuery = useQuery({
+    queryKey: projectId ? projectWebhooksKey(projectId) : ["webhooks", "project"] ,
+    queryFn: () => (projectId ? listWebhooks(projectId) : []),
+    staleTime: 1000 * 30,
+    enabled: Boolean(projectId),
   });
 
   const connectMutation = useMutation({
-    mutationFn: connectIntegrationService,
-    onSuccess: async (_data, variables) => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: userIntegrationsKey(projectId ?? null) }),
-        queryClient.invalidateQueries({ queryKey: userIntegrationsKey(variables.projectId ?? null) }),
-      ]);
+    mutationFn: (input: ConnectInput) => connectIntegrationService(input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["user-integrations"] });
     },
   });
 
   const disconnectMutation = useMutation({
-    mutationFn: disconnectIntegrationService,
+    mutationFn: (id: string) => disconnectIntegrationService(id),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: userIntegrationsKey(projectId ?? null) });
+      await queryClient.invalidateQueries({ queryKey: ["user-integrations"] });
     },
   });
 
-  const updateConfigMutation = useMutation({
-    mutationFn: ({ key, patch }: { key: IntegrationKey; patch: any }) =>
-      updateIntegrationConfigService(key, patch),
+  const updateIntegrationMutation = useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: UpdateUserIntegrationInput }) =>
+      updateUserIntegrationService(id, patch),
+    onMutate: async ({ id, patch }) => {
+      await queryClient.cancelQueries({ queryKey: userIntegrationsKey(projectId) });
+      const previous = queryClient.getQueryData<UserIntegration[]>(userIntegrationsKey(projectId));
+      queryClient.setQueryData<UserIntegration[]>(userIntegrationsKey(projectId), (current = []) =>
+        current.map((item) => (item.id === id ? { ...item, ...patch } : item))
+      );
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(userIntegrationsKey(projectId), context.previous);
+      }
+    },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: integrationsKey });
+      await queryClient.invalidateQueries({ queryKey: ["user-integrations"] });
     },
   });
 
-  return useMemo(
-    () => ({
-      integrations: integrationsQuery.data ?? [],
-      userIntegrations: userIntegrationsQuery.data ?? [],
-      isLoading: integrationsQuery.isLoading || userIntegrationsQuery.isLoading,
-      isRefreshing: integrationsQuery.isFetching || userIntegrationsQuery.isFetching,
+  const createWebhookMutation = useMutation({
+    mutationFn: (input: CreateWebhookInput) => createWebhookService(input),
+    onSuccess: (result, variables) => {
+      const key = variables.projectId ? projectWebhooksKey(variables.projectId) : workspaceWebhooksKey;
+      queryClient.setQueryData<Webhook[]>(key, (current = []) => [result, ...current]);
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["webhooks"] });
+    },
+  });
+
+  const updateWebhookMutation = useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: UpdateWebhookInput }) => updateWebhookService(id, patch),
+    onSuccess: (result) => {
+      const scopeKey = result.project_id ? projectWebhooksKey(result.project_id) : workspaceWebhooksKey;
+      queryClient.setQueryData<Webhook[]>(scopeKey, (current = []) => current.map((item) => (item.id === result.id ? result : item)));
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["webhooks"] });
+    },
+  });
+
+  const deleteWebhookMutation = useMutation({
+    mutationFn: (id: string) => deleteWebhookService(id),
+    onSuccess: (_result, id) => {
+      queryClient.setQueryData<Webhook[]>(workspaceWebhooksKey, (current = []) => current.filter((item) => item.id !== id));
+      if (projectId) {
+        queryClient.setQueryData<Webhook[]>(projectWebhooksKey(projectId), (current = []) =>
+          current.filter((item) => item.id !== id)
+        );
+      }
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["webhooks"] });
+    },
+  });
+
+  return useMemo(() => {
+    const integrations = integrationsQuery.data ?? [];
+    const userIntegrations = userIntegrationsQuery.data ?? [];
+    const workspaceWebhooks = workspaceWebhooksQuery.data ?? [];
+    const projectWebhooks = (projectWebhooksQuery.data ?? []) as Webhook[];
+
+    const error =
+      (integrationsQuery.error as Error | undefined) ||
+      (userIntegrationsQuery.error as Error | undefined) ||
+      (workspaceWebhooksQuery.error as Error | undefined) ||
+      (projectWebhooksQuery.error as Error | undefined) ||
+      null;
+
+    const isLoading =
+      integrationsQuery.isLoading ||
+      userIntegrationsQuery.isLoading ||
+      workspaceWebhooksQuery.isLoading ||
+      projectWebhooksQuery.isLoading;
+
+    const isRefreshing =
+      integrationsQuery.isFetching ||
+      userIntegrationsQuery.isFetching ||
+      workspaceWebhooksQuery.isFetching ||
+      projectWebhooksQuery.isFetching;
+
+    return {
+      integrations: integrations as Integration[],
+      userIntegrations,
+      workspaceWebhooks,
+      projectWebhooks,
+      isLoading,
+      isRefreshing,
+      error,
+      connectIntegration: (input: ConnectInput) => connectMutation.mutateAsync(input),
+      disconnectIntegration: (id: string) => disconnectMutation.mutateAsync(id),
+      updateUserIntegration: (id: string, patch: UpdateUserIntegrationInput) =>
+        updateIntegrationMutation.mutateAsync({ id, patch }),
+      updateIntegrationConfig: (key: Integration["key"], patch: any) =>
+        updateIntegrationConfigService(key, patch),
+      createWebhook: (input: CreateWebhookInput) => createWebhookMutation.mutateAsync(input),
+      updateWebhook: (id: string, patch: UpdateWebhookInput) =>
+        updateWebhookMutation.mutateAsync({ id, patch }),
+      deleteWebhook: (id: string) => deleteWebhookMutation.mutateAsync(id),
       isConnecting: connectMutation.isPending,
       isDisconnecting: disconnectMutation.isPending,
-      isUpdatingConfig: updateConfigMutation.isPending,
-      connectIntegration: async (input) =>
-        connectMutation.mutateAsync({ ...input, projectId: input.projectId ?? projectId ?? null }),
-      disconnectIntegration: (id: string) => disconnectMutation.mutateAsync(id),
-      updateIntegrationConfig: (key, patch) =>
-        updateConfigMutation.mutateAsync({ key, patch }),
-    }),
-    [
-      connectMutation,
-      disconnectMutation,
-      integrationsQuery.data,
-      integrationsQuery.isFetching,
-      integrationsQuery.isLoading,
-      projectId,
-      updateConfigMutation,
-      userIntegrationsQuery.data,
-      userIntegrationsQuery.isFetching,
-      userIntegrationsQuery.isLoading,
-    ]
-  );
+      isUpdatingIntegration: updateIntegrationMutation.isPending,
+      isSavingWebhook: createWebhookMutation.isPending || updateWebhookMutation.isPending,
+      isDeletingWebhook: deleteWebhookMutation.isPending,
+    };
+  }, [
+    connectMutation,
+    createWebhookMutation,
+    deleteWebhookMutation,
+    disconnectMutation,
+    integrationsQuery.data,
+    integrationsQuery.error,
+    integrationsQuery.isFetching,
+    integrationsQuery.isLoading,
+    projectId,
+    projectWebhooksQuery.data,
+    projectWebhooksQuery.error,
+    projectWebhooksQuery.isFetching,
+    projectWebhooksQuery.isLoading,
+    updateIntegrationMutation,
+    updateWebhookMutation,
+    userIntegrationsQuery.data,
+    userIntegrationsQuery.error,
+    userIntegrationsQuery.isFetching,
+    userIntegrationsQuery.isLoading,
+    workspaceWebhooksQuery.data,
+    workspaceWebhooksQuery.error,
+    workspaceWebhooksQuery.isFetching,
+    workspaceWebhooksQuery.isLoading,
+  ]);
 }

--- a/src/lib/navConfig.tsx
+++ b/src/lib/navConfig.tsx
@@ -139,6 +139,7 @@ export const NAV: NavItem[] = [
     path: "/files",
     icon: <Files className="h-5 w-5" aria-hidden="true" />,
     roles: ALL_ROLES,
+    matchPaths: ["/projects/:projectId/files"],
   },
   {
     id: "automations",
@@ -155,6 +156,7 @@ export const NAV: NavItem[] = [
     icon: <Share2 className="h-5 w-5" aria-hidden="true" />,
     roles: LEADERSHIP_ROLES,
     featureFlag: "integrations",
+    matchPaths: ["/projects/:projectId/integrations"],
   },
   {
     id: "forms",

--- a/src/pages/files/FilesPage.tsx
+++ b/src/pages/files/FilesPage.tsx
@@ -1,0 +1,739 @@
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/alert";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+} from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Progress } from "@/components/ui/progress";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { useFiles } from "@/hooks/useFiles";
+import { useToast } from "@/hooks/use-toast";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { supabase } from "@/integrations/supabase/client";
+import { mapSupabaseError } from "@/services/utils";
+import type { ProjectFile } from "@/types";
+import {
+  Download,
+  File as FileIcon,
+  FileArchive,
+  FileAudio,
+  FileSpreadsheet,
+  FileText,
+  FileVideo,
+  ImageIcon,
+  Link as LinkIcon,
+  MoreVertical,
+  Pencil,
+  Search,
+  Trash2,
+  Upload,
+} from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+
+const BLOCKED_TYPES = new Set([
+  "application/x-msdownload",
+  "application/x-msdos-program",
+]);
+
+const MAX_FILE_SIZE_MB = 50;
+
+const formatFileSize = (bytes: number) => {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB", "TB"] as const;
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const size = bytes / 1024 ** exponent;
+  return `${size.toFixed(size >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+};
+
+const getDisplayName = (file: ProjectFile) => {
+  if (file.title && file.title.trim().length > 0) {
+    return file.title.trim();
+  }
+  const pathPart = file.path.split("/").pop();
+  return pathPart || "Untitled";
+};
+
+const getIconForMime = (mime?: string | null) => {
+  if (!mime) {
+    return FileIcon;
+  }
+  if (mime.startsWith("image/")) return ImageIcon;
+  if (mime.startsWith("video/")) return FileVideo;
+  if (mime.startsWith("audio/")) return FileAudio;
+  if (mime.includes("zip") || mime.includes("compressed")) return FileArchive;
+  if (mime.includes("spreadsheet") || mime.includes("excel")) return FileSpreadsheet;
+  if (mime.includes("pdf")) return FileText;
+  if (mime.startsWith("text/")) return FileText;
+  return FileIcon;
+};
+
+const getFileExtension = (file: ProjectFile) => {
+  const name = getDisplayName(file);
+  const ext = name.includes(".") ? name.split(".").pop() : null;
+  return ext ? ext.toUpperCase() : "";
+};
+
+type ProjectOption = { id: string; name: string | null };
+
+type UploadJob = {
+  id: string;
+  name: string;
+  progress: number;
+  status: "uploading" | "success" | "error";
+  message?: string;
+};
+
+type FilesTableProps = {
+  files: ProjectFile[];
+  isLoading: boolean;
+  isFetching: boolean;
+  error: Error | null;
+  onRetry: () => void;
+  onPreview: (file: ProjectFile) => void;
+  onDownload: (file: ProjectFile) => void;
+  onCopyLink: (file: ProjectFile) => void;
+  onRename: (file: ProjectFile, name: string) => Promise<void>;
+  onDelete: (file: ProjectFile) => Promise<void>;
+  renamingId?: string | null;
+  deletingId?: string | null;
+  emptyHint?: string;
+};
+
+type PreviewState = {
+  file: ProjectFile;
+  url: string;
+};
+
+const ProjectsQueryKey = ["files", "projects"] as const;
+
+async function fetchProjects(): Promise<ProjectOption[]> {
+  const { data, error } = await supabase
+    .from("projects")
+    .select("id, name")
+    .order("name", { ascending: true });
+
+  if (error) {
+    throw mapSupabaseError(error, "Unable to load projects.");
+  }
+
+  return (data ?? []) as ProjectOption[];
+}
+
+function useProjectOptions(enabled: boolean) {
+  return useQuery({
+    queryKey: ProjectsQueryKey,
+    queryFn: fetchProjects,
+    enabled,
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+export default function FilesPage() {
+  useDocumentTitle("Files");
+  const { toast } = useToast();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const deferredSearch = useDeferredValue(search);
+  const [uploadJobs, setUploadJobs] = useState<UploadJob[]>([]);
+  const [preview, setPreview] = useState<PreviewState | null>(null);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const {
+    data: projects,
+    isLoading: projectsLoading,
+    error: projectsError,
+  } = useProjectOptions(true);
+
+  useEffect(() => {
+    if (projectsError) {
+      const message = projectsError instanceof Error ? projectsError.message : "Unable to load projects.";
+      toast({
+        title: "Projects unavailable",
+        description: message,
+        variant: "destructive",
+      });
+    }
+  }, [projectsError, toast]);
+
+  const {
+    files,
+    isLoading,
+    isFetching,
+    error,
+    uploadFile,
+    renameFile,
+    deleteFile,
+    getSignedUrl,
+    refetch,
+  } = useFiles({ projectId: selectedProjectId ?? undefined, search: deferredSearch });
+
+  const handleUploadClick = () => {
+    if (!selectedProjectId) {
+      toast({
+        title: "Choose a project",
+        description: "Select a project before uploading.",
+      });
+      return;
+    }
+    fileInputRef.current?.click();
+  };
+
+  const updateJob = (id: string, patch: Partial<UploadJob>) => {
+    setUploadJobs((jobs) => jobs.map((job) => (job.id === id ? { ...job, ...patch } : job)));
+  };
+
+  const removeJob = (id: string) => {
+    setUploadJobs((jobs) => jobs.filter((job) => job.id !== id));
+  };
+
+  const handleFileSelection = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const list = event.target.files;
+    if (!list || list.length === 0) {
+      return;
+    }
+    if (!selectedProjectId) {
+      toast({
+        title: "Choose a project",
+        description: "Select a project before uploading.",
+      });
+      event.target.value = "";
+      return;
+    }
+
+    const filesArray = Array.from(list);
+    for (const file of filesArray) {
+      if (file.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
+        toast({
+          title: "File too large",
+          description: `${file.name} exceeds ${MAX_FILE_SIZE_MB} MB.`,
+          variant: "destructive",
+        });
+        continue;
+      }
+
+      if (file.type && BLOCKED_TYPES.has(file.type)) {
+        toast({
+          title: "Blocked file type",
+          description: `${file.name} cannot be uploaded.`,
+          variant: "destructive",
+        });
+        continue;
+      }
+
+      const jobId = `job-${Date.now()}-${file.name}`;
+      setUploadJobs((jobs) => [
+        ...jobs,
+        {
+          id: jobId,
+          name: file.name,
+          progress: 10,
+          status: "uploading",
+        },
+      ]);
+
+      let progressTimer: number | undefined;
+      try {
+        progressTimer = window.setInterval(() => {
+          setUploadJobs((jobs) =>
+            jobs.map((job) =>
+              job.id === jobId
+                ? { ...job, progress: Math.min(job.progress + 15, 85) }
+                : job
+            )
+          );
+        }, 400);
+
+        await uploadFile({ projectId: selectedProjectId, file });
+
+        if (progressTimer) {
+          window.clearInterval(progressTimer);
+        }
+
+        updateJob(jobId, { progress: 100, status: "success" });
+        toast({ title: "Uploaded", description: `${file.name} is ready.` });
+        setTimeout(() => removeJob(jobId), 1500);
+      } catch (err: any) {
+        if (progressTimer) {
+          window.clearInterval(progressTimer);
+        }
+        const message = err?.message ?? "Upload failed.";
+        updateJob(jobId, { status: "error", message });
+        toast({ title: "Upload failed", description: message, variant: "destructive" });
+      }
+    }
+
+    event.target.value = "";
+  };
+
+  const openPreview = async (file: ProjectFile, openInNewTab = false) => {
+    try {
+      const url = await getSignedUrl(file, 120);
+      if (openInNewTab || !(file.mime_type || "").startsWith("image/")) {
+        window.open(url, "_blank", "noopener,noreferrer");
+        return;
+      }
+      setPreview({ file, url });
+    } catch (err: any) {
+      toast({
+        title: "Preview unavailable",
+        description: err?.message ?? "Unable to open the file.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleCopyLink = async (file: ProjectFile) => {
+    try {
+      const url = await getSignedUrl(file, 300);
+      await navigator.clipboard.writeText(url);
+      toast({ title: "Link copied", description: "Signed link copied to clipboard." });
+    } catch (err: any) {
+      toast({
+        title: "Copy failed",
+        description: err?.message ?? "Unable to copy link.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleRename = async (file: ProjectFile, name: string) => {
+    setRenamingId(file.id);
+    try {
+      await renameFile({ id: file.id, title: name });
+      toast({ title: "Renamed", description: "Name updated." });
+    } catch (err: any) {
+      toast({
+        title: "Rename failed",
+        description: err?.message ?? "Unable to rename file.",
+        variant: "destructive",
+      });
+      throw err;
+    } finally {
+      setRenamingId(null);
+    }
+  };
+
+  const handleDelete = async (file: ProjectFile) => {
+    if (!window.confirm(`Delete ${getDisplayName(file)}?`)) {
+      return;
+    }
+    setDeletingId(file.id);
+    try {
+      await deleteFile(file.id);
+      toast({ title: "Deleted", description: "File removed." });
+    } catch (err: any) {
+      toast({
+        title: "Delete failed",
+        description: err?.message ?? "Unable to delete file.",
+        variant: "destructive",
+      });
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const breadcrumbs = (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbPage>Files</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-2">
+          {breadcrumbs}
+          <h1 className="text-3xl font-semibold tracking-tight">Files</h1>
+          <p className="text-sm text-muted-foreground">
+            Browse every file you can access across projects.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex items-center gap-2">
+            <div className="relative">
+              <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search files"
+                className="w-[220px] pl-8"
+                aria-label="Search files"
+              />
+            </div>
+            <Select
+              value={selectedProjectId ?? "all"}
+              onValueChange={(value) =>
+                setSelectedProjectId(value === "all" ? null : value)
+              }
+            >
+              <SelectTrigger className="w-[220px]">
+                <SelectValue placeholder="All projects" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All projects</SelectItem>
+                {projects?.map((project) => (
+                  <SelectItem key={project.id} value={project.id}>
+                    {project.name ?? project.id}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Button onClick={handleUploadClick} disabled={projectsLoading}>
+            <Upload className="mr-2 h-4 w-4" /> Upload
+          </Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            className="sr-only"
+            onChange={handleFileSelection}
+            multiple
+          />
+        </div>
+      </div>
+
+      {uploadJobs.length > 0 ? (
+        <div className="space-y-2 rounded-lg border bg-muted/30 p-4">
+          <p className="text-sm font-medium text-muted-foreground">Active uploads</p>
+          <div className="space-y-3">
+            {uploadJobs.map((job) => (
+              <div key={job.id} className="space-y-1">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="font-medium truncate" title={job.name}>
+                    {job.name}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {job.status === "uploading"
+                      ? `${job.progress}%`
+                      : job.status === "success"
+                        ? "Completed"
+                        : job.message ?? "Failed"}
+                  </span>
+                </div>
+                <Progress
+                  value={job.status === "error" ? 100 : job.progress}
+                  className={job.status === "error" ? "bg-destructive/20" : undefined}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <FilesTable
+        files={files}
+        isLoading={isLoading}
+        isFetching={isFetching}
+        error={error}
+        onRetry={() => refetch()}
+        onPreview={(file) => openPreview(file)}
+        onDownload={(file) => openPreview(file, true)}
+        onCopyLink={handleCopyLink}
+        onRename={handleRename}
+        onDelete={handleDelete}
+        renamingId={renamingId}
+        deletingId={deletingId}
+        emptyHint={selectedProjectId ? "Upload your first file for this project." : "Select a project to start uploading."}
+      />
+
+      <Drawer open={Boolean(preview)} onOpenChange={(open) => !open && setPreview(null)}>
+        <DrawerContent className="h-[80vh]">
+          <DrawerHeader>
+            <DrawerTitle>{preview ? getDisplayName(preview.file) : "Preview"}</DrawerTitle>
+            <DrawerDescription>
+              {preview ? preview.file.mime_type ?? "Unknown type" : ""}
+            </DrawerDescription>
+          </DrawerHeader>
+          <ScrollArea className="flex-1 px-6 pb-6">
+            {preview ? (
+              <img
+                src={preview.url}
+                alt={getDisplayName(preview.file)}
+                className="mx-auto max-h-full rounded-lg shadow"
+              />
+            ) : null}
+          </ScrollArea>
+          <DrawerFooter className="flex items-center justify-end gap-2">
+            {preview ? (
+              <Button variant="outline" onClick={() => openPreview(preview.file, true)}>
+                <Download className="mr-2 h-4 w-4" /> Download
+              </Button>
+            ) : null}
+            <DrawerClose asChild>
+              <Button variant="secondary">Close</Button>
+            </DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  );
+}
+
+function FilesTable({
+  files,
+  isLoading,
+  isFetching,
+  error,
+  onRetry,
+  onPreview,
+  onDownload,
+  onCopyLink,
+  onRename,
+  onDelete,
+  renamingId,
+  deletingId,
+  emptyHint,
+}: FilesTableProps) {
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>Unable to load files</AlertTitle>
+        <AlertDescription className="flex items-center justify-between gap-4">
+          <span>{error.message}</span>
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            Retry
+          </Button>
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3 rounded-lg border bg-background p-6 shadow-sm">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <div key={index} className="grid grid-cols-6 items-center gap-4">
+            <Skeleton className="h-5 w-full col-span-2" />
+            <Skeleton className="h-5 w-full" />
+            <Skeleton className="h-5 w-full" />
+            <Skeleton className="h-5 w-full" />
+            <Skeleton className="h-8 w-12 justify-self-end" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (files.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 rounded-lg border bg-background p-12 text-center shadow-sm">
+        <FileText className="h-10 w-10 text-muted-foreground" />
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold">No files yet</h2>
+          <p className="text-sm text-muted-foreground">{emptyHint ?? "Upload your first file."}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border bg-background shadow-sm">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[30%]">Name</TableHead>
+            <TableHead>Size</TableHead>
+            <TableHead>Type</TableHead>
+            <TableHead>Uploaded</TableHead>
+            <TableHead>Uploader</TableHead>
+            <TableHead className="w-[80px] text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {files.map((file) => (
+            <FileRow
+              key={file.id}
+              file={file}
+              onPreview={onPreview}
+              onDownload={onDownload}
+              onCopyLink={onCopyLink}
+              onRename={onRename}
+              onDelete={onDelete}
+              isRenaming={renamingId === file.id}
+              isDeleting={deletingId === file.id}
+            />
+          ))}
+        </TableBody>
+      </Table>
+      {isFetching ? (
+        <div className="border-t bg-muted/40 p-2 text-center text-xs text-muted-foreground">
+          Updating…
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+type FileRowProps = {
+  file: ProjectFile;
+  onPreview: (file: ProjectFile) => void;
+  onDownload: (file: ProjectFile) => void;
+  onCopyLink: (file: ProjectFile) => void;
+  onRename: (file: ProjectFile, name: string) => Promise<void>;
+  onDelete: (file: ProjectFile) => Promise<void>;
+  isRenaming: boolean;
+  isDeleting: boolean;
+};
+
+function FileRow({
+  file,
+  onPreview,
+  onDownload,
+  onCopyLink,
+  onRename,
+  onDelete,
+  isRenaming,
+  isDeleting,
+}: FileRowProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(getDisplayName(file));
+  const Icon = useMemo(() => getIconForMime(file.mime_type), [file.mime_type]);
+
+  const handleRename = async () => {
+    if (!isEditing) {
+      setIsEditing(true);
+      return;
+    }
+    if (draft.trim().length === 0) {
+      setDraft(getDisplayName(file));
+      setIsEditing(false);
+      return;
+    }
+    await onRename(file, draft.trim());
+    setIsEditing(false);
+  };
+
+  return (
+    <TableRow>
+      <TableCell>
+        <div className="flex items-center gap-3">
+          <Icon className="h-5 w-5 text-muted-foreground" />
+          <div className="min-w-0 flex-1">
+            {isEditing ? (
+              <Input
+                value={draft}
+                onChange={(event) => setDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    void handleRename();
+                  }
+                  if (event.key === "Escape") {
+                    setIsEditing(false);
+                    setDraft(getDisplayName(file));
+                  }
+                }}
+                autoFocus
+              />
+            ) : (
+              <div className="truncate font-medium" title={getDisplayName(file)}>
+                {getDisplayName(file)}
+              </div>
+            )}
+            <p className="text-xs text-muted-foreground">{file.path}</p>
+          </div>
+        </div>
+      </TableCell>
+      <TableCell>{formatFileSize(file.size_bytes)}</TableCell>
+      <TableCell>
+        <div className="flex flex-col">
+          <span>{file.mime_type ?? "Unknown"}</span>
+          {getFileExtension(file) ? (
+            <span className="text-xs text-muted-foreground">{getFileExtension(file)}</span>
+          ) : null}
+        </div>
+      </TableCell>
+      <TableCell>
+        {file.created_at
+          ? formatDistanceToNow(new Date(file.created_at), { addSuffix: true })
+          : "—"}
+      </TableCell>
+      <TableCell className="truncate" title={file.uploaded_by}>
+        {file.uploaded_by?.slice(0, 8) ?? "—"}
+      </TableCell>
+      <TableCell className="text-right">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <MoreVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-40">
+            <DropdownMenuItem onSelect={() => onPreview(file)} className="gap-2">
+              <FileText className="h-4 w-4" /> Preview
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onDownload(file)} className="gap-2">
+              <Download className="h-4 w-4" /> Download
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onCopyLink(file)} className="gap-2">
+              <LinkIcon className="h-4 w-4" /> Copy link
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => void handleRename()}
+              className="gap-2"
+              disabled={isRenaming}
+            >
+              <Pencil className="h-4 w-4" /> {isEditing ? "Save" : "Rename"}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => onDelete(file)}
+              className="gap-2 text-destructive"
+              disabled={isDeleting}
+            >
+              <Trash2 className="h-4 w-4" /> Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export { FilesTable };

--- a/src/pages/integrations/IntegrationsPage.tsx
+++ b/src/pages/integrations/IntegrationsPage.tsx
@@ -1,0 +1,689 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+} from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { useIntegrations } from "@/hooks/useIntegrations";
+import { useToast } from "@/hooks/use-toast";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import type { Webhook } from "@/types";
+import {
+  CheckCircle2,
+  Download,
+  Eye,
+  EyeOff,
+  GitBranch,
+  Github,
+  Globe,
+  Link as LinkIcon,
+  Loader2,
+  Network,
+  RefreshCw,
+  Slack,
+  Trash2,
+  Upload,
+  Workflow,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export default function IntegrationsPage() {
+  useDocumentTitle("Integrations");
+  const { toast } = useToast();
+  const {
+    userIntegrations,
+    workspaceWebhooks,
+    isLoading,
+    isRefreshing,
+    error,
+    connectIntegration,
+    disconnectIntegration,
+    updateUserIntegration,
+    createWebhook,
+    updateWebhook,
+    deleteWebhook,
+    isConnecting,
+    isDisconnecting,
+    isUpdatingIntegration,
+    isSavingWebhook,
+    isDeletingWebhook,
+  } = useIntegrations();
+
+  const slackConnection = useMemo(
+    () => userIntegrations.find((item) => item.provider === "slack" && !item.project_id) ?? null,
+    [userIntegrations]
+  );
+  const githubConnection = useMemo(
+    () => userIntegrations.find((item) => item.provider === "github" && !item.project_id) ?? null,
+    [userIntegrations]
+  );
+  const driveConnection = useMemo(
+    () => userIntegrations.find((item) => item.provider === "google_drive" && !item.project_id) ?? null,
+    [userIntegrations]
+  );
+
+  const [slackChannel, setSlackChannel] = useState("");
+  const [githubRepo, setGithubRepo] = useState("");
+  const [githubEvents, setGithubEvents] = useState({ issues: true, pull_requests: true });
+  const [driveFolder, setDriveFolder] = useState("");
+
+  useEffect(() => {
+    setSlackChannel(
+      slackConnection?.display_name || slackConnection?.access_data?.channel || ""
+    );
+  }, [slackConnection?.display_name, slackConnection?.access_data]);
+
+  useEffect(() => {
+    setGithubRepo(githubConnection?.access_data?.repo || "");
+    setGithubEvents({
+      issues: githubConnection?.access_data?.events?.includes("issues") ?? true,
+      pull_requests: githubConnection?.access_data?.events?.includes("pull_requests") ?? true,
+    });
+  }, [githubConnection?.access_data]);
+
+  useEffect(() => {
+    setDriveFolder(driveConnection?.access_data?.folder_id || "");
+  }, [driveConnection?.access_data]);
+
+  const [newWebhookUrl, setNewWebhookUrl] = useState("");
+  const [newWebhookSecret, setNewWebhookSecret] = useState("");
+  const [visibleSecrets, setVisibleSecrets] = useState<Record<string, boolean>>({});
+
+  const toggleSecretVisibility = (id: string) => {
+    setVisibleSecrets((current) => ({ ...current, [id]: !current[id] }));
+  };
+
+  const handleSlackSave = async () => {
+    if (!slackChannel.trim()) {
+      toast({ title: "Channel required", description: "Enter a Slack channel.", variant: "destructive" });
+      return;
+    }
+
+    try {
+      if (slackConnection) {
+        await updateUserIntegration(slackConnection.id, {
+          display_name: slackChannel.trim(),
+          access_data: { channel: slackChannel.trim() },
+        });
+        toast({ title: "Slack updated", description: "Default channel saved." });
+      } else {
+        await connectIntegration({
+          provider: "slack",
+          displayName: slackChannel.trim(),
+          accessData: { channel: slackChannel.trim() },
+        });
+        toast({ title: "Slack connected", description: "Workspace notifications are ready." });
+      }
+    } catch (err: any) {
+      toast({
+        title: "Slack error",
+        description: err?.message ?? "Unable to update Slack settings.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleSlackTest = () => {
+    console.info("TODO: Send Slack test notification to", slackChannel);
+    toast({ title: "Test sent", description: "Slack test queued in console." });
+  };
+
+  const handleGithubSave = async () => {
+    if (!/^[^/\s]+\/[^/\s]+$/.test(githubRepo.trim())) {
+      toast({
+        title: "Invalid repository",
+        description: "Use the owner/name format.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      if (githubConnection) {
+        await updateUserIntegration(githubConnection.id, {
+          access_data: {
+            repo: githubRepo.trim(),
+            events: [
+              ...(githubEvents.issues ? ["issues"] : []),
+              ...(githubEvents.pull_requests ? ["pull_requests"] : []),
+            ],
+          },
+        });
+        toast({ title: "GitHub updated", description: "Subscription saved." });
+      } else {
+        await connectIntegration({
+          provider: "github",
+          accessData: {
+            repo: githubRepo.trim(),
+            events: [
+              ...(githubEvents.issues ? ["issues"] : []),
+              ...(githubEvents.pull_requests ? ["pull_requests"] : []),
+            ],
+          },
+        });
+        toast({ title: "GitHub connected", description: "Repository linked." });
+      }
+    } catch (err: any) {
+      toast({
+        title: "GitHub error",
+        description: err?.message ?? "Unable to update GitHub settings.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleGithubTest = () => {
+    console.info("TODO: Trigger GitHub test sync for", githubRepo, githubEvents);
+    toast({ title: "Test triggered", description: "GitHub test logged to console." });
+  };
+
+  const handleDriveSave = async () => {
+    if (!driveFolder.trim()) {
+      toast({ title: "Folder required", description: "Enter a Google Drive folder ID.", variant: "destructive" });
+      return;
+    }
+
+    try {
+      if (driveConnection) {
+        await updateUserIntegration(driveConnection.id, {
+          access_data: { folder_id: driveFolder.trim() },
+        });
+        toast({ title: "Google Drive updated", description: "Default folder saved." });
+      } else {
+        await connectIntegration({
+          provider: "google_drive",
+          accessData: { folder_id: driveFolder.trim() },
+        });
+        toast({ title: "Google Drive connected", description: "Folder linked." });
+      }
+    } catch (err: any) {
+      toast({
+        title: "Google Drive error",
+        description: err?.message ?? "Unable to update Google Drive settings.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleDriveTest = () => {
+    console.info("TODO: Fetch Google Drive folder preview for", driveFolder);
+    toast({ title: "Test scheduled", description: "Drive test logged to console." });
+  };
+
+  const handleWebhookCreate = async () => {
+    if (!newWebhookUrl.trim()) {
+      toast({ title: "URL required", description: "Enter a target URL.", variant: "destructive" });
+      return;
+    }
+
+    try {
+      await createWebhook({ targetUrl: newWebhookUrl.trim(), secret: newWebhookSecret.trim() });
+      setNewWebhookUrl("");
+      setNewWebhookSecret("");
+      toast({ title: "Webhook created", description: "We will start sending events soon." });
+    } catch (err: any) {
+      toast({ title: "Webhook error", description: err?.message ?? "Unable to create webhook.", variant: "destructive" });
+    }
+  };
+
+  const loadingPlaceholder = (
+    <div className="grid gap-6 lg:grid-cols-2">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <Card key={index} className="border-dashed">
+          <CardHeader>
+            <Skeleton className="h-5 w-36" />
+            <Skeleton className="h-4 w-56" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-9 w-24" />
+          </CardContent>
+        </Card>
+      ))}
+      <Card className="lg:col-span-2 border-dashed">
+        <CardHeader>
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-72" />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-20 w-full" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-2">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbPage>Integrations</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight">Integrations</h1>
+            <p className="text-sm text-muted-foreground">
+              Connect Slack, GitHub, Google Drive, and webhooks to automate your workspace.
+            </p>
+          </div>
+        </div>
+        {isRefreshing ? (
+          <span className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" /> Syncing
+          </span>
+        ) : null}
+      </div>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Access limited</AlertTitle>
+          <AlertDescription>
+            {error.message.includes("access")
+              ? "You do not have permission to manage integrations."
+              : error.message}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {isLoading ? (
+        loadingPlaceholder
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-2">
+          <Card>
+            <CardHeader className="space-y-1">
+              <div className="flex items-center gap-2">
+                <Slack className="h-5 w-5 text-primary" />
+                <CardTitle>Slack</CardTitle>
+              </div>
+              <CardDescription>
+                Post task updates to a default channel. TODO: replace with Slack App OAuth.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="slack-channel">Default channel</Label>
+                <Input
+                  id="slack-channel"
+                  placeholder="#launch-announcements"
+                  value={slackChannel}
+                  onChange={(event) => setSlackChannel(event.target.value)}
+                  disabled={isConnecting || isDisconnecting || isUpdatingIntegration}
+                />
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button onClick={handleSlackSave} disabled={isConnecting || isUpdatingIntegration}>
+                  <Upload className="mr-2 h-4 w-4" />
+                  {slackConnection ? "Save" : "Connect"}
+                </Button>
+                {slackConnection ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => disconnectIntegration(slackConnection.id)}
+                    disabled={isDisconnecting}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" /> Disconnect
+                  </Button>
+                ) : null}
+                <Button type="button" variant="secondary" onClick={handleSlackTest}>
+                  <RefreshCw className="mr-2 h-4 w-4" /> Test message
+                </Button>
+              </div>
+              <IntegrationStatus connected={Boolean(slackConnection)} />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="space-y-1">
+              <div className="flex items-center gap-2">
+                <Github className="h-5 w-5 text-primary" />
+                <CardTitle>GitHub</CardTitle>
+              </div>
+              <CardDescription>
+                Link a repository to sync pull requests and issues. TODO: GitHub App install flow.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="github-repo">Repository (owner/name)</Label>
+                <Input
+                  id="github-repo"
+                  placeholder="outpaged/product"
+                  value={githubRepo}
+                  onChange={(event) => setGithubRepo(event.target.value)}
+                  disabled={isConnecting || isUpdatingIntegration}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Events</Label>
+                <div className="flex items-center gap-3 text-sm">
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      id="github-issues"
+                      checked={githubEvents.issues}
+                      onCheckedChange={(checked) =>
+                        setGithubEvents((state) => ({ ...state, issues: checked }))
+                      }
+                    />
+                    <Label htmlFor="github-issues" className="font-normal">
+                      Issues
+                    </Label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      id="github-prs"
+                      checked={githubEvents.pull_requests}
+                      onCheckedChange={(checked) =>
+                        setGithubEvents((state) => ({ ...state, pull_requests: checked }))
+                      }
+                    />
+                    <Label htmlFor="github-prs" className="font-normal">
+                      Pull requests
+                    </Label>
+                  </div>
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button onClick={handleGithubSave} disabled={isConnecting || isUpdatingIntegration}>
+                  <GitBranch className="mr-2 h-4 w-4" />
+                  {githubConnection ? "Save" : "Connect"}
+                </Button>
+                {githubConnection ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => disconnectIntegration(githubConnection.id)}
+                    disabled={isDisconnecting}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" /> Disconnect
+                  </Button>
+                ) : null}
+                <Button type="button" variant="secondary" onClick={handleGithubTest}>
+                  <RefreshCw className="mr-2 h-4 w-4" /> Test sync
+                </Button>
+              </div>
+              <IntegrationStatus connected={Boolean(githubConnection)} />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="space-y-1">
+              <div className="flex items-center gap-2">
+                <Network className="h-5 w-5 text-primary" />
+                <CardTitle>Google Drive</CardTitle>
+              </div>
+              <CardDescription>
+                Attach documents from Drive. TODO: real OAuth with Drive scopes.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="drive-folder">Shared folder ID</Label>
+                <Input
+                  id="drive-folder"
+                  placeholder="0BxxExampleId"
+                  value={driveFolder}
+                  onChange={(event) => setDriveFolder(event.target.value)}
+                  disabled={isConnecting || isUpdatingIntegration}
+                />
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button onClick={handleDriveSave} disabled={isConnecting || isUpdatingIntegration}>
+                  <Upload className="mr-2 h-4 w-4" />
+                  {driveConnection ? "Save" : "Connect"}
+                </Button>
+                {driveConnection ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => disconnectIntegration(driveConnection.id)}
+                    disabled={isDisconnecting}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" /> Disconnect
+                  </Button>
+                ) : null}
+                <Button type="button" variant="secondary" onClick={handleDriveTest}>
+                  <RefreshCw className="mr-2 h-4 w-4" /> Test fetch
+                </Button>
+              </div>
+              <IntegrationStatus connected={Boolean(driveConnection)} />
+            </CardContent>
+          </Card>
+
+          <Card className="lg:col-span-2">
+            <CardHeader className="space-y-1">
+              <div className="flex items-center gap-2">
+                <LinkIcon className="h-5 w-5 text-primary" />
+                <CardTitle>Webhooks</CardTitle>
+              </div>
+              <CardDescription>
+                Trigger outbound HTTP requests when work changes. TODO: background delivery + retries.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-5">
+              <div className="grid gap-3 sm:grid-cols-[2fr_1fr_auto]">
+                <Input
+                  placeholder="https://example.com/webhooks/outpaged"
+                  value={newWebhookUrl}
+                  onChange={(event) => setNewWebhookUrl(event.target.value)}
+                  disabled={isSavingWebhook}
+                />
+                <Input
+                  placeholder="Optional secret"
+                  value={newWebhookSecret}
+                  onChange={(event) => setNewWebhookSecret(event.target.value)}
+                  disabled={isSavingWebhook}
+                />
+                <Button onClick={handleWebhookCreate} disabled={isSavingWebhook}>
+                  <Upload className="mr-2 h-4 w-4" /> Create
+                </Button>
+              </div>
+              <Separator />
+              <div className="space-y-3">
+                {workspaceWebhooks.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    No webhooks yet. Create one to stream updates to your systems.
+                  </p>
+                ) : (
+                  workspaceWebhooks.map((webhook) => (
+                    <WebhookRow
+                      key={webhook.id}
+                      webhook={webhook}
+                      onSave={(patch) => updateWebhook(webhook.id, patch)}
+                      onDelete={() => deleteWebhook(webhook.id)}
+                      onToggleSecret={() => toggleSecretVisibility(webhook.id)}
+                      secretVisible={Boolean(visibleSecrets[webhook.id])}
+                      isUpdating={isSavingWebhook}
+                      isDeleting={isDeletingWebhook}
+                    />
+                  ))
+                )}
+                <p className="text-xs text-muted-foreground">
+                  Recent pings will appear here once the delivery queue is wired up.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}
+
+type IntegrationStatusProps = {
+  connected: boolean;
+};
+
+export function IntegrationStatus({ connected }: IntegrationStatusProps) {
+  return (
+    <div className={cn("inline-flex items-center gap-2 rounded-full px-3 py-1 text-sm", connected ? "bg-emerald-50 text-emerald-700" : "bg-muted text-muted-foreground") }>
+      {connected ? <CheckCircle2 className="h-4 w-4" /> : <Workflow className="h-4 w-4" />}
+      {connected ? "Connected" : "Not connected"}
+    </div>
+  );
+}
+
+export type WebhookRowProps = {
+  webhook: Webhook;
+  onSave: (patch: Partial<Pick<Webhook, "target_url" | "secret" | "active">>) => Promise<any>;
+  onDelete: () => Promise<any>;
+  onToggleSecret: () => void;
+  secretVisible: boolean;
+  isUpdating: boolean;
+  isDeleting: boolean;
+};
+
+export function WebhookRow({
+  webhook,
+  onSave,
+  onDelete,
+  onToggleSecret,
+  secretVisible,
+  isUpdating,
+  isDeleting,
+}: WebhookRowProps) {
+  const { toast } = useToast();
+  const [url, setUrl] = useState(webhook.target_url);
+  const [secret, setSecret] = useState(webhook.secret ?? "");
+  const [active, setActive] = useState(webhook.active);
+  const [isDirty, setDirty] = useState(false);
+
+  const isProjectScoped = Boolean(webhook.project_id);
+  const scopeLabel = isProjectScoped ? "Project" : "Workspace";
+  const ScopeIcon = isProjectScoped ? Workflow : Globe;
+
+  useEffect(() => {
+    setUrl(webhook.target_url);
+    setSecret(webhook.secret ?? "");
+    setActive(webhook.active);
+    setDirty(false);
+  }, [webhook.target_url, webhook.secret, webhook.active]);
+
+  const handleSave = async () => {
+    try {
+      await onSave({ target_url: url, secret, active });
+      toast({ title: "Webhook updated", description: "Changes saved." });
+      setDirty(false);
+    } catch (err: any) {
+      toast({ title: "Webhook error", description: err?.message ?? "Unable to update webhook.", variant: "destructive" });
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm("Delete this webhook?")) {
+      return;
+    }
+    try {
+      await onDelete();
+      toast({ title: "Webhook deleted", description: "Delivery disabled." });
+    } catch (err: any) {
+      toast({ title: "Webhook error", description: err?.message ?? "Unable to delete webhook.", variant: "destructive" });
+    }
+  };
+
+  return (
+    <div className="rounded-lg border p-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="flex-1 space-y-2">
+          <Label htmlFor={`webhook-url-${webhook.id}`} className="text-xs uppercase text-muted-foreground">
+            Target URL
+          </Label>
+          <Input
+            id={`webhook-url-${webhook.id}`}
+            value={url}
+            onChange={(event) => {
+              setUrl(event.target.value);
+              setDirty(true);
+            }}
+            disabled={isUpdating}
+          />
+          <div className="grid gap-2 sm:grid-cols-[1fr_auto_auto] sm:items-center">
+            <div className="space-y-1">
+              <Label htmlFor={`webhook-secret-${webhook.id}`} className="text-xs uppercase text-muted-foreground">
+                Secret
+              </Label>
+              <Input
+                id={`webhook-secret-${webhook.id}`}
+                value={secretVisible ? secret : secret ? "•".repeat(Math.min(secret.length, 12)) : ""}
+                onChange={(event) => {
+                  setSecret(event.target.value);
+                  setDirty(true);
+                }}
+                disabled={isUpdating}
+                type={secretVisible ? "text" : "password"}
+                placeholder="Optional"
+              />
+            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              className="mt-6"
+              onClick={onToggleSecret}
+            >
+              {secretVisible ? (
+                <>
+                  <EyeOff className="mr-2 h-4 w-4" /> Hide
+                </>
+              ) : (
+                <>
+                  <Eye className="mr-2 h-4 w-4" /> Show
+                </>
+              )}
+            </Button>
+            <div className="mt-6 flex items-center gap-2">
+              <Switch
+                id={`webhook-active-${webhook.id}`}
+                checked={active}
+                onCheckedChange={(checked) => {
+                  setActive(checked);
+                  setDirty(true);
+                }}
+                disabled={isUpdating}
+              />
+              <Label htmlFor={`webhook-active-${webhook.id}`} className="text-sm">
+                Active
+              </Label>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col gap-2 sm:items-end">
+          <div className="flex items-center gap-2">
+            <Badge variant={isProjectScoped ? "default" : "secondary"} className="gap-1">
+              <ScopeIcon className="h-3 w-3" /> {scopeLabel}
+            </Badge>
+            <Badge variant="outline">Created {new Date(webhook.created_at).toLocaleDateString()}</Badge>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              onClick={handleSave}
+              disabled={isUpdating || !isDirty}
+            >
+              <Upload className="mr-2 h-4 w-4" /> Save
+            </Button>
+            <Button type="button" variant="outline" onClick={handleDelete} disabled={isDeleting}>
+              <Trash2 className="mr-2 h-4 w-4" /> Delete
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/projects/ProjectFilesPage.tsx
+++ b/src/pages/projects/ProjectFilesPage.tsx
@@ -1,0 +1,406 @@
+import { useDeferredValue, useRef, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Progress } from "@/components/ui/progress";
+import { useFiles } from "@/hooks/useFiles";
+import { useToast } from "@/hooks/use-toast";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { supabase } from "@/integrations/supabase/client";
+import { mapSupabaseError } from "@/services/utils";
+import type { ProjectFile } from "@/types";
+import { Download, Search, Upload } from "lucide-react";
+import { FilesTable } from "../files/FilesPage";
+
+const MAX_FILE_SIZE_MB = 50;
+
+const getFileName = (file: ProjectFile) =>
+  file.title?.trim() || file.path.split("/").pop() || "Untitled";
+
+type ProjectSummary = {
+  id: string;
+  name: string | null;
+};
+
+type UploadJob = {
+  id: string;
+  name: string;
+  progress: number;
+  status: "uploading" | "success" | "error";
+  message?: string;
+};
+
+type PreviewState = {
+  file: ProjectFile;
+  url: string;
+};
+
+async function fetchProject(projectId: string): Promise<ProjectSummary | null> {
+  const { data, error } = await supabase
+    .from("projects")
+    .select("id, name")
+    .eq("id", projectId)
+    .maybeSingle();
+
+  if (error) {
+    throw mapSupabaseError(error, "Unable to load project.");
+  }
+
+  return (data as ProjectSummary | null) ?? null;
+}
+
+export default function ProjectFilesPage() {
+  const { projectId } = useParams<{ projectId: string }>();
+  const resolvedProjectId = projectId ?? "";
+  const { toast } = useToast();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [search, setSearch] = useState("");
+  const deferredSearch = useDeferredValue(search);
+  const [uploadJobs, setUploadJobs] = useState<UploadJob[]>([]);
+  const [preview, setPreview] = useState<PreviewState | null>(null);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const projectQuery = useQuery({
+    queryKey: ["project", resolvedProjectId],
+    queryFn: () => fetchProject(resolvedProjectId),
+    enabled: Boolean(resolvedProjectId),
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const projectName = projectQuery.data?.name ?? resolvedProjectId;
+
+  useDocumentTitle(`Projects / ${projectName} / Files`);
+
+  const {
+    files,
+    isLoading,
+    isFetching,
+    error,
+    uploadFile,
+    renameFile,
+    deleteFile,
+    getSignedUrl,
+    refetch,
+  } = useFiles({ projectId: projectId ?? undefined, search: deferredSearch, enabled: Boolean(resolvedProjectId) });
+
+  const updateJob = (id: string, patch: Partial<UploadJob>) => {
+    setUploadJobs((jobs) => jobs.map((job) => (job.id === id ? { ...job, ...patch } : job)));
+  };
+
+  const removeJob = (id: string) => {
+    setUploadJobs((jobs) => jobs.filter((job) => job.id !== id));
+  };
+
+  const handleFileSelection = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const list = event.target.files;
+    if (!list || list.length === 0) {
+      return;
+    }
+
+    const filesArray = Array.from(list);
+    for (const file of filesArray) {
+      if (file.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
+        toast({
+          title: "File too large",
+          description: `${file.name} exceeds ${MAX_FILE_SIZE_MB} MB.`,
+          variant: "destructive",
+        });
+        continue;
+      }
+
+      const jobId = `job-${Date.now()}-${file.name}`;
+      setUploadJobs((jobs) => [
+        ...jobs,
+        {
+          id: jobId,
+          name: file.name,
+          progress: 10,
+          status: "uploading",
+        },
+      ]);
+
+      let progressTimer: number | undefined;
+      try {
+        progressTimer = window.setInterval(() => {
+          setUploadJobs((jobs) =>
+            jobs.map((job) =>
+              job.id === jobId
+                ? { ...job, progress: Math.min(job.progress + 15, 85) }
+                : job
+            )
+          );
+        }, 400);
+
+        await uploadFile({ projectId: resolvedProjectId, file });
+
+        if (progressTimer) {
+          window.clearInterval(progressTimer);
+        }
+
+        updateJob(jobId, { progress: 100, status: "success" });
+        toast({ title: "Uploaded", description: `${file.name} is ready.` });
+        setTimeout(() => removeJob(jobId), 1500);
+      } catch (err: any) {
+        if (progressTimer) {
+          window.clearInterval(progressTimer);
+        }
+        const message = err?.message ?? "Upload failed.";
+        updateJob(jobId, { status: "error", message });
+        toast({ title: "Upload failed", description: message, variant: "destructive" });
+      }
+    }
+
+    event.target.value = "";
+  };
+
+  const openPreview = async (file: ProjectFile, openInNewTab = false) => {
+    try {
+      const url = await getSignedUrl(file, 120);
+      if (openInNewTab || !(file.mime_type || "").startsWith("image/")) {
+        window.open(url, "_blank", "noopener,noreferrer");
+        return;
+      }
+      setPreview({ file, url });
+    } catch (err: any) {
+      toast({
+        title: "Preview unavailable",
+        description: err?.message ?? "Unable to open the file.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleCopyLink = async (file: ProjectFile) => {
+    try {
+      const url = await getSignedUrl(file, 300);
+      await navigator.clipboard.writeText(url);
+      toast({ title: "Link copied", description: "Signed link copied to clipboard." });
+    } catch (err: any) {
+      toast({
+        title: "Copy failed",
+        description: err?.message ?? "Unable to copy link.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleRename = async (file: ProjectFile, name: string) => {
+    setRenamingId(file.id);
+    try {
+      await renameFile({ id: file.id, title: name });
+      toast({ title: "Renamed", description: "Name updated." });
+    } catch (err: any) {
+      toast({
+        title: "Rename failed",
+        description: err?.message ?? "Unable to rename file.",
+        variant: "destructive",
+      });
+      throw err;
+    } finally {
+      setRenamingId(null);
+    }
+  };
+
+  const handleDelete = async (file: ProjectFile) => {
+    if (!window.confirm(`Delete ${getFileName(file)}?`)) {
+      return;
+    }
+    setDeletingId(file.id);
+    try {
+      await deleteFile(file.id);
+      toast({ title: "Deleted", description: "File removed." });
+    } catch (err: any) {
+      toast({
+        title: "Delete failed",
+        description: err?.message ?? "Unable to delete file.",
+        variant: "destructive",
+      });
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  if (!resolvedProjectId) {
+    return (
+      <Alert variant="destructive" className="m-6">
+        <AlertTitle>Missing project</AlertTitle>
+        <AlertDescription>Project ID is required to view files.</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (projectQuery.isError) {
+    return (
+      <Alert variant="destructive" className="m-6">
+        <AlertTitle>Unable to load project</AlertTitle>
+        <AlertDescription>{(projectQuery.error as Error).message}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!projectQuery.isLoading && projectQuery.data === null) {
+    return (
+      <Alert variant="destructive" className="m-6">
+        <AlertTitle>Project not found</AlertTitle>
+        <AlertDescription>This project could not be located.</AlertDescription>
+      </Alert>
+    );
+  }
+
+  const breadcrumbs = (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link to="/projects">Projects</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link to={`/projects/${resolvedProjectId}/overview`}>
+              {projectQuery.data?.name ?? resolvedProjectId}
+            </Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Files</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-2">
+          {breadcrumbs}
+          <h1 className="text-3xl font-semibold tracking-tight">Project files</h1>
+          <p className="text-sm text-muted-foreground">
+            {projectQuery.isLoading
+              ? "Loading project details…"
+              : `Manage files for ${projectQuery.data?.name ?? "this project"}.`}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="relative">
+            <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search files"
+              className="w-[220px] pl-8"
+              aria-label="Search files"
+            />
+          </div>
+          <Button onClick={() => fileInputRef.current?.click()}>
+            <Upload className="mr-2 h-4 w-4" /> Upload
+          </Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            className="sr-only"
+            onChange={handleFileSelection}
+            multiple
+          />
+        </div>
+      </div>
+
+      {uploadJobs.length > 0 ? (
+        <div className="space-y-2 rounded-lg border bg-muted/30 p-4">
+          <p className="text-sm font-medium text-muted-foreground">Active uploads</p>
+          <div className="space-y-3">
+            {uploadJobs.map((job) => (
+              <div key={job.id} className="space-y-1">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="font-medium truncate" title={job.name}>
+                    {job.name}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {job.status === "uploading"
+                      ? `${job.progress}%`
+                      : job.status === "success"
+                        ? "Completed"
+                        : job.message ?? "Failed"}
+                  </span>
+                </div>
+                <Progress
+                  value={job.status === "error" ? 100 : job.progress}
+                  className={job.status === "error" ? "bg-destructive/20" : undefined}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <FilesTable
+        files={files}
+        isLoading={isLoading}
+        isFetching={isFetching}
+        error={error}
+        onRetry={() => refetch()}
+        onPreview={(file) => openPreview(file)}
+        onDownload={(file) => openPreview(file, true)}
+        onCopyLink={handleCopyLink}
+        onRename={handleRename}
+        onDelete={handleDelete}
+        renamingId={renamingId}
+        deletingId={deletingId}
+        emptyHint="Upload your first file for this project."
+      />
+
+      <Drawer open={Boolean(preview)} onOpenChange={(open) => !open && setPreview(null)}>
+        <DrawerContent className="h-[80vh]">
+          <DrawerHeader>
+            <DrawerTitle>{preview ? getFileName(preview.file) : "Preview"}</DrawerTitle>
+            <DrawerDescription>
+              {preview ? preview.file.mime_type ?? "Unknown type" : ""}
+            </DrawerDescription>
+          </DrawerHeader>
+          <ScrollArea className="flex-1 px-6 pb-6">
+            {preview ? (
+              <img
+                src={preview.url}
+                alt={getFileName(preview.file)}
+                className="mx-auto max-h-full rounded-lg shadow"
+              />
+            ) : null}
+          </ScrollArea>
+          <DrawerFooter className="flex items-center justify-end gap-2">
+            {preview ? (
+              <Button variant="outline" onClick={() => openPreview(preview.file, true)}>
+                <Download className="mr-2 h-4 w-4" /> Download
+              </Button>
+            ) : null}
+            <DrawerClose asChild>
+              <Button variant="secondary">Close</Button>
+            </DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  );
+}

--- a/src/pages/projects/ProjectIntegrationsPage.tsx
+++ b/src/pages/projects/ProjectIntegrationsPage.tsx
@@ -1,0 +1,620 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useIntegrations } from "@/hooks/useIntegrations";
+import { useToast } from "@/hooks/use-toast";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { supabase } from "@/integrations/supabase/client";
+import { mapSupabaseError } from "@/services/utils";
+import type { Webhook } from "@/types";
+import {
+  CheckCircle2,
+  Github,
+  Link as LinkIcon,
+  Loader2,
+  RefreshCw,
+  Slack,
+  Trash2,
+  Upload,
+} from "lucide-react";
+import { IntegrationStatus, WebhookRow } from "@/pages/integrations/IntegrationsPage";
+
+type ProjectSummary = {
+  id: string;
+  name: string | null;
+};
+
+async function fetchProject(projectId: string): Promise<ProjectSummary | null> {
+  const { data, error } = await supabase
+    .from("projects")
+    .select("id, name")
+    .eq("id", projectId)
+    .maybeSingle();
+
+  if (error) {
+    throw mapSupabaseError(error, "Unable to load project.");
+  }
+
+  return (data as ProjectSummary | null) ?? null;
+}
+
+export default function ProjectIntegrationsPage() {
+  const { projectId } = useParams<{ projectId: string }>();
+  const resolvedProjectId = projectId ?? "";
+  const { toast } = useToast();
+
+  const projectQuery = useQuery({
+    queryKey: ["project", resolvedProjectId],
+    queryFn: () => fetchProject(resolvedProjectId),
+    enabled: Boolean(resolvedProjectId),
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const projectName = projectQuery.data?.name ?? resolvedProjectId;
+  useDocumentTitle(`Projects / ${projectName} / Integrations`);
+
+  const {
+    userIntegrations,
+    workspaceWebhooks,
+    projectWebhooks,
+    isLoading,
+    isRefreshing,
+    error,
+    connectIntegration,
+    disconnectIntegration,
+    updateUserIntegration,
+    createWebhook,
+    updateWebhook,
+    deleteWebhook,
+    isConnecting,
+    isDisconnecting,
+    isUpdatingIntegration,
+    isSavingWebhook,
+    isDeletingWebhook,
+  } = useIntegrations({ projectId: resolvedProjectId });
+
+  const workspaceSlack = useMemo(
+    () => userIntegrations.find((item) => item.provider === "slack" && !item.project_id) ?? null,
+    [userIntegrations]
+  );
+  const projectSlack = useMemo(
+    () => userIntegrations.find((item) => item.provider === "slack" && item.project_id === resolvedProjectId) ?? null,
+    [userIntegrations, resolvedProjectId]
+  );
+  const workspaceGithub = useMemo(
+    () => userIntegrations.find((item) => item.provider === "github" && !item.project_id) ?? null,
+    [userIntegrations]
+  );
+  const projectGithub = useMemo(
+    () => userIntegrations.find((item) => item.provider === "github" && item.project_id === resolvedProjectId) ?? null,
+    [userIntegrations, resolvedProjectId]
+  );
+  const workspaceDrive = useMemo(
+    () => userIntegrations.find((item) => item.provider === "google_drive" && !item.project_id) ?? null,
+    [userIntegrations]
+  );
+  const projectDrive = useMemo(
+    () => userIntegrations.find((item) => item.provider === "google_drive" && item.project_id === resolvedProjectId) ?? null,
+    [userIntegrations, resolvedProjectId]
+  );
+
+  const [projectSlackChannel, setProjectSlackChannel] = useState("");
+  const [projectGithubRepo, setProjectGithubRepo] = useState("");
+  const [projectGithubEvents, setProjectGithubEvents] = useState({ issues: true, pull_requests: true });
+  const [projectDriveFolder, setProjectDriveFolder] = useState("");
+
+  useEffect(() => {
+    setProjectSlackChannel(projectSlack?.display_name ?? projectSlack?.access_data?.channel ?? "");
+  }, [projectSlack?.display_name, projectSlack?.access_data]);
+
+  useEffect(() => {
+    setProjectGithubRepo(projectGithub?.access_data?.repo ?? "");
+    setProjectGithubEvents({
+      issues: projectGithub?.access_data?.events?.includes("issues") ?? true,
+      pull_requests: projectGithub?.access_data?.events?.includes("pull_requests") ?? true,
+    });
+  }, [projectGithub?.access_data]);
+
+  useEffect(() => {
+    setProjectDriveFolder(projectDrive?.access_data?.folder_id ?? "");
+  }, [projectDrive?.access_data]);
+
+  const [newWebhookUrl, setNewWebhookUrl] = useState("");
+  const [newWebhookSecret, setNewWebhookSecret] = useState("");
+  const [visibleSecrets, setVisibleSecrets] = useState<Record<string, boolean>>({});
+
+  const toggleSecretVisibility = (id: string) => {
+    setVisibleSecrets((current) => ({ ...current, [id]: !current[id] }));
+  };
+
+  if (!resolvedProjectId) {
+    return (
+      <Alert variant="destructive" className="m-6">
+        <AlertTitle>Missing project</AlertTitle>
+        <AlertDescription>Project ID is required to manage integrations.</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (projectQuery.isError) {
+    return (
+      <Alert variant="destructive" className="m-6">
+        <AlertTitle>Unable to load project</AlertTitle>
+        <AlertDescription>{(projectQuery.error as Error).message}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!projectQuery.isLoading && projectQuery.data === null) {
+    return (
+      <Alert variant="destructive" className="m-6">
+        <AlertTitle>Project not found</AlertTitle>
+        <AlertDescription>This project could not be located.</AlertDescription>
+      </Alert>
+    );
+  }
+
+  const handleProjectSlackSave = async () => {
+    if (!projectSlackChannel.trim()) {
+      toast({ title: "Channel required", description: "Enter a Slack channel.", variant: "destructive" });
+      return;
+    }
+
+    try {
+      if (projectSlack) {
+        await updateUserIntegration(projectSlack.id, {
+          display_name: projectSlackChannel.trim(),
+          access_data: { channel: projectSlackChannel.trim() },
+        });
+        toast({ title: "Slack updated", description: "Project channel saved." });
+      } else {
+        await connectIntegration({
+          provider: "slack",
+          projectId: resolvedProjectId,
+          displayName: projectSlackChannel.trim(),
+          accessData: { channel: projectSlackChannel.trim() },
+        });
+        toast({ title: "Slack connected", description: "Project notifications ready." });
+      }
+    } catch (err: any) {
+      toast({ title: "Slack error", description: err?.message ?? "Unable to update Slack.", variant: "destructive" });
+    }
+  };
+
+  const handleProjectSlackTest = () => {
+    console.info("TODO: Send project Slack test notification to", projectSlackChannel);
+    toast({ title: "Test queued", description: "Slack test logged to console." });
+  };
+
+  const handleProjectGithubSave = async () => {
+    if (!/^[^/\s]+\/[^/\s]+$/.test(projectGithubRepo.trim())) {
+      toast({
+        title: "Invalid repository",
+        description: "Use the owner/name format.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      if (projectGithub) {
+        await updateUserIntegration(projectGithub.id, {
+          access_data: {
+            repo: projectGithubRepo.trim(),
+            events: [
+              ...(projectGithubEvents.issues ? ["issues"] : []),
+              ...(projectGithubEvents.pull_requests ? ["pull_requests"] : []),
+            ],
+          },
+        });
+        toast({ title: "GitHub updated", description: "Project subscription saved." });
+      } else {
+        await connectIntegration({
+          provider: "github",
+          projectId: resolvedProjectId,
+          accessData: {
+            repo: projectGithubRepo.trim(),
+            events: [
+              ...(projectGithubEvents.issues ? ["issues"] : []),
+              ...(projectGithubEvents.pull_requests ? ["pull_requests"] : []),
+            ],
+          },
+        });
+        toast({ title: "GitHub connected", description: "Repository linked for this project." });
+      }
+    } catch (err: any) {
+      toast({ title: "GitHub error", description: err?.message ?? "Unable to update GitHub.", variant: "destructive" });
+    }
+  };
+
+  const handleProjectGithubTest = () => {
+    console.info("TODO: Trigger project GitHub test for", projectGithubRepo, projectGithubEvents);
+    toast({ title: "Test queued", description: "GitHub test logged to console." });
+  };
+
+  const handleProjectDriveSave = async () => {
+    if (!projectDriveFolder.trim()) {
+      toast({ title: "Folder required", description: "Enter a Google Drive folder ID.", variant: "destructive" });
+      return;
+    }
+
+    try {
+      if (projectDrive) {
+        await updateUserIntegration(projectDrive.id, {
+          access_data: { folder_id: projectDriveFolder.trim() },
+        });
+        toast({ title: "Google Drive updated", description: "Project folder saved." });
+      } else {
+        await connectIntegration({
+          provider: "google_drive",
+          projectId: resolvedProjectId,
+          accessData: { folder_id: projectDriveFolder.trim() },
+        });
+        toast({ title: "Google Drive connected", description: "Drive folder linked." });
+      }
+    } catch (err: any) {
+      toast({ title: "Google Drive error", description: err?.message ?? "Unable to update Google Drive.", variant: "destructive" });
+    }
+  };
+
+  const handleProjectDriveTest = () => {
+    console.info("TODO: Fetch Google Drive preview for project folder", projectDriveFolder);
+    toast({ title: "Test queued", description: "Drive test logged to console." });
+  };
+
+  const handleProjectWebhookCreate = async () => {
+    if (!newWebhookUrl.trim()) {
+      toast({ title: "URL required", description: "Enter a target URL.", variant: "destructive" });
+      return;
+    }
+
+    try {
+      await createWebhook({ projectId: resolvedProjectId, targetUrl: newWebhookUrl.trim(), secret: newWebhookSecret.trim() });
+      setNewWebhookUrl("");
+      setNewWebhookSecret("");
+      toast({ title: "Webhook created", description: "Project webhook added." });
+    } catch (err: any) {
+      toast({ title: "Webhook error", description: err?.message ?? "Unable to create webhook.", variant: "destructive" });
+    }
+  };
+
+  const breadcrumbs = (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link to="/projects">Projects</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link to={`/projects/${resolvedProjectId}/overview`}>
+              {projectQuery.data?.name ?? resolvedProjectId}
+            </Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Integrations</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+
+  const loadingPlaceholder = (
+    <div className="grid gap-6 lg:grid-cols-2">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <Card key={index} className="border-dashed">
+          <CardHeader>
+            <Skeleton className="h-5 w-36" />
+            <Skeleton className="h-4 w-56" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-9 w-24" />
+          </CardContent>
+        </Card>
+      ))}
+      <Card className="lg:col-span-2 border-dashed">
+        <CardHeader>
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-72" />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-20 w-full" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-2">
+          {breadcrumbs}
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight">Integrations</h1>
+            <p className="text-sm text-muted-foreground">
+              Configure Slack, GitHub, Google Drive, and webhooks for this project. Workspace defaults are shown for context.
+            </p>
+          </div>
+        </div>
+        {isRefreshing ? (
+          <span className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" /> Syncing
+          </span>
+        ) : null}
+      </div>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Access limited</AlertTitle>
+          <AlertDescription>
+            {error.message.includes("access")
+              ? "You do not have permission to manage integrations in this project."
+              : error.message}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {isLoading ? (
+        loadingPlaceholder
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-2">
+          <Card>
+            <CardHeader className="space-y-1">
+              <div className="flex items-center gap-2">
+                <Slack className="h-5 w-5 text-primary" />
+                <CardTitle>Slack</CardTitle>
+              </div>
+              <CardDescription>
+                Workspace default channel shows broadcasts. Add a project-specific channel if needed.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="rounded-lg border bg-muted/40 p-3 text-sm">
+                <p className="font-medium">Workspace channel</p>
+                <p className="text-muted-foreground">
+                  {workspaceSlack?.display_name || workspaceSlack?.access_data?.channel || "Not connected"}
+                </p>
+                <IntegrationStatus connected={Boolean(workspaceSlack)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="project-slack-channel">Project channel</Label>
+                <Input
+                  id="project-slack-channel"
+                  placeholder="#team-build"
+                  value={projectSlackChannel}
+                  onChange={(event) => setProjectSlackChannel(event.target.value)}
+                  disabled={isConnecting || isUpdatingIntegration}
+                />
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button onClick={handleProjectSlackSave} disabled={isConnecting || isUpdatingIntegration}>
+                  <Upload className="mr-2 h-4 w-4" />
+                  {projectSlack ? "Save" : "Connect"}
+                </Button>
+                {projectSlack ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => disconnectIntegration(projectSlack.id)}
+                    disabled={isDisconnecting}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" /> Disconnect
+                  </Button>
+                ) : null}
+                <Button type="button" variant="secondary" onClick={handleProjectSlackTest}>
+                  <RefreshCw className="mr-2 h-4 w-4" /> Test message
+                </Button>
+              </div>
+              <IntegrationStatus connected={Boolean(projectSlack)} />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="space-y-1">
+              <div className="flex items-center gap-2">
+                <Github className="h-5 w-5 text-primary" />
+                <CardTitle>GitHub</CardTitle>
+              </div>
+              <CardDescription>
+                Workspace default repository: {workspaceGithub?.access_data?.repo || "Not connected"}. Add project overrides as needed.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="project-github-repo">Repository (owner/name)</Label>
+                <Input
+                  id="project-github-repo"
+                  placeholder="outpaged/mobile-app"
+                  value={projectGithubRepo}
+                  onChange={(event) => setProjectGithubRepo(event.target.value)}
+                  disabled={isConnecting || isUpdatingIntegration}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Events</Label>
+                <div className="flex items-center gap-3 text-sm">
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      id="project-github-issues"
+                      checked={projectGithubEvents.issues}
+                      onCheckedChange={(checked) =>
+                        setProjectGithubEvents((state) => ({ ...state, issues: checked }))
+                      }
+                    />
+                    <Label htmlFor="project-github-issues" className="font-normal">
+                      Issues
+                    </Label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      id="project-github-prs"
+                      checked={projectGithubEvents.pull_requests}
+                      onCheckedChange={(checked) =>
+                        setProjectGithubEvents((state) => ({ ...state, pull_requests: checked }))
+                      }
+                    />
+                    <Label htmlFor="project-github-prs" className="font-normal">
+                      Pull requests
+                    </Label>
+                  </div>
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button onClick={handleProjectGithubSave} disabled={isConnecting || isUpdatingIntegration}>
+                  <Upload className="mr-2 h-4 w-4" />
+                  {projectGithub ? "Save" : "Connect"}
+                </Button>
+                {projectGithub ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => disconnectIntegration(projectGithub.id)}
+                    disabled={isDisconnecting}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" /> Disconnect
+                  </Button>
+                ) : null}
+                <Button type="button" variant="secondary" onClick={handleProjectGithubTest}>
+                  <RefreshCw className="mr-2 h-4 w-4" /> Test sync
+                </Button>
+              </div>
+              <IntegrationStatus connected={Boolean(projectGithub)} />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="space-y-1">
+              <div className="flex items-center gap-2">
+                <LinkIcon className="h-5 w-5 text-primary" />
+                <CardTitle>Google Drive</CardTitle>
+              </div>
+              <CardDescription>
+                Workspace folder: {workspaceDrive?.access_data?.folder_id || "Not linked"}. Add project folder for scoped docs.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="project-drive-folder">Project folder ID</Label>
+                <Input
+                  id="project-drive-folder"
+                  placeholder="0BxxExampleId"
+                  value={projectDriveFolder}
+                  onChange={(event) => setProjectDriveFolder(event.target.value)}
+                  disabled={isConnecting || isUpdatingIntegration}
+                />
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button onClick={handleProjectDriveSave} disabled={isConnecting || isUpdatingIntegration}>
+                  <Upload className="mr-2 h-4 w-4" />
+                  {projectDrive ? "Save" : "Connect"}
+                </Button>
+                {projectDrive ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => disconnectIntegration(projectDrive.id)}
+                    disabled={isDisconnecting}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" /> Disconnect
+                  </Button>
+                ) : null}
+                <Button type="button" variant="secondary" onClick={handleProjectDriveTest}>
+                  <RefreshCw className="mr-2 h-4 w-4" /> Test fetch
+                </Button>
+              </div>
+              <IntegrationStatus connected={Boolean(projectDrive)} />
+            </CardContent>
+          </Card>
+
+          <Card className="lg:col-span-2">
+            <CardHeader className="space-y-1">
+              <div className="flex items-center gap-2">
+                <LinkIcon className="h-5 w-5 text-primary" />
+                <CardTitle>Webhooks</CardTitle>
+              </div>
+              <CardDescription>
+                Workspace webhooks deliver global events. Add project webhooks for scoped automation.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-5">
+              <div className="rounded-lg border bg-muted/40 p-3">
+                <p className="text-sm font-medium">Workspace webhooks</p>
+                {workspaceWebhooks.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">None configured.</p>
+                ) : (
+                  <ul className="space-y-2 text-sm text-muted-foreground">
+                    {workspaceWebhooks.map((hook) => (
+                      <li key={hook.id} className="flex items-center gap-2">
+                        <CheckCircle2 className="h-4 w-4 text-emerald-500" /> {hook.target_url}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-[2fr_1fr_auto]">
+                <Input
+                  placeholder="https://example.com/project-webhook"
+                  value={newWebhookUrl}
+                  onChange={(event) => setNewWebhookUrl(event.target.value)}
+                  disabled={isSavingWebhook}
+                />
+                <Input
+                  placeholder="Optional secret"
+                  value={newWebhookSecret}
+                  onChange={(event) => setNewWebhookSecret(event.target.value)}
+                  disabled={isSavingWebhook}
+                />
+                <Button onClick={handleProjectWebhookCreate} disabled={isSavingWebhook}>
+                  <Upload className="mr-2 h-4 w-4" /> Create
+                </Button>
+              </div>
+              <Separator />
+              <div className="space-y-3">
+                {projectWebhooks.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No project webhooks yet.</p>
+                ) : (
+                  projectWebhooks.map((webhook) => (
+                    <WebhookRow
+                      key={webhook.id}
+                      webhook={webhook}
+                      onSave={(patch) => updateWebhook(webhook.id, patch)}
+                      onDelete={() => deleteWebhook(webhook.id)}
+                      onToggleSecret={() => toggleSecretVisibility(webhook.id)}
+                      secretVisible={Boolean(visibleSecrets[webhook.id])}
+                      isUpdating={isSavingWebhook}
+                      isDeleting={isDeletingWebhook}
+                    />
+                  ))
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -16,14 +16,9 @@ import ReportCreate from "@/pages/reports/ReportCreate";
 import ReportDetail from "@/pages/reports/ReportDetail";
 import ReportEdit from "@/pages/reports/ReportEdit";
 import DocsPage from "@/pages/ia/DocsPage";
-import FilesPage from "@/pages/ia/FilesPage";
+import FilesPage from "@/pages/files/FilesPage";
 import AutomationsPage from "@/pages/ia/AutomationsPage";
-import IntegrationsHome from "@/pages/integrations/IntegrationsHome";
-import GoogleIntegrationsPage from "@/pages/integrations/GoogleIntegrationsPage";
-import GitHubIntegrationsPage from "@/pages/integrations/GitHubIntegrationsPage";
-import ProjectIntegrationsPage from "@/pages/integrations/ProjectIntegrationsPage";
-import ProjectGoogleIntegrationsPage from "@/pages/integrations/ProjectGoogleIntegrationsPage";
-import ProjectGitHubIntegrationsPage from "@/pages/integrations/ProjectGitHubIntegrationsPage";
+import IntegrationsPage from "@/pages/integrations/IntegrationsPage";
 import FormsPage from "@/pages/ia/FormsPage";
 import GoalsPage from "@/pages/ia/GoalsPage";
 import TemplatesPage from "@/pages/ia/TemplatesPage";
@@ -81,8 +76,8 @@ import ProjectTimelinePage from "@/pages/ia/projects/ProjectTimelinePage";
 import ProjectDependenciesPage from "@/pages/ia/projects/ProjectDependenciesPage";
 import ProjectReportsPage from "@/pages/ia/projects/ProjectReportsPage";
 import ProjectDocsPage from "@/pages/ia/projects/ProjectDocsPage";
-import ProjectFilesPage from "@/pages/ia/projects/ProjectFilesPage";
-import ProjectIntegrationsPage from "@/pages/ia/projects/ProjectIntegrationsPage";
+import ProjectFilesPage from "@/pages/projects/ProjectFilesPage";
+import ProjectIntegrationsPage from "@/pages/projects/ProjectIntegrationsPage";
 import ProjectAutomationsPage from "@/pages/ia/projects/ProjectAutomationsPage";
 import ProjectSettingsPage from "@/pages/ia/projects/ProjectSettingsPage";
 import NewProjectPage from "@/pages/ia/NewProjectPage";
@@ -256,18 +251,8 @@ codex/implement-people,-teams-and-time-tracking
         { path: "docs", element: <DocsPage /> },
         { path: "files", element: <FilesPage /> },
         { path: "automations", element: <AutomationsPage /> },
-        { path: "integrations", element: <IntegrationsHome /> },
-        { path: "integrations/google", element: <GoogleIntegrationsPage /> },
-        { path: "integrations/github", element: <GitHubIntegrationsPage /> },
+        { path: "integrations", element: <IntegrationsPage /> },
         { path: "projects/:projectId/integrations", element: <ProjectIntegrationsPage /> },
-        {
-          path: "projects/:projectId/integrations/google",
-          element: <ProjectGoogleIntegrationsPage />,
-        },
-        {
-          path: "projects/:projectId/integrations/github",
-          element: <ProjectGitHubIntegrationsPage />,
-        },
         { path: "forms", element: <FormsPage /> },
         { path: "goals", element: <GoalsPage /> },
         { path: "templates", element: <TemplatesPage /> },

--- a/src/services/files.ts
+++ b/src/services/files.ts
@@ -1,0 +1,146 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { ProjectFile } from "@/types";
+import { getSignedUrl as getStorageSignedUrl, uploadToBucket } from "./storage";
+import { escapeLikePattern, mapSupabaseError, normalizeSearchTerm, requireUserId } from "./utils";
+
+const FILE_BUCKET = "files";
+const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
+
+type ListFilesParams = {
+  projectId?: string;
+  q?: string;
+};
+
+const sanitizeFileName = (name: string) =>
+  name
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "") || "file";
+
+const mapRowToFile = (row: any): ProjectFile => ({
+  id: row.id,
+  project_id: row.project_id,
+  bucket: (row.bucket ?? FILE_BUCKET) as ProjectFile["bucket"],
+  path: row.path,
+  size_bytes: Number(row.size_bytes ?? 0),
+  mime_type: row.mime_type ?? null,
+  title: row.title ?? null,
+  uploaded_by: row.uploaded_by,
+  created_at: row.created_at,
+});
+
+export async function listFiles(params: ListFilesParams = {}): Promise<ProjectFile[]> {
+  const { projectId, q } = params;
+
+  let query = supabase
+    .from("project_files")
+    .select("id, project_id, bucket, path, size_bytes, mime_type, title, uploaded_by, created_at")
+    .order("created_at", { ascending: false });
+
+  if (projectId) {
+    query = query.eq("project_id", projectId);
+  }
+
+  if (q && q.trim().length > 0) {
+    const term = normalizeSearchTerm(q);
+    const pattern = `%${escapeLikePattern(term)}%`;
+    query = query.or(`title.ilike.${pattern},path.ilike.${pattern}`);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw mapSupabaseError(error, "Unable to load files.");
+  }
+
+  return (data ?? []).map(mapRowToFile);
+}
+
+export async function uploadFile(projectId: string, file: File): Promise<ProjectFile> {
+  if (!projectId) {
+    throw new Error("A project is required to upload files.");
+  }
+
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    throw new Error("File must be smaller than 50 MB.");
+  }
+
+  const userId = await requireUserId();
+  const safeName = sanitizeFileName(file.name || "file");
+  const objectPath = `${projectId}/${Date.now()}-${safeName}`;
+
+  await uploadToBucket(FILE_BUCKET, objectPath, file, { upsert: true });
+
+  const { data, error } = await supabase
+    .from("project_files")
+    .insert({
+      project_id: projectId,
+      bucket: FILE_BUCKET,
+      path: objectPath,
+      size_bytes: file.size,
+      mime_type: file.type || null,
+      title: file.name || safeName,
+      uploaded_by: userId,
+    })
+    .select("id, project_id, bucket, path, size_bytes, mime_type, title, uploaded_by, created_at")
+    .single();
+
+  if (error) {
+    throw mapSupabaseError(error, "Unable to save file metadata.");
+  }
+
+  return mapRowToFile(data);
+}
+
+export async function getSignedUrl(file: ProjectFile, expiresIn = 60): Promise<string> {
+  return getStorageSignedUrl(file.bucket, file.path, expiresIn);
+}
+
+export async function renameFile(id: string, newTitle: string): Promise<ProjectFile> {
+  const title = newTitle.trim();
+
+  const { data, error } = await supabase
+    .from("project_files")
+    .update({ title: title.length > 0 ? title : null })
+    .eq("id", id)
+    .select("id, project_id, bucket, path, size_bytes, mime_type, title, uploaded_by, created_at")
+    .single();
+
+  if (error) {
+    throw mapSupabaseError(error, "Unable to rename file.");
+  }
+
+  return mapRowToFile(data);
+}
+
+export async function deleteFile(id: string): Promise<void> {
+  const { data, error } = await supabase
+    .from("project_files")
+    .select("bucket, path")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    throw mapSupabaseError(error, "Unable to locate file.");
+  }
+
+  const file = data as { bucket?: string | null; path?: string | null } | null;
+  const bucket = (file?.bucket ?? FILE_BUCKET) as string;
+  const path = file?.path;
+
+  if (path) {
+    const { error: storageError } = await supabase.storage.from(bucket).remove([path]);
+
+    if (storageError) {
+      throw mapSupabaseError(storageError, "Unable to delete file from storage.");
+    }
+  }
+
+  const { error: deleteError } = await supabase.from("project_files").delete().eq("id", id);
+
+  if (deleteError) {
+    throw mapSupabaseError(deleteError, "Unable to delete file record.");
+  }
+}

--- a/src/services/integrations.ts
+++ b/src/services/integrations.ts
@@ -1,16 +1,114 @@
 import { supabase } from "@/integrations/supabase/client";
-import type { IntegrationKey, UserIntegration } from "@/types";
+import type { Integration, UserIntegration, Webhook } from "@/types";
+import { mapSupabaseError, requireUserId } from "./utils";
 
-export type IntegrationRecord = {
-  key: IntegrationKey;
-  name: string;
-  enabled: boolean;
-  config: any;
+const DEFAULT_INTEGRATIONS: Record<Integration["key"], { name: string; config: any }> = {
+  slack: {
+    name: "Slack",
+    config: {
+      default_channel: "",
+      notify_on: ["status_changes", "approvals"],
+    },
+  },
+  github: {
+    name: "GitHub",
+    config: {
+      default_repo: "",
+      events: ["pull_requests", "issues"],
+    },
+  },
+  google_drive: {
+    name: "Google Drive",
+    config: {
+      default_folder_id: "",
+    },
+  },
+  webhooks: {
+    name: "Webhooks",
+    config: {},
+  },
 };
+
+const PROVIDER_ORDER: Integration["key"][] = ["slack", "github", "google_drive", "webhooks"];
+
+const normalizeIntegrationRow = (row: any): Integration => {
+  const key = (row.key ?? "slack") as Integration["key"];
+  const defaults = DEFAULT_INTEGRATIONS[key];
+  return {
+    key,
+    name: row.name ?? defaults?.name ?? key,
+    enabled: row.enabled ?? true,
+    config: {
+      ...(defaults?.config ?? {}),
+      ...(row.config ?? {}),
+    },
+  };
+};
+
+const ensureUrl = (value: string, errorMessage: string) => {
+  try {
+    new URL(value);
+    return value.trim();
+  } catch {
+    throw new Error(errorMessage);
+  }
+};
+
+export async function listIntegrations(): Promise<Integration[]> {
+  const { data, error } = await supabase
+    .from("integrations")
+    .select("key, name, enabled, config")
+    .in("key", PROVIDER_ORDER)
+    .order("name", { ascending: true });
+
+  if (error) {
+    throw mapSupabaseError(error, "Unable to load integrations.");
+  }
+
+  const existing = (data ?? []).map(normalizeIntegrationRow);
+  const foundKeys = new Set(existing.map((item) => item.key));
+
+  const merged: Integration[] = [...existing];
+
+  for (const key of PROVIDER_ORDER) {
+    if (!foundKeys.has(key)) {
+      const defaults = DEFAULT_INTEGRATIONS[key];
+      merged.push({
+        key,
+        name: defaults.name,
+        enabled: true,
+        config: defaults.config,
+      });
+    }
+  }
+
+  return merged.sort((a, b) => a.name.localeCompare(b.name));
+}
 
 type ListUserIntegrationsParams = {
   projectId?: string;
 };
+
+export async function listUserIntegrations(params: ListUserIntegrationsParams = {}): Promise<UserIntegration[]> {
+  const { projectId } = params;
+
+  let query = supabase
+    .from("user_integrations")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (projectId) {
+    query = query.or(`project_id.eq.${projectId},project_id.is.null`);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw mapSupabaseError(error, "Unable to load integration connections.");
+  }
+
+  return (data ?? []) as UserIntegration[];
+}
 
 type ConnectIntegrationInput = {
   provider: UserIntegration["provider"];
@@ -19,119 +117,12 @@ type ConnectIntegrationInput = {
   accessData?: any;
 };
 
-const PROVIDER_NAMES: Record<IntegrationKey, string> = {
-  gmail: "Gmail",
-  google_calendar: "Google Calendar",
-  google_docs: "Google Docs",
-  github: "GitHub",
-};
-
-const PROVIDER_DEFAULT_CONFIG: Record<IntegrationKey, any> = {
-  gmail: {
-    client_id: "",
-    redirect_uri: "",
-    scopes: ["https://mail.google.com/"],
-  },
-  google_calendar: {
-    client_id: "",
-    redirect_uri: "",
-    calendar_id_default: "",
-  },
-  google_docs: {
-    client_id: "",
-    redirect_uri: "",
-  },
-  github: {
-    app_url: "",
-    webhook_url: "",
-    webhook_secret: "",
-    default_repo: "",
-  },
-};
-
-const mergeConfig = (key: IntegrationKey, config: any | null | undefined, patch?: any) => ({
-  ...PROVIDER_DEFAULT_CONFIG[key],
-  ...(config ?? {}),
-  ...(patch ?? {}),
-});
-
-export async function listIntegrations(): Promise<IntegrationRecord[]> {
-  const { data, error } = await supabase
-    .from("integrations")
-    .select("key, name, enabled, config")
-    .order("name", { ascending: true });
-
-  if (error) {
-    throw new Error(error.message || "Failed to load integrations");
-  }
-
-  const existing = (data ?? []).map((row) => ({
-    key: row.key as IntegrationKey,
-    name: row.name ?? PROVIDER_NAMES[row.key as IntegrationKey] ?? row.key,
-    enabled: row.enabled ?? true,
-    config: mergeConfig(row.key as IntegrationKey, row.config),
-  }));
-
-  const foundKeys = new Set(existing.map((item) => item.key));
-
-  const withDefaults: IntegrationRecord[] = [...existing];
-
-  (Object.keys(PROVIDER_NAMES) as IntegrationKey[]).forEach((key) => {
-    if (!foundKeys.has(key)) {
-      withDefaults.push({
-        key,
-        name: PROVIDER_NAMES[key],
-        enabled: false,
-        config: PROVIDER_DEFAULT_CONFIG[key],
-      });
-    }
-  });
-
-  return withDefaults.sort((a, b) => a.name.localeCompare(b.name));
-}
-
-export async function listUserIntegrations(
-  params?: ListUserIntegrationsParams
-): Promise<UserIntegration[]> {
-  const { projectId } = params || {};
-
-  let query = supabase
-    .from("user_integrations")
-    .select("*")
-    .order("created_at", { ascending: false });
-
-  if (projectId) {
-    const orFilter = `project_id.eq.${projectId},project_id.is.null`;
-    query = query.or(orFilter);
-  }
-
-  const { data, error } = await query;
-
-  if (error) {
-    throw new Error(error.message || "Failed to load user integrations");
-  }
-
-  return (data ?? []) as UserIntegration[];
-}
-
-export async function connectIntegration(
-  input: ConnectIntegrationInput
-): Promise<UserIntegration> {
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser();
-
-  if (userError) {
-    throw new Error(userError.message || "Unable to resolve current user");
-  }
-
-  if (!user?.id) {
-    throw new Error("You must be signed in to connect an integration");
-  }
+export async function connectIntegration(input: ConnectIntegrationInput): Promise<UserIntegration> {
+  // TODO: Replace mock connect flow with real OAuth / app installation per provider.
+  const userId = await requireUserId();
 
   const payload = {
-    user_id: user.id,
+    user_id: userId,
     project_id: input.projectId ?? null,
     provider: input.provider,
     display_name: input.displayName ?? null,
@@ -145,27 +136,141 @@ export async function connectIntegration(
     .single();
 
   if (error) {
-    throw new Error(error.message || "Failed to connect integration");
+    throw mapSupabaseError(error, "Unable to connect integration.");
   }
 
   return data as UserIntegration;
 }
 
 export async function disconnectIntegration(id: string): Promise<void> {
-  const { error } = await supabase
-    .from("user_integrations")
-    .delete()
-    .eq("id", id);
+  const { error } = await supabase.from("user_integrations").delete().eq("id", id);
 
   if (error) {
-    throw new Error(error.message || "Failed to disconnect integration");
+    throw mapSupabaseError(error, "Unable to disconnect integration.");
+  }
+}
+
+type UpdateUserIntegrationInput = Partial<Pick<UserIntegration, "display_name" | "access_data">>;
+
+export async function updateUserIntegration(id: string, patch: UpdateUserIntegrationInput): Promise<UserIntegration> {
+  const payload: Record<string, any> = {};
+  if (typeof patch.display_name !== "undefined") {
+    payload.display_name = patch.display_name ?? null;
+  }
+  if (typeof patch.access_data !== "undefined") {
+    payload.access_data = patch.access_data ?? {};
+  }
+
+  const { data, error } = await supabase
+    .from("user_integrations")
+    .update(payload)
+    .eq("id", id)
+    .select("*")
+    .single();
+
+  if (error) {
+    throw mapSupabaseError(error, "Unable to update integration settings.");
+  }
+
+  return data as UserIntegration;
+}
+
+export async function listWebhooks(projectId?: string): Promise<Webhook[]> {
+  let query = supabase
+    .from("webhooks")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (projectId) {
+    query = query.eq("project_id", projectId);
+  } else {
+    query = query.is("project_id", null);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw mapSupabaseError(error, "Unable to load webhooks.");
+  }
+
+  return (data ?? []) as Webhook[];
+}
+
+type CreateWebhookInput = {
+  projectId?: string | null;
+  targetUrl: string;
+  secret?: string | null;
+};
+
+export async function createWebhook(input: CreateWebhookInput): Promise<Webhook> {
+  // TODO: Implement outbound webhook queue with retries and signing support.
+  const owner = await requireUserId();
+  const target_url = ensureUrl(input.targetUrl, "Enter a valid URL.");
+  const secret = input.secret?.trim() || null;
+
+  const { data, error } = await supabase
+    .from("webhooks")
+    .insert({
+      owner,
+      project_id: input.projectId ?? null,
+      target_url,
+      secret,
+      active: true,
+    })
+    .select("*")
+    .single();
+
+  if (error) {
+    throw mapSupabaseError(error, "Unable to create webhook.");
+  }
+
+  return data as Webhook;
+}
+
+type UpdateWebhookInput = Partial<Pick<Webhook, "target_url" | "secret" | "active">>;
+
+export async function updateWebhook(id: string, patch: UpdateWebhookInput): Promise<Webhook> {
+  const payload: Record<string, any> = {};
+
+  if (typeof patch.target_url === "string") {
+    payload.target_url = ensureUrl(patch.target_url, "Enter a valid URL.");
+  }
+
+  if (typeof patch.secret !== "undefined") {
+    payload.secret = patch.secret?.trim() || null;
+  }
+
+  if (typeof patch.active === "boolean") {
+    payload.active = patch.active;
+  }
+
+  const { data, error } = await supabase
+    .from("webhooks")
+    .update(payload)
+    .eq("id", id)
+    .select("*")
+    .single();
+
+  if (error) {
+    throw mapSupabaseError(error, "Unable to update webhook.");
+  }
+
+  return data as Webhook;
+}
+
+export async function deleteWebhook(id: string): Promise<void> {
+  const { error } = await supabase.from("webhooks").delete().eq("id", id);
+
+  if (error) {
+    throw mapSupabaseError(error, "Unable to delete webhook.");
   }
 }
 
 export async function updateIntegrationConfig(
-  key: IntegrationKey,
+  key: Integration["key"],
   patch: any
 ): Promise<void> {
+  const defaults = DEFAULT_INTEGRATIONS[key];
   const { data, error } = await supabase
     .from("integrations")
     .select("config, enabled, name")
@@ -173,17 +278,21 @@ export async function updateIntegrationConfig(
     .maybeSingle();
 
   if (error) {
-    throw new Error(error.message || "Failed to load integration config");
+    throw mapSupabaseError(error, "Unable to load integration config.");
   }
 
-  const mergedConfig = mergeConfig(key, data?.config, patch);
+  const mergedConfig = {
+    ...(defaults?.config ?? {}),
+    ...(data?.config ?? {}),
+    ...(patch ?? {}),
+  };
 
   const { error: upsertError } = await supabase
     .from("integrations")
     .upsert(
       {
         key,
-        name: data?.name ?? PROVIDER_NAMES[key],
+        name: data?.name ?? defaults?.name ?? key,
         enabled: data?.enabled ?? true,
         config: mergedConfig,
       },
@@ -191,6 +300,6 @@ export async function updateIntegrationConfig(
     );
 
   if (upsertError) {
-    throw new Error(upsertError.message || "Failed to update integration config");
+    throw mapSupabaseError(upsertError, "Unable to update integration config.");
   }
 }

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -1,4 +1,3 @@
-codex/perform-deep-dive-on-settings-and-admin
 import { supabase } from "@/integrations/supabase/client";
 import type { PostgrestError } from "@supabase/supabase-js";
 
@@ -24,7 +23,8 @@ export function handleSupabaseError(error: PostgrestError | null, fallbackMessag
   }
 
   throw new Error(error.message || fallbackMessage);
-=======
+}
+
 export function escapeLikePattern(value: string) {
   return value.replace(/[%_]/g, (char) => `\\${char}`);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,204 +1,48 @@
-codex/perform-deep-dive-on-settings-and-admin
-export type Profile = {
+export * from "./types/core";
+export * from "./types/search";
+export * from "./types/help";
+export * from "./types/profile";
+export * from "./types/notifications";
+export * from "./types/comments";
+export * from "./types/backlog";
+export * from "./types/workspace";
+export * from "./types/reports";
+
+export type ProjectFile = {
   id: string;
-  full_name?: string | null;
-  avatar_url?: string | null;
+  project_id: string;
+  bucket: "files";
+  path: string;
+  size_bytes: number;
+  mime_type?: string | null;
   title?: string | null;
-  department?: string | null;
-  timezone?: string | null;
-  capacity_hours_per_week?: number | null;
-  updated_at: string;
-};
-
-export type WorkspaceSettings = {
-  id: string;
-  owner: string;
-  name?: string | null;
-  brand_logo_url?: string | null;
-  default_timezone?: string | null;
-  default_capacity_hours_per_week?: number | null;
-  allowed_email_domain?: string | null;
-  features: any;
-  security: any;
-  billing: any;
-  updated_at: string;
-};
-
-export type WorkspaceMember = {
-  user_id: string;
-  role: "owner" | "admin" | "manager" | "member" | "billing";
-};
-
-export type AuditLog = {
-  id: string;
-  actor?: string | null;
-  action: string;
-  target_type?: string | null;
-  target_id?: string | null;
-  metadata?: any;
+  uploaded_by: string;
   created_at: string;
 };
 
-export type ApiToken = {
-  id: string;
-  user_id: string;
+export type Integration = {
+  key: "slack" | "github" | "google_drive" | "webhooks";
   name: string;
-  token_prefix: string;
-  last_four: string;
-  created_at: string;
-  revoked_at?: string | null;
+  enabled: boolean;
+  config: any;
 };
-
-export type Webhook = {
-  id: string;
-  owner: string;
-  target_url: string;
-  secret?: string | null;
-  active: boolean;
-=======
-codex/implement-notifications-and-inbox-functionality-g8mo3c
-export type NotificationItem = {
-  id: string;
-  user_id: string;
-  type:
-    | 'mention'
-    | 'assigned'
-    | 'comment_reply'
-    | 'status_change'
-    | 'due_soon'
-    | 'automation'
-    | 'file_shared'
-    | 'doc_comment';
-  title?: string | null;
-  body?: string | null;
-  entity_type?: 'task' | 'project' | 'doc' | 'file' | 'automation' | null;
-  entity_id?: string | null;
-  project_id?: string | null;
-  link?: string | null;
-  read_at?: string | null;
-  archived_at?: string | null;
-  created_at: string;
-};
-
-export type NotificationPreferences = {
-  user_id: string;
-  in_app: Record<string, boolean>;
-  email: Record<string, boolean>;
-  digest_frequency: 'off' | 'daily' | 'weekly';
-  updated_at: string;
-};
-
-export type Subscription = {
-  id: string;
-  user_id: string;
-  entity_type: 'task' | 'project' | 'doc';
-  entity_id: string;
-=======
-codex/implement-integrations-with-google-and-github
-export type IntegrationKey = 'gmail' | 'google_calendar' | 'google_docs' | 'github';
 
 export type UserIntegration = {
   id: string;
   user_id: string;
   project_id?: string | null;
-  provider: IntegrationKey;
+  provider: "slack" | "github" | "google_drive";
   display_name?: string | null;
   access_data: any;
   created_at: string;
 };
 
-export type LinkedResource = {
-  id: string;
-  provider: IntegrationKey;
-  external_type: 'email' | 'thread' | 'event' | 'doc' | 'repo' | 'issue' | 'pr' | 'file';
-  external_id?: string | null;
-  url?: string | null;
-  title?: string | null;
-  metadata: any;
-  entity_type: 'task' | 'project' | 'doc';
-  entity_id: string;
-  project_id?: string | null;
-  created_by?: string | null;
-  created_at: string;
-};
-
-export type HelpArticle = {
+export type Webhook = {
   id: string;
   owner: string;
-  title: string;
-  slug?: string | null;
-  category?: string | null;
-  tags?: string[] | null;
-  body_markdown: string;
-  body_html?: string | null;
-  is_published: boolean;
-  created_at: string;
-  updated_at: string;
-};
-
-export type Announcement = {
-  id: string;
-  title: string;
-  version?: string | null;
-  body_markdown: string;
-  body_html?: string | null;
-  published_at: string;
-  created_by?: string | null;
-};
-
-export type SupportTicket = {
-  id: string;
-  user_id: string;
-  subject: string;
-  body: string;
-codex/perform-deep-dive-on-settings-and-admin
-=======
- codex/implement-notifications-and-inbox-functionality-g8mo3c
-  status: 'open' | 'in_progress' | 'resolved' | 'closed';
-  priority: 'low' | 'normal' | 'high' | 'urgent';
-=======
-  status: "open" | "in_progress" | "resolved" | "closed";
-  priority: "low" | "normal" | "high" | "urgent";
-  created_at: string;
-  updated_at: string;
-};
-
-export type FeedbackItem = {
-  id: string;
-  user_id: string;
-codex/perform-deep-dive-on-settings-and-admin
-=======
-codex/implement-notifications-and-inbox-functionality-g8mo3c
-  type: 'bug' | 'idea' | 'question';
-  type: "bug" | "idea" | "question";
-  page_path?: string | null;
-  message: string;
-  screenshot_url?: string | null;
-  created_at: string;
-};
-codex/perform-deep-dive-on-settings-and-admin
-=======
-codex/implement-notifications-and-inbox-functionality-g8mo3c
-
-export type HelpCenterEntity =
-  | HelpArticle
-  | Announcement
-  | SupportTicket
-  | FeedbackItem;
-codex/implement-global-search-and-command-k-palette
-export type SearchResult = {
-  id: string;
-  type: 'task' | 'project' | 'doc' | 'file' | 'comment' | 'person';
-  title: string;
-  snippet?: string | null;
-  url: string;
   project_id?: string | null;
-  updated_at?: string | null;
-  score?: number;
+  target_url: string;
+  secret?: string | null;
+  active: boolean;
+  created_at: string;
 };
-/**
- * DO NOT ADD TYPES HERE.
- * This file only re-exports from src/types/index.ts to keep imports stable.
- * Add new types under src/types/<domain>.ts and export them from src/types/index.ts.
- */
-export * from "./types";

--- a/src/types/files.ts
+++ b/src/types/files.ts
@@ -1,13 +1,1 @@
-import type { ID } from "./core";
-
-export type ProjectFile = {
-  id: ID;
-  project_id: ID;
-  bucket?: "files";
-  path: string;
-  size_bytes?: number;
-  mime_type?: string | null;
-  title?: string | null;
-  uploaded_by?: ID;
-  created_at?: string;
-};
+export type { ProjectFile } from "../types";

--- a/src/types/integrations.ts
+++ b/src/types/integrations.ts
@@ -1,28 +1,5 @@
-import type { ID } from "./core";
+import type { Integration, UserIntegration, Webhook } from "../types";
 
-export type IntegrationKey =
-  | "gmail"
-  | "google_calendar"
-  | "google_docs"
-  | "github"
-  | "webhooks";
+export type IntegrationKey = Integration["key"];
 
-export type UserIntegration = {
-  id: ID;
-  user_id: ID;
-  project_id?: ID | null;
-  provider: IntegrationKey;
-  display_name?: string | null;
-  access_data: any;
-  created_at: string;
-};
-
-export type Webhook = {
-  id: ID;
-  owner: ID;
-  project_id?: ID | null;
-  target_url: string;
-  secret?: string | null;
-  active: boolean;
-  created_at: string;
-};
+export type { Integration, UserIntegration, Webhook };

--- a/supabase/migrations/20251021092000_files_storage.sql
+++ b/supabase/migrations/20251021092000_files_storage.sql
@@ -1,0 +1,73 @@
+-- Files bucket and project file mapping
+select storage.create_bucket('files', public => false);
+
+create table if not exists public.project_files (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  bucket text not null default 'files',
+  path text not null,
+  size_bytes bigint not null default 0,
+  mime_type text,
+  title text,
+  uploaded_by uuid not null references auth.users(id) on delete set null,
+  created_at timestamptz not null default now()
+);
+alter table public.project_files enable row level security;
+
+create policy if not exists "project_files_rw_members" on public.project_files
+for all to authenticated
+using (
+  project_id in (
+    select id from public.projects where owner = auth.uid()
+    union
+    select project_id from public.project_members where user_id = auth.uid()
+  )
+)
+with check (
+  project_id in (
+    select id from public.projects where owner = auth.uid()
+    union
+    select project_id from public.project_members where user_id = auth.uid()
+  )
+);
+
+create index if not exists project_files_project_idx on public.project_files(project_id);
+create index if not exists project_files_path_idx on public.project_files(path);
+
+create policy if not exists "files_select_members" on storage.objects
+for select to authenticated
+using (
+  bucket_id = 'files'
+  and exists (
+    select 1 from public.project_files pf
+    where pf.bucket = 'files' and pf.path = storage.objects.name
+      and pf.project_id in (
+        select id from public.projects where owner = auth.uid()
+        union
+        select project_id from public.project_members where user_id = auth.uid()
+      )
+  )
+);
+
+create policy if not exists "files_insert_members" on storage.objects
+for insert to authenticated
+with check (bucket_id = 'files');
+
+create policy if not exists "files_update_members" on storage.objects
+for update to authenticated
+using (bucket_id = 'files');
+
+create policy if not exists "files_delete_members" on storage.objects
+for delete to authenticated
+using (
+  bucket_id = 'files'
+  and exists (
+    select 1 from public.project_files pf
+    where pf.bucket = 'files' and pf.path = storage.objects.name
+      and pf.project_id in (
+        select id from public.projects where owner = auth.uid()
+        union
+        select project_id from public.project_members where user_id = auth.uid()
+      )
+  )
+);

--- a/supabase/migrations/20251021092100_integrations_expansion.sql
+++ b/supabase/migrations/20251021092100_integrations_expansion.sql
@@ -1,0 +1,55 @@
+-- Integrations, user connections, and webhooks adjustments
+create table if not exists public.integrations (
+  key text primary key,
+  name text not null,
+  enabled boolean not null default true,
+  config jsonb not null default '{}'::jsonb
+);
+
+alter table public.integrations alter column config set default '{}'::jsonb;
+alter table public.integrations alter column enabled set default true;
+alter table public.integrations enable row level security;
+
+create policy if not exists "integrations_read_all" on public.integrations
+for select to authenticated using (true);
+
+create table if not exists public.user_integrations (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  project_id uuid references public.projects(id) on delete cascade,
+  provider text not null,
+  display_name text,
+  access_data jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (user_id, provider, coalesce(project_id, '00000000-0000-0000-0000-000000000000'::uuid))
+);
+
+alter table public.user_integrations alter column access_data set default '{}'::jsonb;
+alter table public.user_integrations alter column created_at set default now();
+alter table public.user_integrations enable row level security;
+
+create policy if not exists "user_integrations_self_rw" on public.user_integrations
+for all to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+create table if not exists public.webhooks (
+  id uuid primary key default gen_random_uuid(),
+  owner uuid not null references auth.users(id) on delete cascade,
+  project_id uuid references public.projects(id) on delete cascade,
+  target_url text not null,
+  secret text,
+  active boolean not null default true,
+  created_at timestamptz not null default now()
+);
+
+alter table public.webhooks
+  alter column active set default true,
+  alter column created_at set default now();
+alter table public.webhooks add column if not exists project_id uuid references public.projects(id) on delete cascade;
+alter table public.webhooks enable row level security;
+
+create policy if not exists "webhooks_owner_rw" on public.webhooks
+for all to authenticated
+using (owner = auth.uid())
+with check (owner = auth.uid());


### PR DESCRIPTION
## Summary
- document the current files and integrations footprint and note broken imports and routes
- ship Supabase-backed integrations services/hooks with new workspace and project management pages
- point the router and navigation to the refreshed integrations UI and align breadcrumbs

## Testing
- npm run lint *(fails: repository contains existing parse errors and lint violations unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68e437fef40c832786dd617b3adf977c